### PR TITLE
Parse error message in edge cases

### DIFF
--- a/smart-send-logistics/includes/lib/Smartsend/Client.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Client.php
@@ -463,7 +463,7 @@ class Client
                 $error->links = null;
                 $error->id = null;
                 $error->code = (int) $this->http_status_code;
-                $error->message = $this->response;
+                $error->message = !empty($this->response->code) ? "API response code: {$this->response->code}" : wp_json_encode($this->response);
                 $error->errors = array();
                 $this->error = $error;
             }


### PR DESCRIPTION
Fixes a problem caused by error message being an object and being handled as a string in some edge cases
https://github.com/smartsendio/woocommerce/blob/4d754e409e883d602833d103881eb62d8da9dd0f/smart-send-logistics/includes/lib/Smartsend/Client.php#L153-L184