### PR TITLE
Agent search by postal code + filters

### DIFF
--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -94,7 +94,7 @@ if (!class_exists('SS_Shipping_Frontend')) :
                         $ss_agents = $this->find_closest_agents_by_postal_code(
 				$carrier,
 				$agentSearchAddress['country'],
-				$agentSearchAddress['postal_code'],
+				$agentSearchAddress['postal_code']
 			);
                     }
 

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -71,36 +71,36 @@ if (!class_exists('SS_Shipping_Frontend')) :
                 ($chosen_shipping == $shipping_id) &&
                 (stripos($meta_data['smart_send_shipping_method'], 'agent') !== false)) {
 
-	            $country = apply_filters(
-		            'smart_send_agent_search_country',
-		            wc_clean(isset($_POST['s_country']) ? $_POST['s_country'] : '')
-	            );
+                $country = apply_filters(
+                    'smart_send_agent_search_country',
+                    wc_clean(isset($_POST['s_country']) ? $_POST['s_country'] : '')
+                );
 
-	            $postal_code = apply_filters(
-		            'smart_send_agent_search_postal_code',
-		            wc_clean(isset($_POST['s_postcode']) ? $_POST['s_postcode'] : '')
-	            );
+                $postal_code = apply_filters(
+                    'smart_send_agent_search_postal_code',
+                    wc_clean(isset($_POST['s_postcode']) ? $_POST['s_postcode'] : '')
+                );
 
-	            if (!empty($country) && !empty($postal_code)) {
-		            $city = isset($_POST['s_city']) ? $_POST['s_city'] : ''; // Not required but preferred
-		            $city = apply_filters(
-			            'smart_send_agent_search_city',
-			            !empty($city) ? wc_clean($city) : null
-		            );
+                if (!empty($country) && !empty($postal_code)) {
+                    $city = isset($_POST['s_city']) ? $_POST['s_city'] : ''; // Not required but preferred
+                    $city = apply_filters(
+                        'smart_send_agent_search_city',
+                        !empty($city) ? wc_clean($city) : null
+                    );
 
-		            $street = apply_filters(
-			            'smart_send_agent_search_street',
-			            wc_clean(isset($_POST['s_address']) ? $_POST['s_address'] : '')
-		            );
+                    $street = apply_filters(
+                        'smart_send_agent_search_street',
+                        wc_clean(isset($_POST['s_address']) ? $_POST['s_address'] : '')
+                    );
 
                     $carrier = SS_SHIPPING_WC()->get_shipping_method_carrier($meta_data['smart_send_shipping_method']);
 
-		            // Production API does not allow street addresses shorter than 5 characters
-		            if(empty($street) || strlen($street) < 5){
-			            $ss_agents = $this->find_closest_agents_by_postal_code($carrier, $country, $postal_code);
-		            }else{
-			            $ss_agents = $this->find_closest_agents_by_address($carrier, $country, $postal_code, $city, $street);
-		            }
+                    // Production API does not allow street addresses shorter than 5 characters
+                    if(empty($street) || strlen($street) < 5){
+                        $ss_agents = $this->find_closest_agents_by_postal_code($carrier, $country, $postal_code);
+                    }else{
+                        $ss_agents = $this->find_closest_agents_by_address($carrier, $country, $postal_code, $city, $street);
+                    }
 
                     if (!empty($ss_agents)) {
 

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -71,11 +71,27 @@ if (!class_exists('SS_Shipping_Frontend')) :
                 ($chosen_shipping == $shipping_id) &&
                 (stripos($meta_data['smart_send_shipping_method'], 'agent') !== false)) {
 
-                if (!empty($_POST['s_country']) && !empty($_POST['s_postcode']) && !empty($_POST['s_address'])) {
-                    $country = wc_clean($_POST['s_country']);
-                    $postal_code = wc_clean($_POST['s_postcode']);
-	                $city = (!empty($_POST['s_city']) ? wc_clean($_POST['s_city']) : null);//not required but preferred
-                    $street = wc_clean($_POST['s_address']);
+	            $country = apply_filters(
+		            'smart_send_agent_search_country',
+		            wc_clean(isset($_POST['s_country']) ? $_POST['s_country'] : '')
+	            );
+
+	            $postal_code = apply_filters(
+		            'smart_send_agent_search_postal_code',
+		            wc_clean(isset($_POST['s_postcode']) ? $_POST['s_postcode'] : '')
+	            );
+
+	            if (!empty($country) && !empty($postal_code)) {
+		            $city = isset($_POST['s_city']) ? $_POST['s_city'] : ''; // Not required but preferred
+		            $city = apply_filters(
+			            'smart_send_agent_search_city',
+			            !empty($city) ? wc_clean($city) : null
+		            );
+
+		            $street = apply_filters(
+			            'smart_send_agent_search_street',
+			            wc_clean(isset($_POST['s_address']) ? $_POST['s_address'] : '')
+		            );
 
                     $carrier = SS_SHIPPING_WC()->get_shipping_method_carrier($meta_data['smart_send_shipping_method']);
 

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -162,34 +162,34 @@ if (!class_exists('SS_Shipping_Frontend')) :
 	        }
         }
 
-	    /**
-	     * Find the closest agents by postal code
-	     *
-	     * @param $carrier string Unique carrier code
-	     * @param $country string ISO3166-A2 Country code
-	     * @param $postal_code string
-	     *
-	     * @return array
-	     */
-	    public function find_closest_agents_by_postal_code($carrier, $country, $postal_code)
-	    {
-		    SS_SHIPPING_WC()->log_msg('Called "findClosestAgentByPostalCode" for website ' . SS_SHIPPING_WC()->get_website_url() . ' with carrier = "' . $carrier . '", country = "' . $country . '", postcode = "' . $postal_code . '"');
+        /**
+        * Find the closest agents by postal code
+        *
+        * @param $carrier string Unique carrier code
+        * @param $country string ISO3166-A2 Country code
+        * @param $postal_code string
+        *
+        * @return array
+        */
+        public function find_closest_agents_by_postal_code($carrier, $country, $postal_code)
+        {
+            SS_SHIPPING_WC()->log_msg('Called "findClosestAgentByPostalCode" for website ' . SS_SHIPPING_WC()->get_website_url() . ' with carrier = "' . $carrier . '", country = "' . $country . '", postcode = "' . $postal_code . '"');
 
-		    if (SS_SHIPPING_WC()->get_api_handle()->findClosestAgentByPostalCode($carrier, $country, $postal_code)) {
+            if (SS_SHIPPING_WC()->get_api_handle()->findClosestAgentByPostalCode($carrier, $country, $postal_code)) {
 
-			    $ss_agents = SS_SHIPPING_WC()->get_api_handle()->getData();
+                $ss_agents = SS_SHIPPING_WC()->get_api_handle()->getData();
 
-			    SS_SHIPPING_WC()->log_msg('Response from "findClosestAgentByPostalCode": ' . SS_SHIPPING_WC()->get_api_handle()->getResponseBody());
-			    // Save all of the agents in sessions
-			    WC()->session->set('ss_shipping_agents', $ss_agents);
+                SS_SHIPPING_WC()->log_msg('Response from "findClosestAgentByPostalCode": ' . SS_SHIPPING_WC()->get_api_handle()->getResponseBody());
+                // Save all of the agents in sessions
+                WC()->session->set('ss_shipping_agents', $ss_agents);
 
-			    return $ss_agents;
-		    } else {
-			    SS_SHIPPING_WC()->log_msg( 'Response from "findClosestAgentByPostalCode": ' . SS_SHIPPING_WC()->get_api_handle()->getErrorString() );
+                return $ss_agents;
+	    } else {
+                SS_SHIPPING_WC()->log_msg( 'Response from "findClosestAgentByPostalCode": ' . SS_SHIPPING_WC()->get_api_handle()->getErrorString() );
 
-			    return array();
-		    }
-	    }
+                return array();
+            }
+        }
 
         /**
          * Get the formatted address to display on the frontend

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -70,36 +70,32 @@ if (!class_exists('SS_Shipping_Frontend')) :
                 ($method_id == 'smart_send_shipping') &&
                 ($chosen_shipping == $shipping_id) &&
                 (stripos($meta_data['smart_send_shipping_method'], 'agent') !== false)) {
+		    
+		$agentSearchAddress = apply_filters('smart_send_agent_search_address', [
+                    'country' => empty($_POST['s_country']) ? null : wc_clean($_POST['s_country']),
+                    'postal_code' => empty($_POST['s_postcode']) ? null : wc_clean($_POST['s_postcode']),
+                    'city' => empty($_POST['s_city']) ? null : wc_clean($_POST['s_city']),
+                    'address' => empty($_POST['s_address']) ? null : wc_clean($_POST['s_address']),
+                ]);
 
-                $country = apply_filters(
-                    'smart_send_agent_search_country',
-                    wc_clean(isset($_POST['s_country']) ? $_POST['s_country'] : '')
-                );
-
-                $postal_code = apply_filters(
-                    'smart_send_agent_search_postal_code',
-                    wc_clean(isset($_POST['s_postcode']) ? $_POST['s_postcode'] : '')
-                );
-
-                if (!empty($country) && !empty($postal_code)) {
-                    $city = isset($_POST['s_city']) ? $_POST['s_city'] : ''; // Not required but preferred
-                    $city = apply_filters(
-                        'smart_send_agent_search_city',
-                        !empty($city) ? wc_clean($city) : null
-                    );
-
-                    $street = apply_filters(
-                        'smart_send_agent_search_street',
-                        wc_clean(isset($_POST['s_address']) ? $_POST['s_address'] : '')
-                    );
-
+                if ($agentSearchAddress['country'] && $agentSearchAddress['postal_code']) {
                     $carrier = SS_SHIPPING_WC()->get_shipping_method_carrier($meta_data['smart_send_shipping_method']);
 
                     // Production API does not allow street addresses shorter than 5 characters
-                    if(empty($street) || strlen($street) < 5){
-                        $ss_agents = $this->find_closest_agents_by_postal_code($carrier, $country, $postal_code);
-                    }else{
-                        $ss_agents = $this->find_closest_agents_by_address($carrier, $country, $postal_code, $city, $street);
+                    if ($agentSearchAddress['address'] && strlen($agentSearchAddress['address']) >= 5) {
+                        $ss_agents = $this->find_closest_agents_by_address(
+				$carrier,
+				$agentSearchAddress['country'],
+				$agentSearchAddress['postal_code'],
+				$agentSearchAddress['city'],
+				$agentSearchAddress['address']
+			);                        
+                    } else {
+                        $ss_agents = $this->find_closest_agents_by_postal_code(
+				$carrier,
+				$agentSearchAddress['country'],
+				$agentSearchAddress['postal_code'],
+			);
                     }
 
                     if (!empty($ss_agents)) {

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -163,14 +163,14 @@ if (!class_exists('SS_Shipping_Frontend')) :
         }
 
         /**
-        * Find the closest agents by postal code
-        *
-        * @param $carrier string Unique carrier code
-        * @param $country string ISO3166-A2 Country code
-        * @param $postal_code string
-        *
-        * @return array
-        */
+         * Find the closest agents by postal code
+         *
+         * @param $carrier string Unique carrier code
+         * @param $country string ISO3166-A2 Country code
+         * @param $postal_code string
+         *
+         * @return array
+         */
         public function find_closest_agents_by_postal_code($carrier, $country, $postal_code)
         {
             SS_SHIPPING_WC()->log_msg('Called "findClosestAgentByPostalCode" for website ' . SS_SHIPPING_WC()->get_website_url() . ' with carrier = "' . $carrier . '", country = "' . $country . '", postcode = "' . $postal_code . '"');

--- a/smart-send-logistics/includes/lib/Smartsend/Api.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Api.php
@@ -164,10 +164,12 @@ class Api extends Client
      */
     public function findClosestAgentByPostalCode($carrier, $country, $postal_code)
     {
-        return $this->httpGet(
-            $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code,
-            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-        );
+	    $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code;
+
+	    return $this->httpGet(
+		    $method,
+		    $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
+	    );
     }
 
     /*

--- a/smart-send-logistics/includes/lib/Smartsend/Api.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Api.php
@@ -164,11 +164,11 @@ class Api extends Client
      */
     public function findClosestAgentByPostalCode($carrier, $country, $postal_code)
     {
-	    $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code;
+        $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code;
 
-	    return $this->httpGet(
-		    $method,
-		    $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
+        return $this->httpGet(
+            $method,
+            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
 	    );
     }
 

--- a/smart-send-logistics/includes/lib/Smartsend/Api.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Api.php
@@ -169,7 +169,7 @@ class Api extends Client
         return $this->httpGet(
             $method,
             $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-	    );
+        );
     }
 
     /*

--- a/smart-send-logistics/includes/lib/Smartsend/Api.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Api.php
@@ -164,10 +164,8 @@ class Api extends Client
      */
     public function findClosestAgentByPostalCode($carrier, $country, $postal_code)
     {
-        $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code;
-
         return $this->httpGet(
-            $method,
+            $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code,
             $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
         );
     }


### PR DESCRIPTION
Add the following filters for modifying agent search address:

- `smart_send_agent_search_country`
- `smart_send_agent_search_postal_code`
- `smart_send_agent_search_city`
- `smart_send_agent_search_street`

and allow searching for agents with just country and postcode when no street is provided.

My use case for this is that some payment gateways like [Klarna](https://woocommerce.com/document/klarna-payments/) (widely used in many countries that PostNord also operates in), only dynamically update shipping country and postcode at checkout and leave city and street address blank. This solution should work out of the box with Klarna and gives more flexibility to users.