### PR TITLE
Edit order totals calculation

### DIFF
--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -380,7 +380,7 @@ if (!class_exists('SS_Shipping_Shipment')) :
                 // Order totals without shipping
                 $order_subtotal = $order_total - $order_shipping;
                 $order_subtotal_tax = $order_total_tax - $order_shipping_tax;
-                $order_subtotal_excl = $order_total_excl - $order_subtotal_tax;
+                $order_subtotal_excl = $order_subtotal - $order_subtotal_tax;
 
                 $parcels = array();
                 if (!empty($ss_args['ss_parcels'])) {

--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -373,14 +373,14 @@ if (!class_exists('SS_Shipping_Shipment')) :
                 $order_total_excl = $order_total - $order_total_tax;
 
                 // Shipping totals
-                $order_shipping = $this->order->get_shipping_total();
-                $order_shipping_tax = $this->order->get_shipping_tax();
-                $order_shipping_excl = $order_shipping - $order_shipping_tax;
+                $order_shipping_excl = (float)$this->order->get_shipping_total();
+                $order_shipping_tax = (float)$this->order->get_shipping_tax();
+                $order_shipping = $order_shipping_excl + $order_shipping_tax;
 
                 // Order totals without shipping
-                $order_subtotal = $order_total - $order_shipping;
                 $order_subtotal_tax = $order_total_tax - $order_shipping_tax;
-                $order_subtotal_excl = $order_subtotal - $order_subtotal_tax;
+                $order_subtotal_excl = $this->order->get_subtotal();
+                $order_subtotal = $order_subtotal_excl + $order_subtotal_tax;
 
                 $parcels = array();
                 if (!empty($ss_args['ss_parcels'])) {

--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -368,19 +368,19 @@ if (!class_exists('SS_Shipping_Shipment')) :
                 $order_note = apply_filters('smart_send_order_note', $order_note, $this->order);
 
                 // Order totals
-                $order_total = $this->order->get_total();
+                $order_total_incl_tax = $this->order->get_total();
                 $order_total_tax = $this->order->get_total_tax();
-                $order_total_excl = $order_total - $order_total_tax;
+                $order_total_excl_tax = $order_total_incl_tax - $order_total_tax;
 
-                // Shipping totals
-                $order_shipping_excl = (float)$this->order->get_shipping_total();
-                $order_shipping_tax = (float)$this->order->get_shipping_tax();
-                $order_shipping = $order_shipping_excl + $order_shipping_tax;
+                // Shipping
+                $order_shipping_incl_tax = (float) $this->order->get_shipping_total(); // Note returns string for some reason
+                $order_shipping_tax = (float) $this->order->get_shipping_tax(); // Note returns string for some reason
+                $order_shipping_excl_tax = $order_shipping_incl_tax - $order_shipping_tax;
 
-                // Order totals without shipping
-                $order_subtotal_tax = $order_total_tax - $order_shipping_tax;
-                $order_subtotal_excl = $this->order->get_subtotal();
-                $order_subtotal = $order_subtotal_excl + $order_subtotal_tax;
+                // Order subtotals (without shipping but with discount)
+                $order_subtotal_incl_tax = $this->order->get_subtotal() - $this->get_total_discount();
+                $order_subtotal_tax = $order_total_tax - $order_shipping_tax - $order->get_discount_tax();
+                $order_subtotal_excl_tax = $order_subtotal_incl_tax - $order_subtotal_tax;
 
                 $parcels = array();
                 if (!empty($ss_args['ss_parcels'])) {
@@ -447,8 +447,8 @@ if (!class_exists('SS_Shipping_Shipment')) :
                         ->setLength(null)
                         ->setFreetext($order_note ?: null)
                         ->setItems($items)// Alternatively add each item using $parcel->addItem(Item $item)
-                        ->setTotalPriceExcludingTax($order_subtotal_excl ?: null)
-                        ->setTotalPriceIncludingTax($order_subtotal ?: null)
+                        ->setTotalPriceExcludingTax($order_subtotal_excl_tax ?: null)
+                        ->setTotalPriceIncludingTax($order_subtotal_incl_tax ?: null)
                         ->setTotalTaxAmount($order_subtotal_tax ?: null);
                 }
             }
@@ -470,12 +470,12 @@ if (!class_exists('SS_Shipping_Shipment')) :
                 ->setShippingDate(date('Y-m-d'))
                 ->setParcels($parcels)// Alternatively add each parcel using $this->shipment->addParcel(Parcel $parcel);
                 ->setServices($services)
-                ->setSubtotalPriceExcludingTax($order_subtotal_excl ?: null)
-                ->setSubtotalPriceIncludingTax($order_subtotal ?: null)
-                ->setTotalPriceExcludingTax($order_total_excl ?: null)
-                ->setTotalPriceIncludingTax($order_total ?: null)
-                ->setShippingPriceExcludingTax($order_shipping_excl ?: null)
-                ->setShippingPriceIncludingTax($order_shipping ?: null)
+                ->setSubtotalPriceExcludingTax($order_subtotal_excl_tax ?: null)
+                ->setSubtotalPriceIncludingTax($order_subtotal_incl_tax ?: null)
+                ->setTotalPriceExcludingTax($order_total_excl_tax ?: null)
+                ->setTotalPriceIncludingTax($order_total_incl_tax ?: null)
+                ->setShippingPriceExcludingTax($order_shipping_excl_tax ?: null)
+                ->setShippingPriceIncludingTax($order_shipping_incl_tax ?: null)
                 ->setTotalTaxAmount($order_total_tax ?: null)
                 ->setCurrency($order_currency ?: null);
         }


### PR DESCRIPTION
https://github.com/smartsendio/woocommerce/blob/4d754e409e883d602833d103881eb62d8da9dd0f/smart-send-logistics/includes/class-ss-shipping-shipment.php#L370-L383

I found that the plugin tries to send a negative subtotal into Smart Send API when there's a discount that is larger than subtotal, but smaller than total price. This is caused by the current subtotal calculation not taking discounts into account resulting in:

`$order_shipping > $order_total`
`$order_subtotal = $order_total - $order_shipping; `
`$order_subtotal < 0`

And this results in the following API error:
```json
{
	"links": {
		"about": "https://app.smartsend.io/docs/errors/ValidationException",
		"status": "https://app.smartsend.io/status"
	},
	"id": null,
	"code": "ValidationException",
	"message": "The given data was invalid.",
	"errors": {
		"subtotal_price_excluding_tax": [
			"The subtotal_price_excluding_tax must be between 0 and 10000000."
		],
		"parcels.0.total_price_excluding_tax": [
			"The parcels.0.total_price_excluding_tax must be between 0 and 10000000."
		]
	}
}

```

This is the new totals calculation. The fix is just to get subtotal directly from WC_Order and throw the calculations around a bit. I invite you to check it thoroughly because it's a sensitive and mistake-prone topic.

```php
// Order totals
$order_total = $this->order->get_total();
$order_total_tax = $this->order->get_total_tax();
$order_total_excl = $order_total - $order_total_tax;

// Shipping totals
$order_shipping_excl = (float)$this->order->get_shipping_total();
$order_shipping_tax = (float)$this->order->get_shipping_tax();
$order_shipping = $order_shipping_excl + $order_shipping_tax;

// Order totals without shipping
$order_subtotal_tax = $order_total_tax - $order_shipping_tax;
$order_subtotal_excl = $this->order->get_subtotal();
$order_subtotal = $order_subtotal_excl + $order_subtotal_tax;
```

`get_shipping_total()` and `get_subtotal()` in my understanding return a taxless price, and `get_total()` returns price including tax.
