### PR TITLE
Add WordPress-loaded integration test suite foundation

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -148,9 +148,9 @@ jobs:
         # The tests are self-contained, so retry the suite once to absorb
         # rare fpm worker crashes; persistent failures still fail both runs.
         run: |
-          vendor/bin/pest || {
+          vendor/bin/pest --testsuite=Browser || {
             echo "::warning::Browser test run failed - retrying once"
-            vendor/bin/pest
+            vendor/bin/pest --testsuite=Browser
           }
 
       - name: Show server and WordPress logs

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,60 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pest:
+    name: Pest integration tests (WP ${{ matrix.wp-version }} / WC ${{ matrix.wc-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # Unlike the browser tests, WordPress + WooCommerce run inside the
+        # Pest process here, so the PHP version is fixed by Pest's own
+        # requirement (8.2+). PHP-version coverage of the plugin comes from
+        # the browser test matrix.
+        wp-version: ['latest']
+        wc-version: ['latest']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Set up the development store
+        # SQLite is fine here: the suite runs in a single PHP process, so the
+        # concurrency-related SQLite crashes seen with php-fpm do not apply.
+        # No web server is needed either - WordPress is loaded in-process.
+        run: |
+          bin/setup-local-dev.sh \
+            --path ./local-dev/wordpress \
+            --url http://127.0.0.1:8181 \
+            --wp-version "${{ matrix.wp-version }}" \
+            --wc-version "${{ matrix.wc-version }}" \
+            --skip-seed
+
+      - name: Run Pest integration tests
+        run: vendor/bin/pest --testsuite=Integration
+
+      - name: Show WordPress debug log
+        if: failure()
+        run: tail -n 200 ./local-dev/wordpress/wp-content/debug.log || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,22 @@ The actual plugin lives entirely in `smart-send-logistics/` — that folder is w
 
 ## Development environment
 
-There is no build step, test suite, or linter config in the repo. Development is done against a local WordPress + WooCommerce install with the plugin symlinked in:
+There is no build step. Development is done against a local WordPress + WooCommerce install created by `bin/setup-local-dev.sh` (default location `./local-dev/wordpress`, plugin symlinked in and activated). The README.md has further details on the development environment.
+
+## Testing
+
+Two Pest suites live in `tests/` (run on modern PHP; the plugin's PHP 5.6 floor only applies to `smart-send-logistics/` code):
+
+- **Browser** (`tests/Browser`) — end-to-end Playwright tests against a *running* store over HTTP (`WP_BASE_URL`, default `http://127.0.0.1:8181`). Few and slow; cover the big flows.
+- **Integration** (`tests/Integration`) — WordPress + WooCommerce loaded *in-process* by `tests/bootstrap.php` from the `bin/setup-local-dev.sh` install (override with `WP_DEV_PATH`); no web server needed. This is where scenario coverage lives (orders with coupons, discounts, fees → shipment payload, filters). Fixtures are built via the factories in `tests/Integration/Helpers.php`, which force-delete everything they create after each test — always create test data through them.
 
 ```bash
-ln -s ~/github.com/smartsendio/woocommerce/smart-send-logistics wp-content/plugins/smart-send-logistics
+composer test:integration   # or: vendor/bin/pest --testsuite=Integration
+composer test:browser       # needs the store running (see README)
+composer test               # both
 ```
 
-The README.md has full WP-CLI instructions for standing up a fresh WordPress + WooCommerce + Storefront environment with sample data, shipping zones, and Smart Send shipping methods.
+CI runs both suites (`.github/workflows/browser-tests.yml` and `integration-tests.yml`).
 
 `composer.json` requires `squizlabs/php_codesniffer` + `wp-coding-standards/wpcs` as dev dependencies (no ruleset file committed); run `composer install` then `vendor/bin/phpcs --standard=WordPress smart-send-logistics` if linting is needed.
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,8 @@
   "scripts": {
     "phpcs": "phpcs",
     "phpcs:fix": "phpcbf",
-    "test": "pest"
+    "test": "pest",
+    "test:integration": "pest --testsuite=Integration",
+    "test:browser": "pest --testsuite=Browser"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          failOnWarning="false"
 >
     <testsuites>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
         <testsuite name="Browser">
             <directory>tests/Browser</directory>
         </testsuite>

--- a/tests/Integration/Helpers.php
+++ b/tests/Integration/Helpers.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Integration suite factories
+|--------------------------------------------------------------------------
+|
+| Small factories for building WooCommerce fixtures inside integration
+| tests. The suite runs against the shared local development database (no
+| transaction rollback), so every created object is registered here and
+| force-deleted after each test by the afterEach hook in tests/Pest.php.
+|
+*/
+
+/**
+ * @var WC_Data[] Objects created during the current test, oldest first.
+ */
+$GLOBALS['ss_integration_created'] = [];
+
+/**
+ * Track a created WooCommerce object for post-test deletion.
+ */
+function remember_for_cleanup($object)
+{
+    $GLOBALS['ss_integration_created'][] = $object;
+
+    return $object;
+}
+
+/**
+ * Force-delete every object created during the test, newest first (orders
+ * before the products they reference).
+ */
+function cleanup_created_objects(): void
+{
+    foreach (array_reverse($GLOBALS['ss_integration_created']) as $object) {
+        $object->delete(true);
+    }
+
+    $GLOBALS['ss_integration_created'] = [];
+}
+
+function create_simple_product(array $props = []): WC_Product_Simple
+{
+    $product = new WC_Product_Simple();
+    $product->set_name($props['name'] ?? 'Integration Test Product');
+    $product->set_regular_price((string) ($props['price'] ?? '100'));
+    $product->set_weight((string) ($props['weight'] ?? '1'));
+
+    if (isset($props['sale_price'])) {
+        $product->set_sale_price((string) $props['sale_price']);
+    }
+    if (isset($props['length'], $props['width'], $props['height'])) {
+        $product->set_length((string) $props['length']);
+        $product->set_width((string) $props['width']);
+        $product->set_height((string) $props['height']);
+    }
+    if (isset($props['virtual'])) {
+        $product->set_virtual($props['virtual']);
+    }
+
+    $product->save();
+
+    return remember_for_cleanup($product);
+}
+
+function create_coupon(array $props = []): WC_Coupon
+{
+    $coupon = new WC_Coupon();
+    $coupon->set_code($props['code'] ?? uniqid('ss-test-'));
+    $coupon->set_discount_type($props['type'] ?? 'percent');
+    $coupon->set_amount((float) ($props['amount'] ?? 10));
+    $coupon->save();
+
+    return remember_for_cleanup($coupon);
+}
+
+/**
+ * Build an order the way checkout would: line items from real products, a
+ * Danish shipping/billing address, optional coupons, recalculated totals.
+ *
+ * Supported $args:
+ *   products : array of WC_Product or [WC_Product, int $quantity]
+ *   coupons  : coupon code string or array of codes
+ *   address  : partial address overrides (merged over the Danish default)
+ *   status   : order status (default 'processing')
+ */
+function create_order(array $args = []): WC_Order
+{
+    $order = wc_create_order([
+        'status'      => $args['status'] ?? 'processing',
+        'created_via' => 'integration-test',
+    ]);
+    remember_for_cleanup($order);
+
+    foreach ($args['products'] ?? [] as $line) {
+        [$product, $quantity] = is_array($line) ? $line : [$line, 1];
+        $order->add_product($product, $quantity);
+    }
+
+    $address = array_merge([
+        'first_name' => 'Test',
+        'last_name'  => 'Customer',
+        'address_1'  => 'Islands Brygge 39',
+        'city'       => 'Copenhagen',
+        'postcode'   => '2300',
+        'country'    => 'DK',
+    ], $args['address'] ?? []);
+
+    $order->set_address(array_merge($address, [
+        'email' => 'integration-test@smartsend.io',
+        'phone' => '+4512345678',
+    ]), 'billing');
+    $order->set_address($address, 'shipping');
+
+    foreach ((array) ($args['coupons'] ?? []) as $code) {
+        $result = $order->apply_coupon($code);
+        if (is_wp_error($result)) {
+            throw new RuntimeException("Could not apply coupon '{$code}': " . $result->get_error_message());
+        }
+    }
+
+    $order->calculate_totals();
+    $order->save();
+
+    return $order;
+}

--- a/tests/Integration/SmokeTest.php
+++ b/tests/Integration/SmokeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Verifies the integration harness itself: WordPress + WooCommerce are
+ * loaded in-process, the Smart Send plugin is active, and the factories in
+ * Helpers.php can build realistic orders. Scenario tests (payload building,
+ * filters) build on this foundation.
+ */
+
+it('loads WordPress and WooCommerce in-process', function () {
+    expect(defined('ABSPATH'))->toBeTrue()
+        ->and(did_action('init'))->toBeGreaterThan(0)
+        ->and(class_exists('WooCommerce'))->toBeTrue()
+        ->and(did_action('woocommerce_loaded'))->toBeGreaterThan(0);
+});
+
+it('has the Smart Send plugin active', function () {
+    expect(function_exists('SS_SHIPPING_WC'))->toBeTrue()
+        ->and(SS_SHIPPING_WC())->toBeInstanceOf(SS_Shipping_WC::class)
+        ->and(class_exists('Smartsend\\Api'))->toBeTrue();
+});
+
+it('creates an order with products and totals', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1.5]);
+
+    $order = create_order(['products' => [[$product, 2]]]);
+
+    expect($order->get_id())->toBeGreaterThan(0)
+        ->and((float) $order->get_total())->toBe(200.0)
+        ->and($order->get_shipping_country())->toBe('DK')
+        ->and(count($order->get_items()))->toBe(1);
+});
+
+it('creates an order with a percentage coupon applied', function () {
+    $product = create_simple_product(['price' => 100]);
+    $coupon  = create_coupon(['type' => 'percent', 'amount' => 10]);
+
+    $order = create_order([
+        'products' => [$product],
+        'coupons'  => $coupon->get_code(),
+    ]);
+
+    expect((float) $order->get_discount_total())->toBe(10.0)
+        ->and((float) $order->get_total())->toBe(90.0)
+        ->and($order->get_coupon_codes())->toBe([$coupon->get_code()]);
+});
+
+it('cleans up created objects between tests', function () {
+    // The orders and products from the previous tests must be gone; the
+    // factories force-delete everything they create after each test.
+    $orders = wc_get_orders([
+        'created_via' => 'integration-test',
+        'limit'       => -1,
+        'return'      => 'ids',
+    ]);
+
+    expect($orders)->toBe([]);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,6 +15,24 @@
 // hanging the suite (observed in CI after an fpm worker crash).
 pest()->browser()->timeout(15_000);
 
+/*
+|--------------------------------------------------------------------------
+| Integration suite
+|--------------------------------------------------------------------------
+|
+| Runs against an in-process WordPress + WooCommerce (loaded by
+| tests/bootstrap.php from the bin/setup-local-dev.sh install). The suite
+| shares the development database, so fixtures built via the factories in
+| tests/Integration/Helpers.php are force-deleted after every test.
+|
+*/
+
+require __DIR__ . '/Integration/Helpers.php';
+
+uses()->afterEach(function (): void {
+    cleanup_created_objects();
+})->in('Integration');
+
 function base_url(string $path = '/'): string
 {
     $base = getenv('WP_BASE_URL') ?: 'http://127.0.0.1:8181';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| PHPUnit / Pest bootstrap
+|--------------------------------------------------------------------------
+|
+| The Browser suite talks to a running store over HTTP and must not load
+| WordPress into the test process. The Integration suite runs against an
+| in-process WordPress + WooCommerce, bootstrapped from the development
+| install created by bin/setup-local-dev.sh (default ./local-dev/wordpress,
+| override with WP_DEV_PATH).
+|
+| WordPress has to be loaded in global scope before any test runs, so the
+| decision is made here from the requested test suite.
+|
+*/
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$suite = null;
+$argv  = $_SERVER['argv'] ?? [];
+foreach ($argv as $i => $arg) {
+    if ($arg === '--testsuite') {
+        $suite = $argv[$i + 1] ?? null;
+    } elseif (str_starts_with($arg, '--testsuite=')) {
+        $suite = substr($arg, strlen('--testsuite='));
+    }
+}
+
+if ($suite === 'Browser') {
+    return;
+}
+
+$wpPath = getenv('WP_DEV_PATH') ?: __DIR__ . '/../local-dev/wordpress';
+$wpLoad = rtrim($wpPath, '/') . '/wp-load.php';
+
+if (! file_exists($wpLoad)) {
+    fwrite(STDERR, <<<MSG
+    The Integration suite needs a local WordPress + WooCommerce install, but none
+    was found at: {$wpPath}
+
+    Create one with:  bin/setup-local-dev.sh
+    Or point WP_DEV_PATH at an existing install created by that script.
+    To run only the browser tests: vendor/bin/pest --testsuite=Browser
+
+    MSG);
+    exit(1);
+}
+
+// WordPress and WooCommerce expect a web-request-like environment; mirror the
+// server variables WP-CLI sets up, derived from the store's base URL.
+$base = getenv('WP_BASE_URL') ?: 'http://localhost:8181';
+$host = parse_url($base, PHP_URL_HOST) ?: 'localhost';
+$port = parse_url($base, PHP_URL_PORT);
+
+$_SERVER['HTTP_HOST']       = $host . ($port ? ':' . $port : '');
+$_SERVER['SERVER_NAME']     = $host;
+$_SERVER['SERVER_PORT']     = (string) ($port ?: 80);
+$_SERVER['REQUEST_URI']     = '/';
+$_SERVER['REQUEST_METHOD']  = 'GET';
+$_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
+$_SERVER['REMOTE_ADDR']     = '127.0.0.1';
+$_SERVER['HTTP_USER_AGENT'] = 'Pest Integration Suite';
+
+define('WP_USE_THEMES', false);
+
+require_once $wpLoad;
+
+// Keep database driver noise out of the test output. With the SQLite dev
+// store, WooCommerce's coupon-hold "SELECT ... FOR UPDATE" queries fail (the
+// driver does not support row locks) and would otherwise print a full error
+// dump per query; WooCommerce treats the failed lookup as zero held coupons,
+// which is fine for tests.
+$GLOBALS['wpdb']->suppress_errors();


### PR DESCRIPTION
## What

Adds the foundation for a Pest **Integration** suite that runs against WordPress + WooCommerce loaded *in-process* — no browser, no web server — so order scenarios (coupons, discounts, fees, …) can be tested in milliseconds. First step towards #35.

- **`tests/bootstrap.php`** — new PHPUnit/Pest bootstrap. For the Integration suite it loads `wp-load.php` from the `bin/setup-local-dev.sh` install (default `./local-dev/wordpress`, override with `WP_DEV_PATH`); for `--testsuite=Browser` it skips WordPress entirely, so browser runs behave exactly as before. Fails fast with setup instructions when no install exists.
- **`tests/Integration/Helpers.php`** — fixture factories (`create_simple_product`, `create_coupon`, `create_order`) that build orders the way checkout would (Danish address, real line items, applied coupons, recalculated totals). The suite shares the dev database, so every created object is force-deleted after each test via an `afterEach` hook in `tests/Pest.php`.
- **`tests/Integration/SmokeTest.php`** — 5 tests validating the harness: WP/WC loaded, Smart Send plugin active, order creation with totals, order with a 10% coupon, and cleanup verification. ~1s locally.
- **Composer scripts** — `composer test:integration`, `composer test:browser`, `composer test` (both).
- **CI** — new `integration-tests.yml` workflow: single PHP 8.4 job with SQLite and `--skip-seed` (no nginx/fpm/Playwright needed since WordPress runs inside the Pest process). The browser workflow now runs `--testsuite=Browser` explicitly.
- **CLAUDE.md** — testing section updated (the "no test suite" claim was already stale).

## Why

The scenario coverage we want (orders with discounts, coupons, fees → correct shipment payload) needs real `WC_Order` objects but not a browser. The WordPress handbook's classic `WP_UnitTestCase` path conflicts with Pest 4 (the WP test library caps at PHPUnit 9.x, Pest 4 requires 11+), so this suite instead reuses the same dev-store install the browser tests already build — one environment, two suites.

## Notes for review

- The Integration suite runs on Pest's PHP (8.2+); PHP-version coverage of the plugin itself still comes from the browser matrix.
- The bootstrap calls `$wpdb->suppress_errors()`: WooCommerce's coupon-hold `SELECT ... FOR UPDATE` queries fail on the SQLite dev store (no row locks) and would print a full error dump per query; WC treats the failed lookup as zero held coupons, which is fine for tests.
- Next step (separate PR): expose `SS_Shipping_Shipment` payload building through a testable seam and add the coupon/discount/fee scenario matrix against it.

Refs #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)