### PR TITLE
Use get_id() method to retrieve order ID

### DIFF
--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -241,7 +241,7 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 
             // ... rest of the code. $post_or_order_object should not be used directly below this point´
 
-            $order_id = $order->ID;
+            $order_id = $order->get_id();
 
             $shipping_ss_settings = SS_SHIPPING_WC()->get_ss_shipping_settings();
 


### PR DESCRIPTION
The `WC_Order` object does not have a public property `$ID` so I am actually wondering why this has worked before 🤔 

This did not work for a particular customer, so changing to `get_id()` (which return `$id`)