### PR TITLE
Fix Latvian postcode format when creating a shipment

### DIFF
--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -69,7 +69,7 @@ if (!class_exists('SS_Shipping_Shipment')) :
 	     *
 	     * @return object
 	     */
-	    public function format_agent( $ss_agent, $order_id ) {
+	    public static function format_agent( $ss_agent, $order_id ) {
 		    if ( ! isset( $ss_agent->country ) ) {
 			    return $ss_agent;
 		    }

--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -61,6 +61,29 @@ if (!class_exists('SS_Shipping_Shipment')) :
             $this->shipment = new \Smartsend\Models\Shipment();
         }
 
+	    /**
+	     * Apply country-specific formatting to agent.
+	     *
+	     * @param object $ss_agent
+	     * @param string|int $order_id
+	     *
+	     * @return object
+	     */
+	    public function format_agent( $ss_agent, $order_id ) {
+		    if ( ! isset( $ss_agent->country ) ) {
+			    return $ss_agent;
+		    }
+
+		    switch ( $ss_agent->country ) {
+			    case 'LV':
+				    if ( isset( $ss_agent->postal_code ) && preg_match( '/(?:LV)?-?(\d+)/i', $ss_agent->postal_code, $matches ) ) {
+					    $ss_agent->postal_code = count( $matches ) >= 2 ? "LV-$matches[1]" : $ss_agent->postal_code;
+				    }
+		    }
+
+		    return $ss_agent;
+	    }
+
         /**
          * Create single order
          *

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -177,6 +177,8 @@ if (!class_exists('SS_Shipping_WC')) :
 
             // Test connection
             add_action('wp_ajax_ss_test_connection', array($this, 'ss_test_connection_callback'));
+
+	        add_filter('smart_send_order_agent', array('SS_Shipping_Shipment', 'format_agent'), 10, 2);
         }
 
 

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -178,7 +178,7 @@ if (!class_exists('SS_Shipping_WC')) :
             // Test connection
             add_action('wp_ajax_ss_test_connection', array($this, 'ss_test_connection_callback'));
 
-	        add_filter('smart_send_order_agent', array('SS_Shipping_Shipment', 'format_agent'), 10, 2);
+            add_filter('smart_send_order_agent', array('SS_Shipping_Shipment', 'format_agent'), 10, 2);
         }
 
 


### PR DESCRIPTION
Should fix the following error response from Smart Send API when trying to create a shipment to a Latvian pick-up point:

```json
{
	"links": {
		"about": "https://app.smartsend.io/docs/errors/ValidationException",
		"status": "https://app.smartsend.io/status"
	},
	"id": null,
	"code": "ValidationException",
	"message": "The given data was invalid.",
	"errors": {
		"agent.postal_code": [
			"The agent.postal code must be a valid postal code in LV (examples LV-1073)."
		]
	}
}
```

Although the real solution is for the API endpoint called by findClosestAgentByAddress to return valid postal codes.
Let me know if you need more info about this issue.
