### PR TITLE
Add v9 characterization test safety net

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -2,7 +2,7 @@ name: Browser Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@ composer test:browser       # needs the store running (see README)
 composer test               # both
 ```
 
-CI runs both suites (`.github/workflows/browser-tests.yml` and `integration-tests.yml`).
+CI runs both suites (`.github/workflows/browser-tests.yml` and `integration-tests.yml`) on every pull request and on pushes to `main` and `develop`.
+
+**v9 refactoring rule: no refactor PR merges without tests covering the moved behaviour.** The characterization suites (payload golden tests, rate calculation, order meta, label generation, frontend display — see `tests/Integration`) capture current behaviour; a refactor PR must keep them green, and any code it moves that is not yet covered must gain tests in the same PR. Tests assert *current* behaviour, including known oddities (marked `v8 oddity` in the test files) — changing such an expectation is a deliberate behaviour change and must be called out in the PR.
 
 `composer.json` requires `squizlabs/php_codesniffer` + `wp-coding-standards/wpcs` as dev dependencies (no ruleset file committed); run `composer install` then `vendor/bin/phpcs --standard=WordPress smart-send-logistics` if linting is needed.
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ Pre-existing violations are recorded in [phpcs.baseline.xml](phpcs.baseline.xml)
 vendor/bin/phpcs --report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline --report-file=phpcs.baseline.xml
 ```
 
+### Test safety net (v9 rule)
+
+The `tests/Integration` suite contains characterization tests that pin down the current behaviour of the core flows (shipment payload "golden" tests, rate calculation, order meta accessors on legacy and HPOS storage, label generation with a mocked API, frontend pick-up point display). **No refactor PR merges without tests covering the moved behaviour**: keep these suites green, and extend them in the same PR for any code you move that is not yet covered. Both CI workflows run on every pull request and on pushes to `main` and `develop`.
+
 ### Browser tests
 
 End-to-end browser tests are written with [Pest](https://pestphp.com/docs/browser-testing) (backed by Playwright) and run against a store created by the setup script. Locally:

--- a/tests/Browser/SmartSendFlowsTest.php
+++ b/tests/Browser/SmartSendFlowsTest.php
@@ -1,0 +1,422 @@
+<?php
+
+/*
+ * End-to-end characterization of the three big Smart Send flows against a
+ * running store:
+ *
+ *  - classic checkout with an agent method: pick-up point selector shown,
+ *    a point chosen, order placed, agent shown on the thank-you page;
+ *  - generating a label from the admin order screen;
+ *  - the bulk "Generate Labels" action on two orders.
+ *
+ * The Smart Send API is mocked with a temporary mu-plugin (installed into
+ * the development store for the duration of this file and removed again),
+ * gated on the ss_test_api_mock option, so no real API calls are made. The
+ * store fixtures (shipping method instance, classic checkout page, orders)
+ * are created through WP-CLI and torn down in afterAll.
+ *
+ * These tests need filesystem + WP-CLI access to the store installation
+ * (WP_DEV_PATH, default ./local-dev/wordpress) in addition to WP_BASE_URL;
+ * they are skipped when the installation is not reachable, e.g. when the
+ * suite targets a remote store.
+ */
+
+function ss_browser_wp_path(): string
+{
+    return rtrim(getenv('WP_DEV_PATH') ?: __DIR__ . '/../../local-dev/wordpress', '/');
+}
+
+function ss_browser_store_manageable(): bool
+{
+    return file_exists(ss_browser_wp_path() . '/wp-load.php')
+        && file_exists(ss_browser_wp_path() . '/.wp-cli/wp-cli.phar');
+}
+
+/**
+ * Run a PHP snippet inside the store via WP-CLI and return the decoded JSON
+ * the snippet echoed on its last line.
+ */
+function ss_browser_wp_eval(string $code): array
+{
+    $snippet = tempnam(sys_get_temp_dir(), 'ss-browser-eval-') . '.php';
+    file_put_contents($snippet, "<?php\n" . $code);
+
+    $command = escapeshellarg(PHP_BINARY)
+        . ' -d memory_limit=512M -d error_reporting=0 -d display_errors=0 '
+        . escapeshellarg(ss_browser_wp_path() . '/.wp-cli/wp-cli.phar')
+        . ' --path=' . escapeshellarg(ss_browser_wp_path())
+        . ' eval-file ' . escapeshellarg($snippet) . ' 2>/dev/null';
+
+    $output = shell_exec($command);
+    unlink($snippet);
+
+    // WP-CLI may print deprecation noise before the snippet's JSON line.
+    $json = null;
+    foreach (array_reverse(explode("\n", trim((string) $output))) as $line) {
+        if (str_starts_with(trim($line), '{')) {
+            $json = json_decode(trim($line), true);
+            break;
+        }
+    }
+
+    if (!is_array($json)) {
+        throw new RuntimeException("WP-CLI eval did not return JSON. Output was:\n" . $output);
+    }
+
+    return $json;
+}
+
+function ss_browser_mu_plugin_path(): string
+{
+    return ss_browser_wp_path() . '/wp-content/mu-plugins/ss-browser-test-api-mock.php';
+}
+
+function ss_browser_install_api_mock(): void
+{
+    $mu_dir = dirname(ss_browser_mu_plugin_path());
+    if (!is_dir($mu_dir)) {
+        mkdir($mu_dir, 0755, true);
+    }
+
+    file_put_contents(ss_browser_mu_plugin_path(), <<<'PHP'
+<?php
+/**
+ * Smart Send API mock for the Pest browser tests. Installed temporarily by
+ * tests/Browser/SmartSendFlowsTest.php and removed again when the file's
+ * tests finish. Only active while the ss_test_api_mock option is 'yes'.
+ */
+add_filter('pre_http_request', function ($pre, $args, $url) {
+    if (get_option('ss_test_api_mock') !== 'yes' || strpos($url, 'smartsend.io') === false) {
+        return $pre;
+    }
+
+    $respond = function ($body) {
+        return array(
+            'response' => array('code' => 200, 'message' => 'OK'),
+            'headers'  => array('content-type' => 'application/json'),
+            'body'     => json_encode($body),
+            'cookies'  => array(),
+            'filename' => null,
+        );
+    };
+
+    if (strpos($url, 'agents/closest') !== false) {
+        return $respond(array('data' => array(
+            array('id' => 1, 'agent_no' => '1234', 'company' => 'Browser Test Shop', 'address_line1' => 'Main Street 1', 'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK', 'distance' => 0.42),
+            array('id' => 2, 'agent_no' => '5678', 'company' => 'Second Test Shop', 'address_line1' => 'Other Street 9', 'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK', 'distance' => 1.2),
+        )));
+    }
+
+    if (strpos($url, 'shipments/labels/combine') !== false) {
+        return $respond(array('data' => array(
+            'pdf' => array('link' => 'https://mock.smartsend.test/labels/combined.pdf', 'base_64_encoded' => base64_encode('%PDF-combo')),
+        )));
+    }
+
+    if (strpos($url, 'shipments/labels') !== false) {
+        return $respond(array('data' => array(
+            'shipment_id'  => 'browser-shipment-' . uniqid(),
+            'carrier_name' => 'PostNord',
+            'carrier_code' => 'postnord',
+            'pdf'          => array('link' => 'https://mock.smartsend.test/labels/label.pdf', 'base_64_encoded' => base64_encode('%PDF-label')),
+            'parcels'      => array(
+                array('parcel_internal_id' => 1, 'tracking_code' => 'BROWSERTRACK1', 'tracking_link' => 'https://mock.smartsend.test/track/1'),
+            ),
+        )));
+    }
+
+    if (strpos($url, 'agents/carrier') !== false) {
+        return $respond(array('data' => array(
+            'id' => 1, 'agent_no' => '1234', 'company' => 'Browser Test Shop', 'address_line1' => 'Main Street 1', 'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK',
+        )));
+    }
+
+    return $respond(array('data' => array('id' => 1, 'email' => 'mock@smartsend.test', 'website' => 'localhost')));
+}, 5, 3);
+PHP);
+}
+
+/**
+ * The fixture state created by beforeAll (ids of the zone method, checkout
+ * page, product and admin-test orders).
+ */
+function ss_browser_state(): array
+{
+    return $GLOBALS['ss_browser_state'];
+}
+
+beforeAll(function (): void {
+    if (!ss_browser_store_manageable()) {
+        return;
+    }
+
+    ss_browser_install_api_mock();
+
+    $GLOBALS['ss_browser_state'] = ss_browser_wp_eval(<<<'PHP'
+$original_settings = get_option('woocommerce_smart_send_shipping_settings');
+update_option('woocommerce_smart_send_shipping_settings', array(
+    'demo' => 'yes', 'ss_debug' => 'no', 'include_order_comment' => 'no',
+    'save_shipping_labels_in_uploads' => 'no', 'dropdown_display_format' => '4',
+    'default_select_agent' => 'no', 'order_status' => '0',
+));
+update_option('ss_test_api_mock', 'yes');
+
+// Cash on delivery so the checkout can be completed.
+$cod = get_option('woocommerce_cod_settings', array());
+$cod_was_enabled = isset($cod['enabled']) ? $cod['enabled'] : 'no';
+$cod['enabled'] = 'yes';
+update_option('woocommerce_cod_settings', $cod);
+
+// Denmark zone with a Smart Send agent method instance.
+$zone_id = 0;
+foreach (WC_Shipping_Zones::get_zones() as $zone_data) {
+    foreach ($zone_data['zone_locations'] as $location) {
+        if ($location->code === 'DK') {
+            $zone_id = $zone_data['id'];
+            break 2;
+        }
+    }
+}
+if (!$zone_id) {
+    $zone = new WC_Shipping_Zone();
+    $zone->set_zone_name('Denmark');
+    $zone->set_zone_locations(array((object) array('code' => 'DK', 'type' => 'country')));
+    $zone->save();
+    $zone_id = $zone->get_id();
+}
+$zone = new WC_Shipping_Zone($zone_id);
+$instance_id = 0;
+foreach ($zone->get_shipping_methods() as $iid => $method) {
+    if ($method->id === 'smart_send_shipping') {
+        $instance_id = $iid;
+        break;
+    }
+}
+$created_instance = 0;
+if (!$instance_id) {
+    $instance_id = $zone->add_shipping_method('smart_send_shipping');
+    $created_instance = 1;
+}
+update_option('woocommerce_smart_send_shipping_' . $instance_id . '_settings', array(
+    'title' => 'Smart Send Pick-up Point',
+    'method' => 'postnord_agent',
+    'return_method' => 'postnord_returndropoff',
+    'auto_generate_return_label' => 'no',
+    'tax_status' => 'none',
+    'requires' => '',
+    'flatfee_cost' => '0',
+    'min_amount' => '0',
+    'advanced_settings_enable' => 'no',
+    'cost_weight' => array(array('ss_min_weight' => '', 'ss_max_weight' => '', 'ss_cost_weight' => '29')),
+));
+
+// A classic (shortcode) checkout page; the pick-up point selector only
+// renders in the classic checkout.
+$page_id = wp_insert_post(array(
+    'post_title'   => 'SS Classic Checkout',
+    'post_name'    => 'ss-classic-checkout',
+    'post_content' => '[woocommerce_checkout]',
+    'post_status'  => 'publish',
+    'post_type'    => 'page',
+));
+$original_checkout_page = get_option('woocommerce_checkout_page_id');
+update_option('woocommerce_checkout_page_id', $page_id);
+
+// A product to buy.
+$product_id = wc_get_product_id_by_sku('SS-BROWSER-TEST');
+if (!$product_id) {
+    $product = new WC_Product_Simple();
+    $product->set_name('SS Browser Test Product');
+    $product->set_sku('SS-BROWSER-TEST');
+    $product->set_regular_price('100');
+    $product->set_weight('1');
+    $product->save();
+    $product_id = $product->get_id();
+}
+
+// Orders for the admin label tests, built like checkout would build them.
+$make_order = function () use ($product_id) {
+    $order = wc_create_order(array('status' => 'processing', 'created_via' => 'ss-browser-test'));
+    $order->add_product(wc_get_product($product_id), 1);
+    $address = array(
+        'first_name' => 'Browser', 'last_name' => 'Test', 'address_1' => 'Islands Brygge 39',
+        'city' => 'Copenhagen', 'postcode' => '2300', 'country' => 'DK',
+    );
+    $order->set_address(array_merge($address, array('email' => 'ss-browser-test@smartsend.io', 'phone' => '+4512345678')), 'billing');
+    $order->set_address($address, 'shipping');
+    $item = new WC_Order_Item_Shipping();
+    $item->set_method_title('Smart Send Pick-up Point');
+    $item->set_method_id('smart_send_shipping');
+    $item->set_instance_id(1);
+    $item->set_total('29');
+    $item->add_meta_data('smart_send_shipping_method', 'postnord_agent', true);
+    $item->add_meta_data('smart_send_return_method', 'postnord_returndropoff', true);
+    $item->add_meta_data('smart_send_auto_generate_return_label', 'no', true);
+    $order->add_item($item);
+    $order->calculate_totals();
+    $order->update_meta_data('ss_shipping_order_agent_no', '1234');
+    $order->update_meta_data('_ss_shipping_order_agent', (object) array(
+        'id' => 1, 'agent_no' => '1234', 'company' => 'Browser Test Shop', 'address_line1' => 'Main Street 1',
+        'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK',
+    ));
+    $order->save();
+    return $order;
+};
+$order_a = $make_order();
+$order_b = $make_order();
+
+$hpos = Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+
+$state = array(
+    'original_settings'      => $original_settings === false ? null : $original_settings,
+    'zone_id'                => $zone_id,
+    'instance_id'            => $instance_id,
+    'created_instance'       => $created_instance,
+    'checkout_page_id'       => $page_id,
+    'original_checkout_page' => $original_checkout_page,
+    'cod_was_enabled'        => $cod_was_enabled,
+    'product_id'             => $product_id,
+    'order_a'                => $order_a->get_id(),
+    'order_b'                => $order_b->get_id(),
+    'order_a_edit_path'      => $hpos
+        ? '/wp-admin/admin.php?page=wc-orders&action=edit&id=' . $order_a->get_id()
+        : '/wp-admin/post.php?post=' . $order_a->get_id() . '&action=edit',
+    'orders_list_path'       => $hpos ? '/wp-admin/admin.php?page=wc-orders' : '/wp-admin/edit.php?post_type=shop_order',
+    'hpos'                   => $hpos ? 1 : 0,
+);
+update_option('ss_browser_test_state', $state);
+echo json_encode($state);
+PHP);
+});
+
+afterAll(function (): void {
+    if (!ss_browser_store_manageable() || empty($GLOBALS['ss_browser_state'])) {
+        return;
+    }
+
+    ss_browser_wp_eval(<<<'PHP'
+$state = get_option('ss_browser_test_state', array());
+
+// Orders created by the admin fixtures and by the checkout test run.
+$fixture_orders = wc_get_orders(array('created_via' => 'ss-browser-test', 'limit' => -1));
+$checkout_orders = wc_get_orders(array('billing_email' => 'ss-browser-test@smartsend.io', 'limit' => -1));
+foreach (array_merge($fixture_orders, $checkout_orders) as $order) {
+    $order->delete(true);
+}
+
+if (!empty($state['created_instance']) && !empty($state['zone_id'])) {
+    $zone = new WC_Shipping_Zone($state['zone_id']);
+    $zone->delete_shipping_method($state['instance_id']);
+}
+
+if (!empty($state['checkout_page_id'])) {
+    wp_delete_post($state['checkout_page_id'], true);
+}
+if (isset($state['original_checkout_page'])) {
+    update_option('woocommerce_checkout_page_id', $state['original_checkout_page']);
+}
+
+if (($state['cod_was_enabled'] ?? 'no') !== 'yes') {
+    $cod = get_option('woocommerce_cod_settings', array());
+    $cod['enabled'] = $state['cod_was_enabled'] ?? 'no';
+    update_option('woocommerce_cod_settings', $cod);
+}
+
+$product_id = wc_get_product_id_by_sku('SS-BROWSER-TEST');
+if ($product_id) {
+    $product = wc_get_product($product_id);
+    $product->delete(true);
+}
+
+if (empty($state['original_settings'])) {
+    delete_option('woocommerce_smart_send_shipping_settings');
+} else {
+    update_option('woocommerce_smart_send_shipping_settings', $state['original_settings']);
+}
+
+delete_option('ss_test_api_mock');
+delete_option('ss_browser_test_state');
+echo json_encode(array('cleaned' => true));
+PHP);
+
+    if (file_exists(ss_browser_mu_plugin_path())) {
+        unlink(ss_browser_mu_plugin_path());
+    }
+});
+
+beforeEach(function (): void {
+    if (!ss_browser_store_manageable()) {
+        $this->markTestSkipped('The WordPress installation is not reachable from the test process (WP_DEV_PATH).');
+    }
+});
+
+it('shows the pick-up point selector on classic checkout and stores the chosen agent on the order', function () {
+    $state = ss_browser_state();
+
+    $page = visit(base_url('/?add-to-cart=' . $state['product_id']));
+
+    $page->navigate(base_url('/?page_id=' . $state['checkout_page_id']))
+        ->assertSee('Billing details')
+        ->fill('#billing_first_name', 'Browser')
+        ->fill('#billing_last_name', 'Test')
+        ->fill('#billing_address_1', 'Islands Brygge 39')
+        ->fill('#billing_city', 'Copenhagen')
+        ->fill('#billing_postcode', '2300')
+        ->fill('#billing_phone', '+4512345678')
+        ->fill('#billing_email', 'ss-browser-test@smartsend.io');
+
+    // Choose the Smart Send agent method; the checkout refreshes and the
+    // plugin renders the pick-up point dropdown (fed by the mocked API).
+    // WooCommerce derives the radio id from the rate id
+    // ('smart_send_shipping:N' -> 'smart_send_shippingN').
+    $page->click('#shipping_method_0_smart_send_shipping' . $state['instance_id'])
+        ->assertPresent('select[name=ss_shipping_store_pickup]')
+        // The mocked agents are options of the (closed) dropdown, so assert
+        // against the markup rather than visible text.
+        ->assertSourceHas('Browser Test Shop');
+
+    // Cash on delivery is the only enabled gateway, so it is preselected
+    // (and its radio hidden). Pick the agent last so no further checkout
+    // refresh re-renders the dropdown before submitting.
+    $page->assertSee('Cash on delivery')
+        ->select('ss_shipping_store_pickup', '1234')
+        // Explicit selector: text-based lookups do not match submit buttons
+        // by their value and hang instead of failing.
+        ->click('#place_order');
+
+    // Thank-you page: the frontend hook renders the stored pick-up point,
+    // which proves the agent meta ended up on the order.
+    $page->assertSee('order has been received')
+        ->assertSee('Pick-up Point')
+        ->assertSee('Browser Test Shop')
+        ->assertSee('Main Street 1');
+});
+
+it('generates a shipping label from the admin order screen', function () {
+    $state = ss_browser_state();
+
+    login_as_admin()
+        ->navigate(base_url($state['order_a_edit_path']))
+        ->assertSee('Smart Send Shipping')
+        ->assertSee('Pick-up Point')
+        ->assertSee('Browser Test Shop')
+        ->click('#ss-shipping-label-button')
+        ->assertSeeIn('#ss-label-created', 'Download shipping label');
+});
+
+it('generates labels for two orders through the bulk action', function () {
+    $state = ss_browser_state();
+
+    $page = login_as_admin()->navigate(base_url($state['orders_list_path']));
+
+    $checkbox_name = $state['hpos'] ? 'id[]' : 'post[]';
+    $page->check($checkbox_name, (string) $state['order_a'])
+        ->check($checkbox_name, (string) $state['order_b'])
+        ->select('action', 'ss_shipping_label_bulk')
+        // Explicit selector: the Apply button is an input[type=submit], which
+        // text-based lookups cannot find.
+        ->click('#doaction');
+
+    $page->assertSee('Shipping labels created by Smart Send for 2 orders')
+        ->assertSee('Download combined pdf');
+});

--- a/tests/Integration/FrontendAgentDisplayTest.php
+++ b/tests/Integration/FrontendAgentDisplayTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * Characterization tests for SS_Shipping_Frontend: the pick-up point block
+ * on the thank-you page and in order emails, the checkout validation and
+ * agent persistence, and the invalid-order guard from #60.
+ */
+
+/**
+ * Fresh frontend instance to call the hook callbacks directly. (The plugin
+ * singleton keeps its own instance private; constructing another one only
+ * re-adds idempotent hooks.)
+ */
+function frontend(): SS_Shipping_Frontend
+{
+    return new SS_Shipping_Frontend();
+}
+
+function capture_agent_display(WC_Order $order): string
+{
+    ob_start();
+    frontend()->display_ss_shipping_agent($order);
+
+    return ob_get_clean();
+}
+
+beforeEach(function (): void {
+    with_ss_settings();
+});
+
+it('hooks the agent display into the thank-you page and order emails', function () {
+    expect(has_action('woocommerce_order_details_after_order_table'))->not->toBeFalse()
+        ->and(has_action('woocommerce_email_after_order_table'))->not->toBeFalse()
+        ->and(has_action('woocommerce_after_shipping_rate'))->not->toBeFalse()
+        ->and(has_action('woocommerce_checkout_process'))->not->toBeFalse()
+        ->and(has_action('woocommerce_checkout_order_processed'))->not->toBeFalse();
+});
+
+it('renders the pick-up point block for an order with a selected agent', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_agent']);
+
+    $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+    $handler->save_ss_shipping_order_agent_no($order->get_id(), '1234');
+    $handler->save_ss_shipping_order_agent($order->get_id(), sample_agent());
+
+    $output = capture_agent_display($order);
+
+    expect($output)->toContain('Pick-up Point')
+        ->toContain('Corner Shop')
+        ->toContain('Main Street 1')
+        ->toContain('DK 2300 Copenhagen')
+        ->toContain('<address>');
+});
+
+it('renders nothing for an order without an agent', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_homedelivery']);
+
+    expect(capture_agent_display($order))->toBe('');
+});
+
+it('survives deleting the agent meta of an order that no longer exists', function () {
+    // Invalid-order guard (#60): the deleted_post_meta hook can fire for
+    // orders that were already removed; the handler must not fatal.
+    $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+
+    $handler->delete_ss_shipping_order_agent(999999999);
+    $handler->action_deleted_agent_meta([1], 999999999, 'ss_shipping_order_agent_no', '1234');
+
+    expect(true)->toBeTrue();
+});
+
+it('rejects checkout when the pick-up point dropdown is present but empty', function () {
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+    wc_clear_notices();
+
+    $_POST['ss_shipping_store_pickup'] = '';
+    remember_cleanup_callback(function (): void {
+        unset($_POST['ss_shipping_store_pickup']);
+        wc_clear_notices();
+    });
+
+    frontend()->validate_agent_selected();
+
+    expect(wc_notice_count('error'))->toBe(1);
+
+    $notices = wc_get_notices('error');
+    expect($notices[0]['notice'])->toBe('A pick-up point must be selected.');
+});
+
+it('accepts checkout when a pick-up point is selected', function () {
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+    wc_clear_notices();
+
+    $_POST['ss_shipping_store_pickup'] = '1234';
+    remember_cleanup_callback(function (): void {
+        unset($_POST['ss_shipping_store_pickup']);
+        wc_clear_notices();
+    });
+
+    frontend()->validate_agent_selected();
+
+    expect(wc_notice_count('error'))->toBe(0);
+});
+
+it('saves the selected agent from the session onto the order at checkout', function () {
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_agent']);
+
+    WC()->session->set('ss_shipping_agents', [
+        sample_agent(['agent_no' => '1111', 'company' => 'Other Shop']),
+        sample_agent(['agent_no' => '1234', 'company' => 'Corner Shop']),
+    ]);
+    $_POST['ss_shipping_store_pickup'] = '1234';
+    remember_cleanup_callback(function (): void {
+        unset($_POST['ss_shipping_store_pickup']);
+        WC()->session->set('ss_shipping_agents', null);
+    });
+
+    frontend()->process_ss_pickup_points($order->get_id(), []);
+
+    $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+    expect($handler->get_ss_shipping_order_agent_no($order->get_id()))->toBe('1234')
+        ->and($handler->get_ss_shipping_order_agent($order->get_id())->company)->toBe('Corner Shop');
+});
+
+it('saves nothing when the posted agent is not in the session list', function () {
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_agent']);
+
+    WC()->session->set('ss_shipping_agents', [sample_agent(['agent_no' => '1111'])]);
+    $_POST['ss_shipping_store_pickup'] = '9999';
+    remember_cleanup_callback(function (): void {
+        unset($_POST['ss_shipping_store_pickup']);
+        WC()->session->set('ss_shipping_agents', null);
+    });
+
+    frontend()->process_ss_pickup_points($order->get_id(), []);
+
+    expect(SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_ss_shipping_order_agent_no($order->get_id()))
+        ->toBeNull();
+});

--- a/tests/Integration/Helpers.php
+++ b/tests/Integration/Helpers.php
@@ -18,6 +18,11 @@
 $GLOBALS['ss_integration_created'] = [];
 
 /**
+ * @var callable[] Cleanup callbacks registered during the current test.
+ */
+$GLOBALS['ss_integration_cleanup_callbacks'] = [];
+
+/**
  * Track a created WooCommerce object for post-test deletion.
  */
 function remember_for_cleanup($object)
@@ -28,8 +33,17 @@ function remember_for_cleanup($object)
 }
 
 /**
+ * Register a callback that must run after the test (restore an option,
+ * remove a filter, delete a tax rate, ...). Runs newest first.
+ */
+function remember_cleanup_callback(callable $callback): void
+{
+    $GLOBALS['ss_integration_cleanup_callbacks'][] = $callback;
+}
+
+/**
  * Force-delete every object created during the test, newest first (orders
- * before the products they reference).
+ * before the products they reference), then run the cleanup callbacks.
  */
 function cleanup_created_objects(): void
 {
@@ -38,6 +52,170 @@ function cleanup_created_objects(): void
     }
 
     $GLOBALS['ss_integration_created'] = [];
+
+    foreach (array_reverse($GLOBALS['ss_integration_cleanup_callbacks']) as $callback) {
+        $callback();
+    }
+
+    $GLOBALS['ss_integration_cleanup_callbacks'] = [];
+}
+
+/**
+ * Override the Smart Send plugin settings for the duration of the test.
+ * The suite runs against the shared development database, so the previous
+ * value is restored afterwards.
+ */
+function with_ss_settings(array $overrides = []): array
+{
+    $option_key = 'woocommerce_smart_send_shipping_settings';
+    $original   = get_option($option_key);
+
+    $settings = array_merge([
+        'demo'                            => 'yes',
+        'ss_debug'                        => 'no',
+        'include_order_comment'           => 'no',
+        'save_shipping_labels_in_uploads' => 'no',
+        'dropdown_display_format'         => '4',
+        'order_status'                    => '0',
+    ], $overrides);
+
+    update_option($option_key, $settings);
+
+    remember_cleanup_callback(function () use ($option_key, $original): void {
+        if ($original === false) {
+            delete_option($option_key);
+        } else {
+            update_option($option_key, $original);
+        }
+    });
+
+    return $settings;
+}
+
+/**
+ * Override any WordPress option for the duration of the test.
+ */
+function with_option(string $option_key, $value): void
+{
+    $original = get_option($option_key);
+
+    update_option($option_key, $value);
+
+    remember_cleanup_callback(function () use ($option_key, $original): void {
+        if ($original === false) {
+            delete_option($option_key);
+        } else {
+            update_option($option_key, $original);
+        }
+    });
+}
+
+/**
+ * Mock the Smart Send API through the pre_http_request filter. Every request
+ * to smartsend.io is captured and answered by $responder (defaults to a
+ * successful create-shipment-and-labels response). Returns the capture
+ * object; inspect ->requests for [url, method, body] entries.
+ */
+function mock_smart_send_api(?callable $responder = null): object
+{
+    $capture = new class {
+        public array $requests = [];
+    };
+
+    $responder = $responder ?? function () {
+        return ss_api_response(200, ['data' => ss_api_shipment_data()]);
+    };
+
+    $filter = function ($pre, $args, $url) use ($capture, $responder) {
+        if (strpos($url, 'smartsend.io') === false) {
+            return $pre;
+        }
+
+        $capture->requests[] = [
+            'url'    => $url,
+            'method' => $args['method'] ?? null,
+            'body'   => $args['body'] ?? null,
+        ];
+
+        return $responder($url, $args);
+    };
+
+    add_filter('pre_http_request', $filter, 10, 3);
+
+    remember_cleanup_callback(function () use ($filter): void {
+        remove_filter('pre_http_request', $filter, 10);
+    });
+
+    return $capture;
+}
+
+/**
+ * Build a wp_remote_request-shaped response array with a JSON body.
+ */
+function ss_api_response(int $status, array $body): array
+{
+    return [
+        'response' => ['code' => $status, 'message' => $status === 200 ? 'OK' : 'Error'],
+        'headers'  => ['content-type' => 'application/json'],
+        'body'     => json_encode($body),
+        'cookies'  => [],
+        'filename' => null,
+    ];
+}
+
+/**
+ * A successful shipment payload as returned by createShipmentAndLabels.
+ */
+function ss_api_shipment_data(array $overrides = []): array
+{
+    return array_merge([
+        'shipment_id'  => $overrides['shipment_id'] ?? 'test-shipment-' . uniqid(),
+        'carrier_name' => 'PostNord',
+        'carrier_code' => 'postnord',
+        'pdf'          => [
+            'link'             => 'https://api.example.test/labels/label.pdf',
+            'base_64_encoded'  => base64_encode('%PDF-fake'),
+        ],
+        'parcels'      => [
+            [
+                'parcel_internal_id' => 1,
+                'tracking_code'      => 'TRACK-1234',
+                'tracking_link'      => 'https://tracking.example.test/TRACK-1234',
+            ],
+        ],
+    ], $overrides);
+}
+
+/**
+ * An error response body in the shape the Smart Send API produces.
+ */
+function ss_api_error_body(string $message = 'The given data was invalid.'): array
+{
+    return [
+        'links'   => ['about' => 'https://app.smartsend.io/help/errors/ValidationException'],
+        'id'      => 'test-error-id',
+        'code'    => 'ValidationException',
+        'message' => $message,
+        'errors'  => ['receiver.postal_code' => ['The postal code is invalid.']],
+    ];
+}
+
+/**
+ * A pick-up point agent object as the plugin stores it in order meta.
+ */
+function sample_agent(array $overrides = []): object
+{
+    return (object) array_merge([
+        'id'            => 7,
+        'agent_no'      => '1234',
+        'company'       => 'Corner Shop',
+        'address_line1' => 'Main Street 1',
+        'address_line2' => null,
+        'postal_code'   => '2300',
+        'city'          => 'Copenhagen',
+        'country'       => 'DK',
+        'distance'      => 0.5,
+    ], $overrides);
 }
 
 function create_simple_product(array $props = []): WC_Product_Simple
@@ -45,10 +223,22 @@ function create_simple_product(array $props = []): WC_Product_Simple
     $product = new WC_Product_Simple();
     $product->set_name($props['name'] ?? 'Integration Test Product');
     $product->set_regular_price((string) ($props['price'] ?? '100'));
-    $product->set_weight((string) ($props['weight'] ?? '1'));
+    if (array_key_exists('weight', $props)) {
+        if ($props['weight'] !== null) {
+            $product->set_weight((string) $props['weight']);
+        }
+    } else {
+        $product->set_weight('1');
+    }
 
     if (isset($props['sale_price'])) {
         $product->set_sale_price((string) $props['sale_price']);
+    }
+    if (isset($props['sku'])) {
+        $product->set_sku($props['sku']);
+    }
+    if (isset($props['shipping_class_id'])) {
+        $product->set_shipping_class_id($props['shipping_class_id']);
     }
     if (isset($props['length'], $props['width'], $props['height'])) {
         $product->set_length((string) $props['length']);
@@ -61,7 +251,93 @@ function create_simple_product(array $props = []): WC_Product_Simple
 
     $product->save();
 
+    // Per-product Smart Send customs meta (stored as plain post meta by
+    // SS_Shipping_WC_Product and read back by SS_Shipping_Shipment).
+    foreach (['hs_code' => '_ss_hs_code', 'customs_desc' => '_ss_customs_desc', 'country_of_origin' => '_ss_country_of_origin'] as $prop => $meta_key) {
+        if (isset($props[$prop])) {
+            update_post_meta($product->get_id(), $meta_key, $props[$prop]);
+        }
+    }
+
     return remember_for_cleanup($product);
+}
+
+/**
+ * Build a variable product with a single "Size: Large" variation.
+ *
+ * Variation-level $props: price, weight, sku (all applied to the variation).
+ * Returns [WC_Product_Variable $parent, WC_Product_Variation $variation].
+ */
+function create_variable_product(array $props = []): array
+{
+    $attribute = new WC_Product_Attribute();
+    $attribute->set_name('Size');
+    $attribute->set_options(['Large']);
+    $attribute->set_visible(true);
+    $attribute->set_variation(true);
+
+    $parent = new WC_Product_Variable();
+    $parent->set_name($props['name'] ?? 'Integration Test Variable Product');
+    $parent->set_attributes([$attribute]);
+    $parent->save();
+    remember_for_cleanup($parent);
+
+    $variation = new WC_Product_Variation();
+    $variation->set_parent_id($parent->get_id());
+    $variation->set_attributes(['size' => 'Large']);
+    $variation->set_regular_price((string) ($props['price'] ?? '100'));
+    $variation->set_weight((string) ($props['weight'] ?? '1'));
+    if (isset($props['sku'])) {
+        $variation->set_sku($props['sku']);
+    }
+    $variation->save();
+    remember_for_cleanup($variation);
+
+    return [$parent, $variation];
+}
+
+/**
+ * Create a shipping class term; returns its term id.
+ */
+function create_shipping_class(string $name): int
+{
+    $term = wp_insert_term($name . '-' . uniqid(), 'product_shipping_class');
+
+    if (is_wp_error($term)) {
+        throw new RuntimeException('Could not create shipping class: ' . $term->get_error_message());
+    }
+
+    $term_id = (int) $term['term_id'];
+
+    remember_cleanup_callback(function () use ($term_id): void {
+        wp_delete_term($term_id, 'product_shipping_class');
+    });
+
+    return $term_id;
+}
+
+/**
+ * Insert a standard tax rate, deleted again after the test.
+ */
+function create_tax_rate(array $props = []): int
+{
+    $rate_id = WC_Tax::_insert_tax_rate([
+        'tax_rate_country'  => $props['country'] ?? 'DK',
+        'tax_rate_state'    => '',
+        'tax_rate'          => (string) ($props['rate'] ?? '25.0000'),
+        'tax_rate_name'     => $props['name'] ?? 'Moms',
+        'tax_rate_priority' => 1,
+        'tax_rate_compound' => 0,
+        'tax_rate_shipping' => $props['shipping'] ?? 1,
+        'tax_rate_order'    => 0,
+        'tax_rate_class'    => '',
+    ]);
+
+    remember_cleanup_callback(function () use ($rate_id): void {
+        WC_Tax::_delete_tax_rate($rate_id);
+    });
+
+    return $rate_id;
 }
 
 function create_coupon(array $props = []): WC_Coupon
@@ -80,10 +356,18 @@ function create_coupon(array $props = []): WC_Coupon
  * Danish shipping/billing address, optional coupons, recalculated totals.
  *
  * Supported $args:
- *   products : array of WC_Product or [WC_Product, int $quantity]
- *   coupons  : coupon code string or array of codes
- *   address  : partial address overrides (merged over the Danish default)
- *   status   : order status (default 'processing')
+ *   products        : array of WC_Product or [WC_Product, int $quantity]
+ *   coupons         : coupon code string or array of codes
+ *   address         : partial address overrides (merged over the Danish default)
+ *   billing_address : partial billing overrides (defaults to `address`)
+ *   status          : order status (default 'processing')
+ *   shipping_method : Smart Send method code (e.g. 'postnord_agent'); adds a
+ *                     smart_send_shipping order item like checkout does
+ *   shipping_total  : shipping cost for that item (default '0')
+ *   return_method   : value for the smart_send_return_method item meta
+ *   auto_return     : 'yes'/'no' for smart_send_auto_generate_return_label
+ *   fees            : array of [name, amount] fee lines
+ *   customer_note   : the order's customer note
  */
 function create_order(array $args = []): WC_Order
 {
@@ -107,11 +391,37 @@ function create_order(array $args = []): WC_Order
         'country'    => 'DK',
     ], $args['address'] ?? []);
 
-    $order->set_address(array_merge($address, [
+    $billing_address = array_merge($address, [
         'email' => 'integration-test@smartsend.io',
         'phone' => '+4512345678',
-    ]), 'billing');
+    ], $args['billing_address'] ?? []);
+
+    $order->set_address($billing_address, 'billing');
     $order->set_address($address, 'shipping');
+
+    if (!empty($args['shipping_method'])) {
+        $shipping_item = new WC_Order_Item_Shipping();
+        $shipping_item->set_method_title('Smart Send');
+        $shipping_item->set_method_id('smart_send_shipping');
+        $shipping_item->set_instance_id(1);
+        $shipping_item->set_total((string) ($args['shipping_total'] ?? '0'));
+        $shipping_item->add_meta_data('smart_send_shipping_method', $args['shipping_method'], true);
+        $shipping_item->add_meta_data('smart_send_return_method', $args['return_method'] ?? 'postnord_returndropoff', true);
+        $shipping_item->add_meta_data('smart_send_auto_generate_return_label', $args['auto_return'] ?? 'no', true);
+        $order->add_item($shipping_item);
+    }
+
+    foreach ($args['fees'] ?? [] as [$fee_name, $fee_amount]) {
+        $fee = new WC_Order_Item_Fee();
+        $fee->set_name($fee_name);
+        $fee->set_amount((string) $fee_amount);
+        $fee->set_total((string) $fee_amount);
+        $order->add_item($fee);
+    }
+
+    if (isset($args['customer_note'])) {
+        $order->set_customer_note($args['customer_note']);
+    }
 
     foreach ((array) ($args['coupons'] ?? []) as $code) {
         $result = $order->apply_coupon($code);

--- a/tests/Integration/LabelGenerationTest.php
+++ b/tests/Integration/LabelGenerationTest.php
@@ -1,0 +1,277 @@
+<?php
+
+/*
+ * Characterization tests for label generation in SS_Shipping_WC_Order with
+ * the Smart Send API mocked through pre_http_request: the success path
+ * (order meta, order note, status change), the API error path, auto return
+ * labels, and the bulk order actions with the admin notices they produce.
+ */
+
+/**
+ * Invoke the protected create_label_for_single_order_maybe_return().
+ * The only public entry points (the AJAX handler and the bulk handler) wrap
+ * this method; the AJAX handler cannot run in-process because it ends with
+ * wp_send_json() + wp_die().
+ */
+function create_labels_for(int $order_id, bool $return = false, bool $save_order_note = true): array
+{
+    $method = new ReflectionMethod(SS_Shipping_WC_Order::class, 'create_label_for_single_order_maybe_return');
+
+    return $method->invoke(SS_SHIPPING_WC()->get_ss_shipping_wc_order(), $order_id, $return, $save_order_note);
+}
+
+/**
+ * Reset the bulk-action flash message option and restore it afterwards.
+ */
+function with_empty_flash_messages(): void
+{
+    // Seed an empty bag for the current user: add_admin_flash_messages()
+    // reads $bags[$bag] without an isset() check and would emit an
+    // "Undefined array key" warning on a completely empty option.
+    with_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY, [get_current_user_id() => []]);
+}
+
+/**
+ * An order that can have a label generated for it.
+ */
+function create_labelable_order(array $args = []): WC_Order
+{
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+
+    return create_order(array_merge([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_agent',
+        'shipping_total'  => '39',
+    ], $args));
+}
+
+beforeEach(function (): void {
+    with_ss_settings();
+});
+
+it('registers the AJAX label generation handler', function () {
+    expect(has_action('wp_ajax_ss_shipping_generate_label'))->not->toBeFalse();
+});
+
+it('creates a label, saves the shipment id and adds an order note on success', function () {
+    $order   = create_labelable_order();
+    $capture = mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => ss_api_shipment_data(['shipment_id' => 'shipment-abc'])]);
+    });
+
+    $fired = [];
+    $listener = function ($order_id, $response) use (&$fired): void {
+        $fired[] = $order_id;
+    };
+    add_action('smart_send_shipping_label_created', $listener, 10, 2);
+    remember_cleanup_callback(function () use ($listener): void {
+        remove_action('smart_send_shipping_label_created', $listener, 10);
+    });
+
+    $response = create_labels_for($order->get_id());
+
+    expect($response)->toHaveCount(1)
+        ->and($response[0])->toHaveKey('success')
+        ->and($response[0]['success']->shipment_id)->toBe('shipment-abc')
+        ->and($response[0]['success']->woocommerce['label_url'])->toBe('https://api.example.test/labels/label.pdf')
+        ->and($response[0]['success']->woocommerce['return'])->toBeFalse()
+        ->and($capture->requests)->toHaveCount(1)
+        ->and($fired)->toBe([$order->get_id()]);
+
+    $fresh = wc_get_order($order->get_id());
+    expect($fresh->get_meta('_ss_shipping_label_id', true))->toBe('shipment-abc')
+        ->and($fresh->get_status())->toBe('processing');
+
+    $notes = wc_get_order_notes(['order_id' => $order->get_id()]);
+    $note_contents = implode("\n", wp_list_pluck($notes, 'content'));
+    expect($note_contents)->toContain('Shipping label')
+        ->toContain('https://api.example.test/labels/label.pdf')
+        ->toContain('TRACK-1234')
+        ->toContain('https://tracking.example.test/TRACK-1234');
+});
+
+it('updates the order status after label generation when configured', function () {
+    with_ss_settings(['order_status' => 'wc-completed']);
+
+    $order = create_labelable_order();
+    mock_smart_send_api();
+
+    $response = create_labels_for($order->get_id());
+
+    expect($response[0])->toHaveKey('success')
+        ->and(wc_get_order($order->get_id())->get_status())->toBe('completed');
+});
+
+it('returns the formatted API error message when the API rejects the shipment', function () {
+    $order = create_labelable_order();
+    mock_smart_send_api(function () {
+        return ss_api_response(422, ss_api_error_body('The given data was invalid.'));
+    });
+
+    $response = create_labels_for($order->get_id());
+
+    expect($response)->toHaveCount(1)
+        ->and($response[0])->toHaveKey('error')
+        ->and($response[0]['error'])->toContain('The given data was invalid.')
+        ->toContain('Read more here')
+        ->toContain('Unique ID: test-error-id')
+        ->toContain('The postal code is invalid.');
+
+    expect(wc_get_order($order->get_id())->get_meta('_ss_shipping_label_id', true))->toBe('');
+});
+
+it('auto-generates the return label after a successful normal label', function () {
+    $order   = create_labelable_order(['auto_return' => 'yes']);
+    $capture = mock_smart_send_api();
+
+    $response = create_labels_for($order->get_id());
+
+    expect($response)->toHaveCount(2)
+        ->and($response[0])->toHaveKey('success')
+        ->and($response[0]['success']->woocommerce['return'])->toBeFalse()
+        ->and($response[1])->toHaveKey('success')
+        ->and($response[1]['success']->woocommerce['return'])->toBeTrue()
+        ->and($capture->requests)->toHaveCount(2);
+
+    // The second request books the configured return method.
+    $return_payload = json_decode($capture->requests[1]['body'], true);
+    expect($return_payload['shipping_carrier'])->toBe('postnord')
+        ->and($return_payload['shipping_method'])->toBe('returndropoff')
+        // Return shipments never include a pick-up point agent.
+        ->and($return_payload['agent'])->toBeNull();
+
+    $fresh = wc_get_order($order->get_id());
+    expect($fresh->get_meta('_ss_shipping_label_id', true))->not->toBe('')
+        ->and($fresh->get_meta('_ss_shipping_return_label_id', true))->not->toBe('');
+});
+
+it('creates only a return label when explicitly requested', function () {
+    $order = create_labelable_order();
+    mock_smart_send_api();
+
+    $response = create_labels_for($order->get_id(), true);
+
+    expect($response)->toHaveCount(1)
+        ->and($response[0])->toHaveKey('success')
+        ->and($response[0]['success']->woocommerce['return'])->toBeTrue();
+
+    $fresh = wc_get_order($order->get_id());
+    expect($fresh->get_meta('_ss_shipping_return_label_id', true))->not->toBe('')
+        ->and($fresh->get_meta('_ss_shipping_label_id', true))->toBe('');
+
+    $notes = wc_get_order_notes(['order_id' => $order->get_id()]);
+    expect(implode("\n", wp_list_pluck($notes, 'content')))->toContain('Return shipping label');
+});
+
+it('generates labels for two orders via the bulk action and flashes a combined-pdf notice', function () {
+    with_empty_flash_messages();
+
+    $order_a = create_labelable_order();
+    $order_b = create_labelable_order();
+
+    mock_smart_send_api(function ($url) {
+        if (strpos($url, 'shipments/labels/combine') !== false) {
+            return ss_api_response(200, ['data' => [
+                'pdf' => ['link' => 'https://api.example.test/labels/combined.pdf', 'base_64_encoded' => base64_encode('%PDF-combo')],
+            ]]);
+        }
+
+        return ss_api_response(200, ['data' => ss_api_shipment_data()]);
+    });
+
+    $handler  = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+    $sendback = $handler->handle_bulk_order_actions('/wp-admin/edit.php', 'ss_shipping_label_bulk', [
+        $order_a->get_id(),
+        $order_b->get_id(),
+    ]);
+
+    expect($sendback)->toBe('/wp-admin/edit.php');
+
+    // The flash messages are stored per user id until rendered.
+    $bags = get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY);
+    $messages = $bags[get_current_user_id()];
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0]['type'])->toBe('success')
+        ->and($messages[0]['message'])->toContain('Shipping labels created by Smart Send for 2 orders')
+        ->toContain('https://api.example.test/labels/combined.pdf')
+        ->toContain('Download combined pdf');
+
+    // render_admin_messages() prints the notices and clears the bag. The
+    // screen helpers are admin-only, so load them on demand.
+    if (!function_exists('convert_to_screen')) {
+        require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+        require_once ABSPATH . 'wp-admin/includes/screen.php';
+        require_once ABSPATH . 'wp-admin/includes/template.php';
+    }
+    ob_start();
+    $handler->render_admin_messages(convert_to_screen('edit-shop_order'));
+    $output = ob_get_clean();
+
+    expect($output)->toContain('notice-success')
+        ->toContain('Download combined pdf');
+    expect(get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY)[get_current_user_id()])->toBe([]);
+});
+
+it('flashes an error for bulk label generation on an order without a Smart Send method', function () {
+    with_empty_flash_messages();
+
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product]]);
+
+    mock_smart_send_api();
+
+    SS_SHIPPING_WC()->get_ss_shipping_wc_order()
+        ->handle_bulk_order_actions('/wp-admin/edit.php', 'ss_shipping_label_bulk', [$order->get_id()]);
+
+    $messages = get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY)[get_current_user_id()];
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0]['type'])->toBe('error')
+        // (sic) "Send Smart" typo is current v8 behaviour.
+        ->and($messages[0]['message'])->toContain('The selected order did not include a Send Smart shipping method');
+});
+
+it('flashes the API error per order when bulk label generation fails', function () {
+    with_empty_flash_messages();
+
+    $order = create_labelable_order();
+    mock_smart_send_api(function () {
+        return ss_api_response(422, ss_api_error_body('The given data was invalid.'));
+    });
+
+    SS_SHIPPING_WC()->get_ss_shipping_wc_order()
+        ->handle_bulk_order_actions('/wp-admin/edit.php', 'ss_shipping_label_bulk', [$order->get_id()]);
+
+    $messages = get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY)[get_current_user_id()];
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0]['type'])->toBe('error')
+        ->and($messages[0]['message'])->toContain('Order #' . $order->get_order_number())
+        ->toContain('The given data was invalid.');
+});
+
+it('rejects bulk label generation for more than five orders', function () {
+    with_empty_flash_messages();
+
+    $capture = mock_smart_send_api();
+
+    SS_SHIPPING_WC()->get_ss_shipping_wc_order()
+        ->handle_bulk_order_actions('/wp-admin/edit.php', 'ss_shipping_label_bulk', [1, 2, 3, 4, 5, 6]);
+
+    $messages = get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY)[get_current_user_id()];
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0]['type'])->toBe('error')
+        ->and($messages[0]['message'])->toContain('not possible to create labels for more than 5 orders')
+        ->and($capture->requests)->toBe([]);
+});
+
+it('ignores bulk actions that are not Smart Send actions', function () {
+    with_empty_flash_messages();
+
+    $result = SS_SHIPPING_WC()->get_ss_shipping_wc_order()
+        ->handle_bulk_order_actions('/wp-admin/edit.php', 'mark_processing', [1]);
+
+    // v8 oddity: for foreign actions the handler returns null instead of
+    // passing $sendback through.
+    expect($result)->toBeNull()
+        ->and(get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY))
+        ->toBe([get_current_user_id() => []]);
+});

--- a/tests/Integration/OrderMetaTest.php
+++ b/tests/Integration/OrderMetaTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * Characterization tests for the SS_Shipping_WC_Order meta accessors (agent
+ * no, agent object, parcels, label/shipment ids) and for the Smart Send
+ * method detection on an order. The same accessor assertions run against
+ * both order storage backends: legacy post meta and HPOS (the custom orders
+ * table), toggled through the woocommerce_custom_orders_table_enabled
+ * option for the duration of the test.
+ */
+
+/**
+ * The shared accessor assertions, storage-agnostic.
+ */
+function assert_order_meta_accessors_roundtrip(bool $hpos): void
+{
+    $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_agent']);
+    $order_id = $order->get_id();
+
+    // Agent no.
+    expect($handler->get_ss_shipping_order_agent_no($order_id))->toBeNull();
+    $handler->save_ss_shipping_order_agent_no($order_id, '1234');
+    expect($handler->get_ss_shipping_order_agent_no($order_id))->toBe('1234');
+
+    // Agent object (stored under the private _ss_shipping_order_agent key).
+    expect($handler->get_ss_shipping_order_agent($order_id))->toBeNull();
+    $handler->save_ss_shipping_order_agent($order_id, sample_agent());
+    $agent = $handler->get_ss_shipping_order_agent($order_id);
+    expect($agent)->toBeObject()
+        ->and($agent->agent_no)->toBe('1234')
+        ->and($agent->company)->toBe('Corner Shop');
+    expect(wc_get_order($order_id)->get_meta('_ss_shipping_order_agent', true))->toBeObject();
+
+    // v8 oddity: delete_ss_shipping_order_agent() calls delete_meta_data()
+    // but never saves the order, so the delete is not persisted. What a
+    // subsequent read sees then DIFFERS per backend: under legacy storage a
+    // fresh wc_get_order() reloads from the database and still finds the
+    // agent; under HPOS the in-process order cache returns the same object
+    // instance, whose in-memory meta was already deleted.
+    $handler->delete_ss_shipping_order_agent($order_id);
+    if ($hpos) {
+        expect($handler->get_ss_shipping_order_agent($order_id))->toBeNull();
+    } else {
+        expect($handler->get_ss_shipping_order_agent($order_id))->toBeObject();
+    }
+
+    // Parcels.
+    expect($handler->get_ss_shipping_order_parcels($order_id))->toBe('');
+    $parcels = [['id' => $product->get_id(), 'name' => 'Integration Test Product', 'value' => '1']];
+    $handler->save_ss_shipping_order_parcels($order_id, $parcels);
+    expect($handler->get_ss_shipping_order_parcels($order_id))->toEqual($parcels);
+
+    // Shipment/label ids for both normal and return labels.
+    $handler->save_ss_shipment_id_in_order_meta($order_id, 'shipment-123', false);
+    $handler->save_ss_shipment_id_in_order_meta($order_id, 'return-456', true);
+    $fresh = wc_get_order($order_id);
+    expect($fresh->get_meta('_ss_shipping_label_id', true))->toBe('shipment-123')
+        ->and($fresh->get_meta('_ss_shipping_return_label_id', true))->toBe('return-456');
+
+    // Label URLs are derived from the shipment id and the uploads dir.
+    expect($handler->get_label_url_from_order_id($order_id, false))
+        ->toContain('smart-send-label-shipment-123.pdf')
+        ->and($handler->get_label_url_from_order_id($order_id, true))
+        ->toContain('smart-send-label-return-456.pdf');
+}
+
+it('roundtrips order meta through the accessors on legacy post storage', function () {
+    with_option('woocommerce_custom_orders_table_enabled', 'no');
+
+    assert_order_meta_accessors_roundtrip(false);
+
+    // Delete the fixtures while legacy storage is still active.
+    cleanup_created_objects();
+});
+
+it('roundtrips order meta through the accessors on HPOS storage', function () {
+    with_option('woocommerce_custom_orders_table_enabled', 'yes');
+
+    assert_order_meta_accessors_roundtrip(true);
+
+    // Delete the fixtures while HPOS is still active.
+    cleanup_created_objects();
+});
+
+it('falls back to the vConnect meta for agent no and agent object', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product]]);
+    $order->update_meta_data('_vc_aio_options', [
+        'addressId'   => ['value' => '9876'],
+        'name'        => ['value' => 'vConnect Shop'],
+        'addressText' => ['value' => 'Side Street 2'],
+        'city'        => ['value' => 'Aarhus'],
+        'postcode'    => ['value' => '8000'],
+        'country'     => ['value' => 'DK'],
+    ]);
+    $order->save();
+
+    $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+
+    expect($handler->get_ss_shipping_order_agent_no($order->get_id()))->toBe('9876');
+
+    $agent = $handler->get_ss_shipping_order_agent($order->get_id());
+    expect($agent->agent_no)->toBe('9876')
+        ->and($agent->company)->toBe('vConnect Shop')
+        ->and($agent->address_line1)->toBe('Side Street 2')
+        ->and($agent->city)->toBe('Aarhus')
+        ->and($agent->postal_code)->toBe('8000')
+        ->and($agent->country)->toBe('DK');
+});
+
+it('detects the Smart Send shipping method on an order', function () {
+    $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+
+    $ss_order = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_agent',
+        'return_method'   => 'postnord_returndropoff',
+        'auto_return'     => 'yes',
+    ]);
+    expect($handler->get_smart_send_method_id($ss_order->get_id()))->toBe('postnord_agent')
+        ->and($handler->get_smart_send_method_id($ss_order->get_id(), true))->toEqual([
+            'smart_send_return_method'              => 'postnord_returndropoff',
+            'smart_send_auto_generate_return_label' => 'yes',
+        ]);
+
+    $plain_order = create_order(['products' => [$product]]);
+    expect($handler->get_smart_send_method_id($plain_order->get_id()))->toBe('');
+
+    expect($handler->get_smart_send_method_id(0))->toBe('');
+});
+
+it('maps WooCommerce free shipping to the configured Smart Send method', function () {
+    with_ss_settings(['shipping_method_for_free_shipping' => 'gls_agent']);
+
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product]]);
+
+    $shipping_item = new WC_Order_Item_Shipping();
+    $shipping_item->set_method_title('Free shipping');
+    $shipping_item->set_method_id('free_shipping');
+    $shipping_item->set_instance_id(2);
+    $shipping_item->set_total('0');
+    $order->add_item($shipping_item);
+    $order->save();
+
+    expect(SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_smart_send_method_id($order->get_id()))
+        ->toBe('gls_agent');
+});

--- a/tests/Integration/RateCalculationTest.php
+++ b/tests/Integration/RateCalculationTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/*
+ * Characterization tests for SS_Shipping_WC_Method rate calculation: the
+ * weight-bracket table, the free-shipping rules and the availability
+ * options. These capture the CURRENT v8 semantics; #16 will change the
+ * free-shipping behaviour deliberately and must update these tests.
+ */
+
+/**
+ * Build a Smart Send shipping method instance with the given instance
+ * settings persisted in the options table (restored after the test).
+ */
+function create_ss_method(array $instance_settings = [], int $instance_id = 99931): SS_Shipping_WC_Method
+{
+    $settings = array_merge([
+        'title'                    => 'SS Test Method',
+        'method'                   => 'postnord_agent',
+        'return_method'            => 'postnord_returndropoff',
+        'auto_generate_return_label' => 'no',
+        'tax_status'               => 'none',
+        'requires'                 => '',
+        'flatfee_cost'             => '0',
+        'min_amount'               => '0',
+        'cost_weight'              => [],
+        'advanced_settings_enable' => 'no',
+    ], $instance_settings);
+
+    with_option('woocommerce_smart_send_shipping_' . $instance_id . '_settings', $settings);
+
+    return new SS_Shipping_WC_Method($instance_id);
+}
+
+/**
+ * Put products in a fresh cart and return the shipping package the way
+ * WooCommerce hands it to calculate_shipping().
+ */
+function cart_package(array $product_lines): array
+{
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+
+    WC()->cart->empty_cart();
+    remember_cleanup_callback(function (): void {
+        WC()->cart->empty_cart();
+    });
+
+    foreach ($product_lines as $line) {
+        [$product, $quantity] = is_array($line) ? $line : [$line, 1];
+        WC()->cart->add_to_cart($product->get_id(), $quantity);
+    }
+
+    WC()->cart->calculate_totals();
+
+    return current(WC()->cart->get_shipping_packages());
+}
+
+beforeEach(function (): void {
+    with_ss_settings();
+});
+
+it('adds a rate when the cart weight falls inside a bracket, with the Smart Send meta data', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1.5]);
+    $package = cart_package([[$product, 2]]); // 3 kg
+
+    $method = create_ss_method([
+        'cost_weight' => [
+            ['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49'],
+        ],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1);
+
+    $rate = current($method->rates);
+    expect($rate->get_id())->toBe('smart_send_shipping:99931')
+        ->and($rate->get_label())->toBe('SS Test Method')
+        ->and((float) $rate->get_cost())->toBe(49.0)
+        ->and($rate->get_meta_data())->toEqual([
+            'smart_send_shipping_method'            => 'postnord_agent',
+            'smart_send_return_method'              => 'postnord_returndropoff',
+            'smart_send_auto_generate_return_label' => 'no',
+            // Added by WooCommerce core (WC_Shipping_Method::add_rate).
+            'Items'                                 => 'Integration Test Product &times; 2',
+        ]);
+});
+
+it('treats the bracket minimum as inclusive and the maximum as exclusive', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 3]);
+    $package = cart_package([$product]); // exactly 3 kg
+
+    $on_min = create_ss_method([
+        'cost_weight' => [['ss_min_weight' => '3', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ]);
+    $on_min->calculate_shipping($package);
+
+    $on_max = create_ss_method([
+        'cost_weight' => [['ss_min_weight' => '1', 'ss_max_weight' => '3', 'ss_cost_weight' => '49']],
+    ], 99932);
+    $on_max->calculate_shipping($package);
+
+    expect($on_min->rates)->toHaveCount(1)
+        ->and($on_max->rates)->toHaveCount(0);
+});
+
+it('treats a bracket bound of 0 as "no bound" because of the empty() check', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 0.5]);
+    $package = cart_package([$product]);
+
+    // v8 oddity: min/max are checked with empty(), so a "0" minimum (and an
+    // empty maximum) never constrain the bracket.
+    $method = create_ss_method([
+        'cost_weight' => [['ss_min_weight' => '0', 'ss_max_weight' => '', 'ss_cost_weight' => '29']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(29.0);
+});
+
+it('adds no rate when no bracket matches the cart weight', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 10]);
+    $package = cart_package([$product]);
+
+    $method = create_ss_method([
+        'cost_weight' => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(0);
+});
+
+it('keeps only the last matching bracket when brackets overlap', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 2]);
+    $package = cart_package([$product]);
+
+    // v8 oddity: every matching bracket calls add_rate() with the same rate
+    // id, so the last matching row silently wins.
+    $method = create_ss_method([
+        'cost_weight' => [
+            ['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49'],
+            ['ss_min_weight' => '1', 'ss_max_weight' => '10', 'ss_cost_weight' => '99'],
+        ],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(99.0);
+});
+
+it('evaluates cost formulas with the [qty] placeholder', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $package = cart_package([[$product, 3]]);
+
+    $method = create_ss_method([
+        'cost_weight' => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '10 * [qty]']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect((float) current($method->rates)->get_cost())->toBe(30.0);
+});
+
+it('uses the flat fee instead of the weight table when the minimum order amount is met', function () {
+    $product = create_simple_product(['price' => 150, 'weight' => 2]);
+    $package = cart_package([$product]);
+
+    $method = create_ss_method([
+        'requires'     => 'min_amount',
+        'min_amount'   => '100',
+        'flatfee_cost' => '0',
+        'cost_weight'  => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(0.0);
+});
+
+it('falls back to the weight table below the free-shipping threshold', function () {
+    $product = create_simple_product(['price' => 50, 'weight' => 2]);
+    $package = cart_package([$product]);
+
+    $method = create_ss_method([
+        'requires'     => 'min_amount',
+        'min_amount'   => '100',
+        'flatfee_cost' => '0',
+        'cost_weight'  => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(49.0);
+});
+
+it('grants free shipping for a valid free-shipping coupon when required', function () {
+    $product = create_simple_product(['price' => 50, 'weight' => 2]);
+    $coupon  = create_coupon(['type' => 'percent', 'amount' => 0]);
+    $coupon->set_free_shipping(true);
+    $coupon->save();
+
+    $package = cart_package([$product]);
+    WC()->cart->apply_coupon($coupon->get_code());
+
+    $method = create_ss_method([
+        'requires'     => 'coupon',
+        'flatfee_cost' => '0',
+        'cost_weight'  => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(0.0);
+});
+
+it('charges the flat fee whenever the rules are set to always enabled', function () {
+    $product = create_simple_product(['price' => 10, 'weight' => 2]);
+    $package = cart_package([$product]);
+
+    $method = create_ss_method([
+        'requires'     => 'enabled',
+        'flatfee_cost' => '25',
+        'cost_weight'  => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(25.0);
+});
+
+it('is available by default and respects the guest role exclusion', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $package = cart_package([$product]);
+
+    $default = create_ss_method();
+    expect($default->is_available($package))->toBeTrue();
+
+    // The integration suite runs unauthenticated, so the current "customer"
+    // is the guest pseudo-role.
+    $excluding_guests = create_ss_method([
+        'advanced_settings_enable' => 'yes',
+        'user_roles'               => ['guest'],
+    ], 99932);
+    expect($excluding_guests->is_available($package))->toBeFalse();
+});
+
+it('applies the shipping class availability options', function () {
+    $class_id = create_shipping_class('ss-test-class');
+    $classed  = create_simple_product(['price' => 100, 'weight' => 1, 'shipping_class_id' => $class_id]);
+    $package  = cart_package([$classed]);
+
+    $class_slug = get_term($class_id, 'product_shipping_class')->slug;
+
+    $requires_one = create_ss_method([
+        'advanced_settings_enable'   => 'yes',
+        'display_shipping_class_opt' => 'one_shipping_class',
+        'display_shipping_class'     => [$class_slug],
+    ]);
+    expect($requires_one->is_available($package))->toBeTrue();
+
+    $excludes_all = create_ss_method([
+        'advanced_settings_enable'   => 'yes',
+        'display_shipping_class_opt' => 'nall_shipping_class',
+        'display_shipping_class'     => [$class_slug],
+    ], 99932);
+    expect($excludes_all->is_available($package))->toBeFalse();
+});

--- a/tests/Integration/ShipmentPayloadTest.php
+++ b/tests/Integration/ShipmentPayloadTest.php
@@ -1,0 +1,539 @@
+<?php
+
+/*
+ * Characterization ("golden") tests for the booking payload that
+ * SS_Shipping_Shipment sends to the Smart Send API. Each test builds a
+ * representative order, captures the JSON body posted to the (mocked) API,
+ * and compares it to the complete expected payload. If any field of the
+ * booking request changes, these tests fail.
+ *
+ * IMPORTANT: these tests assert CURRENT v8 behaviour, including known
+ * oddities (marked "v8 oddity"). Do not "fix" an expectation here without a
+ * deliberate behaviour change in the plugin.
+ */
+
+/**
+ * Send the order through SS_Shipping_Shipment against a mocked API and
+ * return the decoded JSON payload of the createShipmentAndLabels request.
+ */
+function capture_shipment_payload(WC_Order $order, bool $return = false): array
+{
+    $capture = mock_smart_send_api();
+
+    $shipment = new SS_Shipping_Shipment($order, SS_SHIPPING_WC()->get_ss_shipping_wc_order());
+    expect($shipment->make_single_shipment_api_call($return))->toBeTrue();
+
+    $request = end($capture->requests);
+    expect($request['url'])->toContain('shipments/labels');
+
+    return json_decode($request['body'], true);
+}
+
+/**
+ * The full expected payload for a plain domestic order: one parcel with one
+ * item line per product. $overrides is array_replace_recursive'd over the
+ * base so each scenario states exactly what it changes.
+ */
+function expected_payload(WC_Order $order, array $overrides = []): array
+{
+    $order_id = (string) $order->get_id();
+
+    $base = [
+        'internal_id'        => $order_id,
+        'internal_reference' => $order_id,
+        'shipping_carrier'   => 'postnord',
+        'shipping_method'    => 'agent',
+        'shipping_date'      => date('Y-m-d'),
+        'sender'             => null,
+        'receiver'           => [
+            'internal_id'        => $order_id,
+            'internal_reference' => $order_id,
+            'company'            => null,
+            'name_line1'         => 'Test',
+            'name_line2'         => 'Customer',
+            'address_line1'      => 'Islands Brygge 39',
+            'address_line2'      => null,
+            'postal_code'        => '2300',
+            'city'               => 'Copenhagen',
+            'country'            => 'DK',
+            'sms'                => '+4512345678',
+            'email'              => 'integration-test@smartsend.io',
+        ],
+        'agent'              => null,
+        'parcels'            => [],
+        'services'           => [
+            'email_notification' => 'integration-test@smartsend.io',
+            'sms_notification'   => '+4512345678',
+            'flex_delivery'      => null,
+        ],
+        'subtotal_price_excluding_tax' => null,
+        'subtotal_price_including_tax' => null,
+        'shipping_price_excluding_tax' => null,
+        'shipping_price_including_tax' => null,
+        'total_price_excluding_tax'    => null,
+        'total_price_including_tax'    => null,
+        'total_tax_amount'             => null,
+        'currency'                     => 'DKK',
+    ];
+
+    return array_replace_recursive($base, $overrides);
+}
+
+/**
+ * A full expected item line for a simple product.
+ */
+function expected_item(WC_Product $product, array $overrides = []): array
+{
+    $product_id = (string) $product->get_id();
+
+    return array_replace([
+        'internal_id'        => $product_id,
+        'internal_reference' => $product_id,
+        'sku'                => $product->get_sku() ? $product->get_sku() : $product_id,
+        'name'               => $product->get_name(),
+        'description'        => null,
+        'hs_code'            => null,
+        'country_of_origin'  => null,
+        'image_url'          => null,
+        'unit_weight'        => 1,
+        'unit_price_excluding_tax' => 100,
+        'unit_price_including_tax' => 100,
+        'quantity'           => 1,
+        'total_price_excluding_tax' => 100,
+        'total_price_including_tax' => 100,
+        'total_tax_amount'   => null,
+    ], $overrides);
+}
+
+beforeEach(function (): void {
+    with_ss_settings();
+});
+
+it('books a simple domestic agent order with the full expected payload', function () {
+    $product = create_simple_product(['name' => 'Simple Product', 'price' => 100, 'weight' => 1.5, 'sku' => 'SIMPLE-' . uniqid()]);
+    $order   = create_order([
+        'products'        => [[$product, 2]],
+        'shipping_method' => 'postnord_agent',
+        'shipping_total'  => '39',
+    ]);
+    SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent($order->get_id(), sample_agent());
+
+    $payload  = capture_shipment_payload($order);
+    $order_id = (string) $order->get_id();
+
+    expect($payload)->toEqual(expected_payload($order, [
+        'agent' => [
+            'internal_id'        => '7',
+            'internal_reference' => '7',
+            'agent_no'           => '1234',
+            'company'            => 'Corner Shop',
+            'name_line1'         => null,
+            'name_line2'         => null,
+            'address_line1'      => 'Main Street 1',
+            'address_line2'      => null,
+            'postal_code'        => '2300',
+            'city'               => 'Copenhagen',
+            'country'            => 'DK',
+            'sms'                => null,
+            'email'              => null,
+        ],
+        'parcels' => [
+            [
+                'internal_id'        => $order_id,
+                'internal_reference' => $order_id,
+                'weight'             => 3,
+                'height'             => null,
+                'width'              => null,
+                'length'             => null,
+                'freetext'           => null,
+                'items'              => [
+                    expected_item($product, [
+                        'unit_weight'               => 1.5,
+                        'quantity'                  => 2,
+                        'total_price_excluding_tax' => 200,
+                        'total_price_including_tax' => 200,
+                    ]),
+                ],
+                // v8 oddity: with zero tax, the parcel "excluding tax" total
+                // includes shipping (order_total - subtotal_tax) while the
+                // "including tax" total does not.
+                'total_price_excluding_tax' => 239,
+                'total_price_including_tax' => 200,
+                'total_tax_amount'          => null,
+            ],
+        ],
+        // v8 oddity: same asymmetry on the shipment-level subtotal.
+        'subtotal_price_excluding_tax' => 239,
+        'subtotal_price_including_tax' => 200,
+        'shipping_price_excluding_tax' => 39,
+        'shipping_price_including_tax' => 39,
+        'total_price_excluding_tax'    => 239,
+        'total_price_including_tax'    => 239,
+    ]));
+});
+
+it('prices item lines pre-discount when a percentage coupon is applied', function () {
+    $product = create_simple_product(['name' => 'Couponed Product', 'price' => 100, 'weight' => 1]);
+    $coupon  = create_coupon(['type' => 'percent', 'amount' => 10]);
+    $order   = create_order([
+        'products'        => [[$product, 2]],
+        'coupons'         => $coupon->get_code(),
+        'shipping_method' => 'postnord_homedelivery',
+        'shipping_total'  => '39',
+    ]);
+    $order_id = (string) $order->get_id();
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload)->toEqual(expected_payload($order, [
+        'shipping_method' => 'homedelivery',
+        'parcels'         => [
+            [
+                'internal_id'        => $order_id,
+                'internal_reference' => $order_id,
+                'weight'             => 2,
+                'height'             => null,
+                'width'              => null,
+                'length'             => null,
+                'freetext'           => null,
+                'items'              => [
+                    // v8 oddity: item lines use the pre-discount subtotal, so
+                    // the coupon discount never shows up on the item lines.
+                    expected_item($product, [
+                        'quantity'                  => 2,
+                        'total_price_excluding_tax' => 200,
+                        'total_price_including_tax' => 200,
+                    ]),
+                ],
+                'total_price_excluding_tax' => 219,
+                'total_price_including_tax' => 180,
+                'total_tax_amount'          => null,
+            ],
+        ],
+        'subtotal_price_excluding_tax' => 219,
+        'subtotal_price_including_tax' => 180,
+        'shipping_price_excluding_tax' => 39,
+        'shipping_price_including_tax' => 39,
+        'total_price_excluding_tax'    => 219,
+        'total_price_including_tax'    => 219,
+    ]));
+});
+
+it('folds an order fee into the parcel totals but not into any item line', function () {
+    $product = create_simple_product(['name' => 'Product With Fee', 'price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'fees'            => [['Handling fee', 25]],
+        'shipping_method' => 'postnord_homedelivery',
+        'shipping_total'  => '39',
+    ]);
+    $order_id = (string) $order->get_id();
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload)->toEqual(expected_payload($order, [
+        'shipping_method' => 'homedelivery',
+        'parcels'         => [
+            [
+                'internal_id'        => $order_id,
+                'internal_reference' => $order_id,
+                'weight'             => 1,
+                'height'             => null,
+                'width'              => null,
+                'length'             => null,
+                'freetext'           => null,
+                'items'              => [expected_item($product)],
+                // Fee is part of the order subtotal, so the parcel totals
+                // exceed the sum of the item lines.
+                'total_price_excluding_tax' => 164,
+                'total_price_including_tax' => 125,
+                'total_tax_amount'          => null,
+            ],
+        ],
+        'subtotal_price_excluding_tax' => 164,
+        'subtotal_price_including_tax' => 125,
+        'shipping_price_excluding_tax' => 39,
+        'shipping_price_including_tax' => 39,
+        'total_price_excluding_tax'    => 164,
+        'total_price_including_tax'    => 164,
+    ]));
+});
+
+it('books a taxed order with the v8 tax semantics', function () {
+    with_option('woocommerce_calc_taxes', 'yes');
+    create_tax_rate(['rate' => '25.0000', 'country' => 'DK', 'shipping' => 1]);
+
+    $product = create_simple_product(['name' => 'Taxed Product', 'price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_homedelivery',
+        'shipping_total'  => '39',
+    ]);
+    $order_id = (string) $order->get_id();
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload)->toEqual(expected_payload($order, [
+        'shipping_method' => 'homedelivery',
+        'parcels'         => [
+            [
+                'internal_id'        => $order_id,
+                'internal_reference' => $order_id,
+                'weight'             => 1,
+                'height'             => null,
+                'width'              => null,
+                'length'             => null,
+                'freetext'           => null,
+                'items'              => [
+                    expected_item($product, [
+                        'unit_price_including_tax'  => 125,
+                        'total_price_including_tax' => 125,
+                        'total_tax_amount'          => 25,
+                    ]),
+                ],
+                'total_price_excluding_tax' => 114,
+                'total_price_including_tax' => 134.75,
+                'total_tax_amount'          => 25,
+            ],
+        ],
+        // v8 oddity: WC_Order::get_shipping_total() is already excluding
+        // tax, but the plugin treats it as including tax; the resulting
+        // "excluding tax" shipping price subtracts the shipping tax twice.
+        'subtotal_price_excluding_tax' => 114,
+        'subtotal_price_including_tax' => 134.75,
+        'shipping_price_excluding_tax' => 29.25,
+        'shipping_price_including_tax' => 39,
+        'total_price_excluding_tax'    => 139,
+        'total_price_including_tax'    => 173.75,
+        'total_tax_amount'             => 34.75,
+    ]));
+});
+
+it('includes customs data on the item lines for an international order', function () {
+    $product = create_simple_product([
+        'name'              => 'Customs Product',
+        'price'             => 100,
+        'weight'            => 1,
+        'hs_code'           => '61091000',
+        'customs_desc'      => 'Cotton t-shirt',
+        'country_of_origin' => 'DK',
+    ]);
+    $order = create_order([
+        'products'        => [$product],
+        'address'         => [
+            'address_1' => '350 Fifth Avenue',
+            'city'      => 'New York',
+            'postcode'  => '10118',
+            'country'   => 'US',
+        ],
+        'shipping_method' => 'postnord_commercial',
+        'shipping_total'  => '150',
+    ]);
+    $order_id = (string) $order->get_id();
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload)->toEqual(expected_payload($order, [
+        'shipping_method' => 'commercial',
+        'receiver'        => [
+            'address_line1' => '350 Fifth Avenue',
+            'postal_code'   => '10118',
+            'city'          => 'New York',
+            'country'       => 'US',
+        ],
+        'parcels' => [
+            [
+                'internal_id'        => $order_id,
+                'internal_reference' => $order_id,
+                'weight'             => 1,
+                'height'             => null,
+                'width'              => null,
+                'length'             => null,
+                'freetext'           => null,
+                'items'              => [
+                    expected_item($product, [
+                        'description'       => 'Cotton t-shirt',
+                        'hs_code'           => '61091000',
+                        'country_of_origin' => 'DK',
+                    ]),
+                ],
+                'total_price_excluding_tax' => 250,
+                'total_price_including_tax' => 100,
+                'total_tax_amount'          => null,
+            ],
+        ],
+        'subtotal_price_excluding_tax' => 250,
+        'subtotal_price_including_tax' => 100,
+        'shipping_price_excluding_tax' => 150,
+        'shipping_price_including_tax' => 150,
+        'total_price_excluding_tax'    => 250,
+        'total_price_including_tax'    => 250,
+    ]));
+});
+
+it('drops the receiver phone when billing and shipping countries differ', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'address'         => [
+            'address_1' => 'Karl Johans gate 1',
+            'city'      => 'Oslo',
+            'postcode'  => '0154',
+            'country'   => 'NO',
+        ],
+        'billing_address' => [
+            'address_1' => 'Islands Brygge 39',
+            'city'      => 'Copenhagen',
+            'postcode'  => '2300',
+            'country'   => 'DK',
+        ],
+        'shipping_method' => 'postnord_homedelivery',
+    ]);
+
+    $payload = capture_shipment_payload($order);
+
+    // Only local phone numbers are accepted by the API, so the billing
+    // phone is dropped when the shipping country differs from billing.
+    expect($payload['receiver']['sms'])->toBeNull()
+        ->and($payload['receiver']['country'])->toBe('NO')
+        ->and($payload['services']['sms_notification'])->toBeNull()
+        ->and($payload['services']['email_notification'])->toBe('integration-test@smartsend.io');
+});
+
+it('uses the variation id, sku and weight for variable products', function () {
+    [$parent, $variation] = create_variable_product([
+        'name'   => 'Variable Product',
+        'price'  => 100,
+        'weight' => 2.5,
+        'sku'    => 'VAR-L-' . uniqid(),
+    ]);
+    $order = create_order([
+        'products'        => [$variation],
+        'shipping_method' => 'postnord_agent',
+    ]);
+    $order_id     = (string) $order->get_id();
+    $variation_id = (string) $variation->get_id();
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload)->toEqual(expected_payload($order, [
+        'parcels' => [
+            [
+                'internal_id'        => $order_id,
+                'internal_reference' => $order_id,
+                'weight'             => 2.5,
+                'height'             => null,
+                'width'              => null,
+                'length'             => null,
+                'freetext'           => null,
+                'items'              => [
+                    [
+                        'internal_id'        => $variation_id,
+                        'internal_reference' => $variation_id,
+                        'sku'                => $variation->get_sku(),
+                        'name'               => 'Variable Product',
+                        'description'        => null,
+                        'hs_code'            => null,
+                        'country_of_origin'  => null,
+                        'image_url'          => null,
+                        'unit_weight'        => 2.5,
+                        'unit_price_excluding_tax' => 100,
+                        'unit_price_including_tax' => 100,
+                        'quantity'           => 1,
+                        'total_price_excluding_tax' => 100,
+                        'total_price_including_tax' => 100,
+                        'total_tax_amount'   => null,
+                    ],
+                ],
+                'total_price_excluding_tax' => 100,
+                'total_price_including_tax' => 100,
+                'total_tax_amount'          => null,
+            ],
+        ],
+        'subtotal_price_excluding_tax' => 100,
+        'subtotal_price_including_tax' => 100,
+        'total_price_excluding_tax'    => 100,
+        'total_price_including_tax'    => 100,
+    ]));
+});
+
+it('sends a null parcel weight when products have no weight', function () {
+    $product = create_simple_product(['name' => 'Weightless Product', 'price' => 50, 'weight' => null]);
+    $order   = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_homedelivery',
+    ]);
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload['parcels'][0]['weight'])->toBeNull()
+        ->and($payload['parcels'][0]['items'][0]['unit_weight'])->toBeNull()
+        // v8 oddity: a zero shipping total is sent as null, not 0.
+        ->and($payload['shipping_price_excluding_tax'])->toBeNull()
+        ->and($payload['shipping_price_including_tax'])->toBeNull();
+});
+
+it('splits the shipment into one parcel per box when parcels meta is set', function () {
+    $product_a = create_simple_product(['name' => 'Box One Product', 'price' => 100, 'weight' => 1]);
+    $product_b = create_simple_product(['name' => 'Box Two Product', 'price' => 50, 'weight' => 2]);
+    $order     = create_order([
+        'products'        => [$product_a, $product_b],
+        'shipping_method' => 'postnord_agent',
+        'shipping_total'  => '39',
+    ]);
+    SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_parcels($order->get_id(), [
+        ['id' => $product_a->get_id(), 'name' => 'Box One Product', 'value' => '1'],
+        ['id' => $product_b->get_id(), 'name' => 'Box Two Product', 'value' => '2'],
+    ]);
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload['parcels'])->toHaveCount(2)
+        ->and($payload['parcels'][0]['items'][0]['name'])->toBe('Box One Product')
+        ->and($payload['parcels'][0]['weight'])->toEqual(1)
+        ->and($payload['parcels'][0]['total_price_excluding_tax'])->toEqual(100)
+        ->and($payload['parcels'][0]['total_price_including_tax'])->toEqual(100)
+        ->and($payload['parcels'][1]['items'][0]['name'])->toBe('Box Two Product')
+        ->and($payload['parcels'][1]['weight'])->toEqual(2)
+        ->and($payload['parcels'][1]['total_price_excluding_tax'])->toEqual(50)
+        ->and($payload['parcels'][1]['total_price_including_tax'])->toEqual(50);
+});
+
+it('includes the customer note as parcel freetext when enabled in settings', function () {
+    with_ss_settings(['include_order_comment' => 'yes']);
+
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_homedelivery',
+        'customer_note'   => 'Please leave at the back door',
+    ]);
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload['parcels'][0]['freetext'])->toBe('Please leave at the back door');
+});
+
+it('lets the smart_send_shipping_label_args filter override carrier and method', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_homedelivery',
+    ]);
+
+    $filter = function (array $ss_args) {
+        $ss_args['ss_carrier'] = 'gls';
+        $ss_args['ss_type']    = 'homedelivery';
+
+        return $ss_args;
+    };
+    add_filter('smart_send_shipping_label_args', $filter);
+    remember_cleanup_callback(function () use ($filter): void {
+        remove_filter('smart_send_shipping_label_args', $filter);
+    });
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload['shipping_carrier'])->toBe('gls')
+        ->and($payload['shipping_method'])->toBe('homedelivery');
+});


### PR DESCRIPTION
Adds the v9 characterization test safety net (Phase 1 of v9). All tests assert **current v8 behaviour** — including several oddities, which are captured with `v8 oddity` comments rather than fixed. Zero changes under `smart-send-logistics/`.

## Coverage added

**Integration** (`tests/Integration`, 33 new tests, run in ~10s):

- **`ShipmentPayloadTest`** (11) — golden tests for the `createShipmentAndLabels` booking payload: the full JSON body is compared field-by-field for a simple domestic agent order, coupon, fee, taxed order, international order with customs meta (HS code / country of origin / customs description), variation product, missing weights, split parcels, order-comment freetext, and the `smart_send_shipping_label_args` filter. Any unintended change to the booking request fails these.
- **`RateCalculationTest`** (12) — weight-bracket matching (min inclusive / max exclusive, `empty()` bound semantics, overlapping brackets), `[qty]` cost formulas, free-shipping threshold + coupon + always-enabled rules (current v8 semantics — #16 will update these deliberately), rate meta data, and availability (shipping-class options, user-role exclusion).
- **`OrderMetaTest`** (5) — agent no / agent object / parcels / label-id accessors run identically against **legacy post storage and HPOS** (toggled per test), vConnect fallbacks, Smart Send method detection incl. the free-shipping mapping.
- **`LabelGenerationTest`** (11) — label creation with the API mocked via `pre_http_request`: success (meta, order note, tracking, `smart_send_shipping_label_created`), configured status change, API error formatting, auto return label, return-only label, bulk action on two orders incl. the combined-PDF admin notice rendering/clearing, bulk error paths (>5 orders, non-Smart-Send order, API failure).
- **`FrontendAgentDisplayTest`** (8) — thank-you/email pick-up point display, empty-agent case, checkout validation notice, agent persistence from session at checkout, and the invalid-order guard (#60).
- **`Helpers.php`** — new factories/utilities: Smart Send API mock (`pre_http_request`), settings/option overrides with restore, variable products, tax rates, shipping classes, fees and Smart Send shipping items on orders; everything force-cleaned after each test.

**Browser** (`tests/Browser/SmartSendFlowsTest.php`, 3 new tests, verified locally against a `bin/setup-local-dev.sh` store):

- Classic checkout: agent method selected → pick-up point dropdown rendered → point chosen → order placed (COD) → agent shown on the thank-you page.
- Admin order screen: Generate label → "Download shipping label" link.
- Bulk action on two orders → combined-PDF success notice.
- The Smart Send API is mocked with a temporary mu-plugin installed into the store for the duration of the file (gated on an option, removed in `afterAll`); fixtures (zone method, classic checkout page, orders, product) are created via WP-CLI and torn down afterwards. The tests skip themselves when the suite targets a store whose filesystem is not reachable.

**Process:**

- Both CI workflows now also trigger on pushes to `develop` (they already ran on all PRs, which covers PRs into `develop` — verified, no change needed there).
- The **no-refactor-without-tests** rule is documented in `CLAUDE.md` (Testing) and `README.md` (Test safety net).

## Behaviour oddities surfaced (characterized, not fixed)

1. **Subtotal/parcel “excluding tax” totals include shipping** when tax ≠ the incl/excl delta: `order_subtotal_excl = order_total_excl − order_subtotal_tax`, so for a tax-free order the payload reports `subtotal_price_excluding_tax` *higher* than `subtotal_price_including_tax` (e.g. 239 vs 200).
2. **Shipping price tax handling is inverted**: `WC_Order::get_shipping_total()` is already excl. tax, but the payload uses it as `shipping_price_including_tax` and reports `total − tax` (tax subtracted twice) as `shipping_price_excluding_tax`.
3. **Item lines ignore coupon discounts** — they are built from the pre-discount subtotal, while order totals are post-discount.
4. **Zero values are nulled** throughout the payload (`?: null`), e.g. a 0.00 shipping total is sent as `null`.
5. **Split-parcel totals use unit prices and per-unit weights**, ignoring quantities.
6. **`delete_ss_shipping_order_agent()` never saves the order**, and the visible result then differs by backend: under legacy storage a fresh read still returns the agent; under HPOS the in-process order cache makes the (unsaved) delete visible immediately.
7. **Overlapping weight brackets**: every matching row calls `add_rate()` with the same rate id, so the last matching row silently wins.
8. **A weight bound of `0` means “no bound”** (checked with `empty()`).
9. **Bulk handler returns `null`** instead of `$sendback` for non-Smart-Send bulk actions.
10. **“Send Smart” typo** in the bulk error message for orders without a Smart Send method.
11. **`add_admin_flash_messages()`** reads the bag without `isset()` and emits an “Undefined array key” warning on a fresh option.

## Running

```bash
composer test:integration   # needs a bin/setup-local-dev.sh install (WP_DEV_PATH to override)
composer test:browser       # needs the store running + WP-CLI/filesystem access (see README)
composer test               # both
```

Local runs: Integration 52 passing tests (208 assertions, ~10s); Browser 10 passing tests (35 assertions, ~14s) against a fresh setup-script store. CI runs both on this PR.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
