### PR TITLE
Bound browser test operations at 15 seconds

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,6 +11,10 @@
 |
 */
 
+// Bound every browser operation so a broken page fails the test instead of
+// hanging the suite (observed in CI after an fpm worker crash).
+pest()->browser()->timeout(15_000);
+
 function base_url(string $path = '/'): string
 {
     $base = getenv('WP_BASE_URL') ?: 'http://127.0.0.1:8181';


### PR DESCRIPTION
## Summary

Follow-up to #66. A Playwright operation against a broken page could block indefinitely — observed in CI when an fpm worker crashed mid-request: the suite hung until the step timeout instead of failing fast, which also defeated the suite-level retry.

Sets a global 15s browser operation timeout in `tests/Pest.php`, so a crashed worker fails the affected test quickly and the retry pass can go green. Full suite verified locally (7 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)