### PR TITLE
Case rate cost to a float

### DIFF
--- a/smart-send-logistics/readme.txt
+++ b/smart-send-logistics/readme.txt
@@ -8,7 +8,7 @@ Developer URI: https://smartsend.io/
 Tags: shipping, pick-up-points, shipping-label, postnord, smart send
 Requires at least: 3.0.1
 Tested up to: 6.8
-Stable tag: 8.1.2
+Stable tag: 8.1.3
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Requires Plugins: woocommerce
@@ -200,6 +200,9 @@ This box appears when a "Select Pick-up Point" shipping method is selected, but 
 
 
 == Changelog ==
+
+= 8.1.3 =
+* Fix issue when shipping cost is a string instead of a number (WC_Shipping_Rate::get_cost() can from WooCommerce 9.9.3 be a string)
 
 = 8.1.2 =
 * Gracefully handle when order cannot be loaded during deletion of agent meta data

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -6,7 +6,7 @@
  * Author: Smart Send ApS
  * Author URI: https://www.smartsend.io
  * Text Domain: smart-send-logistics
- * Version: 8.1.2
+ * Version: 8.1.3
  * Requires Plugins: woocommerce
  * WC requires at least: 4.7.0
  * WC tested up to: 9.7
@@ -35,7 +35,7 @@ if (!class_exists('SS_Shipping_WC')) :
     class SS_Shipping_WC
     {
 
-        private $version = "8.1.2";
+        private $version = "8.1.3";
 
         /**
          * Instance to call certain functions globally within the plugin
@@ -631,7 +631,8 @@ if (!class_exists('SS_Shipping_WC')) :
                 $prices = array();
                 foreach ($available_shipping_methods as $shipping_method) {
                     // the price is the cost + taxes
-                    $prices[] = $shipping_method->cost + array_sum($shipping_method->taxes);
+                    // Note that WC_Shipping_Rate::get_cost() can be a string, so we need to cast it to float. @see https://wordpress.org/support/topic/add-to-cart-not-working-after-update-from-9-8-5-9-9-3/
+                    $prices[] = floatval($shipping_method->cost) + array_sum($shipping_method->taxes);
                 }
 
                 // use the prices to sort the rates


### PR DESCRIPTION
This pull request updates the Smart Send Logistics plugin to version 8.1.3, addressing a compatibility issue with WooCommerce 9.9.3 and ensuring proper handling of shipping costs. Below are the most important changes grouped by theme:

### Version Update:
* Updated the version number from `8.1.2` to `8.1.3` in `smart-send-logistics/readme.txt` and `smart-send-logistics/smart-send-logistics.php`, including the `$version` property in the `SS_Shipping_WC` class. [[1]](diffhunk://#diff-e7ed532a9d3e2c94f2d44e66ab127c070b9014b05e44b15bf4150b2f0cc4a32eL11-R11) [[2]](diffhunk://#diff-4f7c652d6e6dc1a1c67be0461bbb6613439a52bdc52d8b7c030378931dba245eL9-R9) [[3]](diffhunk://#diff-4f7c652d6e6dc1a1c67be0461bbb6613439a52bdc52d8b7c030378931dba245eL38-R38)

### Bug Fix:
* Fixed an issue where `WC_Shipping_Rate::get_cost()` could return a string instead of a number. The cost is now explicitly cast to a float to ensure proper calculations.

### Documentation:
* Added a changelog entry in `smart-send-logistics/readme.txt` to describe the fix for handling shipping costs as strings in version 8.1.3.