### PR TITLE
Guard wc_get_order() call sites against missing orders

### DIFF
--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -146,15 +146,23 @@ if (!class_exists('SS_Shipping_WC_Order')) :
                     foreach ($items as $order_id) {
                         $order = wc_get_order($order_id);
 
-                        if (! $order instanceof WC_Order) {
-                            array_push($array_messages_error, array(
-                                'message' => sprintf(__('Order #%s', 'smart-send-logistics'),
-                                        $order_id) . ': ' . __('The order could not be found',
-                                        'smart-send-logistics'),
-                                'type'    => 'error',
-                            ));
-                            continue;
-                        }
+						if ( ! $order instanceof WC_Order ) {
+							array_push(
+								$array_messages_error,
+								array(
+									'message' => sprintf(
+										/* translators: %s: WooCommerce order id */
+										__( 'Order #%s', 'smart-send-logistics' ),
+										$order_id
+									) . ': ' . __(
+										'The order could not be found',
+										'smart-send-logistics'
+									),
+									'type'    => 'error',
+								)
+							);
+							continue;
+						}
 
                         $ss_shipping_method_id = $this->get_smart_send_method_id($order_id);
 
@@ -250,8 +258,8 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 
             // ... rest of the code. $post_or_order_object should not be used directly below this point´
 
-            if (! $order instanceof WC_Order) {
-                return;
+			if ( ! $order instanceof WC_Order ) {
+				return;
             }
 
             $order_id = $order->get_id();
@@ -673,15 +681,20 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          */
         protected function create_label_for_single_order($order_id, $return = false, $setting_save_order_note = true)
         {
-            // Load WC Order
-            $order = wc_get_order($order_id);
+			// Load WC Order
+			$order = wc_get_order( $order_id );
 
-            if (! $order instanceof WC_Order) {
-                return array('error' => sprintf(__('Order #%s', 'smart-send-logistics'), $order_id)
-                    . ': ' . __('The order could not be found', 'smart-send-logistics'));
-            }
+			if ( ! $order instanceof WC_Order ) {
+				return array(
+					'error' => sprintf(
+						/* translators: %s: WooCommerce order id */
+						__( 'Order #%s', 'smart-send-logistics' ),
+						$order_id
+					) . ': ' . __( 'The order could not be found', 'smart-send-logistics' ),
+				);
+			}
 
-            $ss_order_api = new SS_Shipping_Shipment($order, $this);
+			$ss_order_api = new SS_Shipping_Shipment( $order, $this );
 
             if ($ss_order_api->make_single_shipment_api_call( $return )) {
 
@@ -867,15 +880,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          * @param array $parcels
          *
          * @return void
-         */
-        public function save_ss_shipping_order_parcels($order_id, $parcels)
-        {
-            $order = wc_get_order($order_id);
-            if (! $order instanceof WC_Order) {
-                return;
-            }
-            $order->update_meta_data('ss_shipping_order_parcels', $parcels);
-            $order->save();
+		 */
+		public function save_ss_shipping_order_parcels( $order_id, $parcels ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return;
+			}
+			$order->update_meta_data( 'ss_shipping_order_parcels', $parcels );
+			$order->save();
         }
 
         /**
@@ -888,11 +900,11 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          */
         public function get_ss_shipping_order_parcels($order_id)
         {
-            $order = wc_get_order( $order_id );
-            if (! $order instanceof WC_Order) {
-                return false;
-            }
-            return $order->get_meta( 'ss_shipping_order_parcels', true );
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return false;
+			}
+			return $order->get_meta( 'ss_shipping_order_parcels', true );
         }
 
 
@@ -903,15 +915,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          * @param array $agent_no Agent No.
          *
          * @return void
-         */
-        public function save_ss_shipping_order_agent_no($order_id, $agent_no)
-        {
-            $order = wc_get_order($order_id);
-            if (! $order instanceof WC_Order) {
-                return;
-            }
-            $order->update_meta_data('ss_shipping_order_agent_no', $agent_no);
-            $order->save();
+		 */
+		public function save_ss_shipping_order_agent_no( $order_id, $agent_no ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return;
+			}
+			$order->update_meta_data( 'ss_shipping_order_agent_no', $agent_no );
+			$order->save();
         }
 
         /*
@@ -924,16 +935,16 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function get_ss_shipping_order_agent_no($order_id)
         {
             // Fetch agent_no from meta field saved by Smart Send
-            $order = wc_get_order( $order_id );
+			$order = wc_get_order( $order_id );
 
-            // wc_get_order() returns false when the order does not exist, e.g. when
-            // WooCommerce's email preview fires the order-details hooks with a
-            // placeholder order ID. See issue #60.
-            if (! $order instanceof WC_Order) {
-                return null;
-            }
+			// wc_get_order() returns false when the order does not exist, e.g. when
+			// WooCommerce's email preview fires the order-details hooks with a
+			// placeholder order ID. See issue #60.
+			if ( ! $order instanceof WC_Order ) {
+				return null;
+			}
 
-            $ss_agent_number = $order->get_meta( 'ss_shipping_order_agent_no', true );
+			$ss_agent_number = $order->get_meta( 'ss_shipping_order_agent_no', true );
             if ($ss_agent_number) {
                 // Return the agent_no found
                 return $ss_agent_number;
@@ -955,15 +966,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          * @param array $agent Agent Object
          *
          * @return void
-         */
-        public function save_ss_shipping_order_agent($order_id, $agent)
-        {
-            $order = wc_get_order($order_id);
-            if (! $order instanceof WC_Order) {
-                return;
-            }
-            $order->update_meta_data('_ss_shipping_order_agent', $agent);
-            $order->save();
+		 */
+		public function save_ss_shipping_order_agent( $order_id, $agent ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return;
+			}
+			$order->update_meta_data( '_ss_shipping_order_agent', $agent );
+			$order->save();
         }
 
 	    /**
@@ -994,14 +1004,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          */
         public function get_ss_shipping_order_agent($order_id)
         {
-            // Fetch agent info from meta field saved by Smart Send
-            $order = wc_get_order( $order_id );
+			// Fetch agent info from meta field saved by Smart Send
+			$order = wc_get_order( $order_id );
 
-            if (! $order instanceof WC_Order) {
-                return null;
-            }
+			if ( ! $order instanceof WC_Order ) {
+				return null;
+			}
 
-            $ss_agent_info = $order->get_meta( '_ss_shipping_order_agent', true );
+			$ss_agent_info = $order->get_meta( '_ss_shipping_order_agent', true );
             if ($ss_agent_info) {
                 // Return the agent_no found
                 return $ss_agent_info;
@@ -1032,16 +1042,16 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          * @param boolean $return Whether or not the label is return (true) or normal (false)
          *
          * @return void
-         */
-        public function save_ss_shipment_id_in_order_meta($order_id, $shipment_id, $return)
-        {
-            $order = wc_get_order($order_id);
-            if (! $order instanceof WC_Order) {
-                return;
-            }
-            if ($return) {
-                $order->update_meta_data('_ss_shipping_return_label_id', $shipment_id);
-            } else {
+		 */
+		// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.returnFound -- pre-existing public method signature, kept for backwards compatibility.
+		public function save_ss_shipment_id_in_order_meta( $order_id, $shipment_id, $return ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return;
+			}
+			if ( $return ) {
+				$order->update_meta_data( '_ss_shipping_return_label_id', $shipment_id );
+			} else {
                 $order->update_meta_data('_ss_shipping_label_id', $shipment_id);
             }
             $order->save();
@@ -1057,12 +1067,12 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          */
         public function get_label_url_from_order_id($order_id, $return): string
         {
-            $order = wc_get_order( $order_id );
-            if (! $order instanceof WC_Order) {
-                return '';
-            }
-            if ($return) {
-                $shipment_id = $order->get_meta( '_ss_shipping_return_label_id', true );
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return '';
+			}
+			if ( $return ) {
+				$shipment_id = $order->get_meta( '_ss_shipping_return_label_id', true );
             } else {
                 $shipment_id = $order->get_meta( '_ss_shipping_label_id', true );
             }

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -6,7 +6,6 @@ if (!defined('ABSPATH')) {
 
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
-use WooCommerce\Classes\WC_Order;
 
 /**
  * WooCommerce Smart Send Shipping Order.
@@ -147,6 +146,16 @@ if (!class_exists('SS_Shipping_WC_Order')) :
                     foreach ($items as $order_id) {
                         $order = wc_get_order($order_id);
 
+                        if (! $order instanceof WC_Order) {
+                            array_push($array_messages_error, array(
+                                'message' => sprintf(__('Order #%s', 'smart-send-logistics'),
+                                        $order_id) . ': ' . __('The order could not be found',
+                                        'smart-send-logistics'),
+                                'type'    => 'error',
+                            ));
+                            continue;
+                        }
+
                         $ss_shipping_method_id = $this->get_smart_send_method_id($order_id);
 
                         if (!empty($ss_shipping_method_id)) {
@@ -240,6 +249,10 @@ if (!class_exists('SS_Shipping_WC_Order')) :
             $order = ( $post_or_order_object instanceof WP_Post ) ? wc_get_order( $post_or_order_object->ID ) : $post_or_order_object;
 
             // ... rest of the code. $post_or_order_object should not be used directly below this point´
+
+            if (! $order instanceof WC_Order) {
+                return;
+            }
 
             $order_id = $order->get_id();
 
@@ -662,7 +675,12 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         {
             // Load WC Order
             $order = wc_get_order($order_id);
-            
+
+            if (! $order instanceof WC_Order) {
+                return array('error' => sprintf(__('Order #%s', 'smart-send-logistics'), $order_id)
+                    . ': ' . __('The order could not be found', 'smart-send-logistics'));
+            }
+
             $ss_order_api = new SS_Shipping_Shipment($order, $this);
 
             if ($ss_order_api->make_single_shipment_api_call( $return )) {
@@ -853,6 +871,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function save_ss_shipping_order_parcels($order_id, $parcels)
         {
             $order = wc_get_order($order_id);
+            if (! $order instanceof WC_Order) {
+                return;
+            }
             $order->update_meta_data('ss_shipping_order_parcels', $parcels);
             $order->save();
         }
@@ -868,6 +889,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function get_ss_shipping_order_parcels($order_id)
         {
             $order = wc_get_order( $order_id );
+            if (! $order instanceof WC_Order) {
+                return false;
+            }
             return $order->get_meta( 'ss_shipping_order_parcels', true );
         }
 
@@ -883,6 +907,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function save_ss_shipping_order_agent_no($order_id, $agent_no)
         {
             $order = wc_get_order($order_id);
+            if (! $order instanceof WC_Order) {
+                return;
+            }
             $order->update_meta_data('ss_shipping_order_agent_no', $agent_no);
             $order->save();
         }
@@ -898,6 +925,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         {
             // Fetch agent_no from meta field saved by Smart Send
             $order = wc_get_order( $order_id );
+
+            // wc_get_order() returns false when the order does not exist, e.g. when
+            // WooCommerce's email preview fires the order-details hooks with a
+            // placeholder order ID. See issue #60.
+            if (! $order instanceof WC_Order) {
+                return null;
+            }
+
             $ss_agent_number = $order->get_meta( 'ss_shipping_order_agent_no', true );
             if ($ss_agent_number) {
                 // Return the agent_no found
@@ -924,6 +959,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function save_ss_shipping_order_agent($order_id, $agent)
         {
             $order = wc_get_order($order_id);
+            if (! $order instanceof WC_Order) {
+                return;
+            }
             $order->update_meta_data('_ss_shipping_order_agent', $agent);
             $order->save();
         }
@@ -957,7 +995,12 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function get_ss_shipping_order_agent($order_id)
         {
             // Fetch agent info from meta field saved by Smart Send
-            $order         = wc_get_order( $order_id );
+            $order = wc_get_order( $order_id );
+
+            if (! $order instanceof WC_Order) {
+                return null;
+            }
+
             $ss_agent_info = $order->get_meta( '_ss_shipping_order_agent', true );
             if ($ss_agent_info) {
                 // Return the agent_no found
@@ -993,6 +1036,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function save_ss_shipment_id_in_order_meta($order_id, $shipment_id, $return)
         {
             $order = wc_get_order($order_id);
+            if (! $order instanceof WC_Order) {
+                return;
+            }
             if ($return) {
                 $order->update_meta_data('_ss_shipping_return_label_id', $shipment_id);
             } else {
@@ -1012,6 +1058,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function get_label_url_from_order_id($order_id, $return): string
         {
             $order = wc_get_order( $order_id );
+            if (! $order instanceof WC_Order) {
+                return '';
+            }
             if ($return) {
                 $shipment_id = $order->get_meta( '_ss_shipping_return_label_id', true );
             } else {

--- a/tests/Integration/FrontendAgentDisplayTest.php
+++ b/tests/Integration/FrontendAgentDisplayTest.php
@@ -60,6 +60,23 @@ it('renders nothing for an order without an agent', function () {
     expect(capture_agent_display($order))->toBe('');
 });
 
+it('renders nothing for an order that does not exist in the database', function () {
+    // Regression for #60: WooCommerce's email preview fires the order-details
+    // hooks (woocommerce_email_after_order_table etc.) with a placeholder
+    // order that has no database row, so wc_get_order() returns false inside
+    // the meta accessors. This used to fatal with
+    // "Call to a member function get_meta() on bool".
+    $ghost = new WC_Order(); // Unsaved: get_id() is 0 and wc_get_order(0) is false.
+
+    expect(capture_agent_display($ghost))->toBe('');
+
+    // Fire the actual hooks the way the email templates do.
+    ob_start();
+    do_action('woocommerce_order_details_after_order_table', $ghost);
+    do_action('woocommerce_email_after_order_table', $ghost, false);
+    expect(ob_get_clean())->toBe('');
+});
+
 it('survives deleting the agent meta of an order that no longer exists', function () {
     // Invalid-order guard (#60): the deleted_post_meta hook can fire for
     // orders that were already removed; the handler must not fatal.

--- a/tests/Integration/OrderMetaTest.php
+++ b/tests/Integration/OrderMetaTest.php
@@ -110,6 +110,28 @@ it('falls back to the vConnect meta for agent no and agent object', function () 
         ->and($agent->country)->toBe('DK');
 });
 
+it('handles a missing order in every meta accessor without fatals', function () {
+    // Regression for #60: wc_get_order() returns false for order IDs that do
+    // not exist (e.g. WooCommerce's email preview placeholder); every
+    // accessor must guard instead of calling methods on false.
+    $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+    $missing = 999999999;
+
+    expect($handler->get_ss_shipping_order_agent_no($missing))->toBeNull()
+        ->and($handler->get_ss_shipping_order_agent($missing))->toBeNull()
+        ->and($handler->get_ss_shipping_order_parcels($missing))->toBeFalse()
+        ->and($handler->get_label_url_from_order_id($missing, false))->toBe('')
+        ->and($handler->get_label_url_from_order_id($missing, true))->toBe('');
+
+    // The savers no-op instead of fataling.
+    $handler->save_ss_shipping_order_agent_no($missing, '1234');
+    $handler->save_ss_shipping_order_agent($missing, sample_agent());
+    $handler->save_ss_shipping_order_parcels($missing, []);
+    $handler->save_ss_shipment_id_in_order_meta($missing, 'shipment-1', false);
+
+    expect($handler->get_ss_shipping_order_agent_no($missing))->toBeNull();
+});
+
 it('detects the Smart Send shipping method on an order', function () {
     $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
     $product = create_simple_product(['price' => 100, 'weight' => 1]);


### PR DESCRIPTION
> [!NOTE]
> Stacked on #75 (`feature/issue-70-test-safety-net`); this PR targets that branch so the diff shows only its own changes.

## Root cause

`wc_get_order()` returns `false` when no order exists for the given ID. WooCommerce's email preview (WC >= 8.x admin feature) fires the order-details email hooks with a placeholder order, so `SS_Shipping_Frontend::display_ss_shipping_agent()` -> `SS_Shipping_WC_Order::get_ss_shipping_order_agent_no()` ended up calling `$order->get_meta()` on `false`, fataling with `Call to a member function get_meta() on bool` (class-ss-shipping-wc-order.php:901).

While fixing this, a second latent bug surfaced: the file had a bogus `use WooCommerce\Classes\WC_Order;` import, which made any unqualified `instanceof WC_Order` in the file silently resolve to a **nonexistent class** (always `false`, no error). No pre-existing code in the file referenced the alias, but the new guards would have silently no-opped every meta save with it in place. The import is removed.

## Call sites audited (all `wc_get_order()` calls in `smart-send-logistics/`)

**Guarded in this PR** (`includes/class-ss-shipping-wc-order.php`):

| Call site | Guard behaviour when order is missing |
|---|---|
| `process_orders_bulk_actions()` (bulk label loop) | pushes an "order could not be found" admin error and `continue`s |
| `render_smart_send_order_meta_box()` | early `return` (renders nothing) |
| `create_label_for_single_order()` | returns `array('error' => ...)`, matching the error shape callers already handle |
| `save_ss_shipping_order_parcels()` | early `return` |
| `get_ss_shipping_order_parcels()` | returns `false` (per docblock) |
| `save_ss_shipping_order_agent_no()` | early `return` |
| `get_ss_shipping_order_agent_no()` | returns `null` — **the reported fatal** |
| `save_ss_shipping_order_agent()` | early `return` |
| `get_ss_shipping_order_agent()` | returns `null` |
| `save_ss_shipment_id_in_order_meta()` | early `return` |
| `get_label_url_from_order_id()` | returns `''` |

**Already safe (no change needed):**
- `get_smart_send_method_id()` (~line 404) — existing `if (!$order) return '';` guard
- the vConnect re-fetch inside `get_smart_send_method_id()` (~line 449) — only reachable after the guard above verified the order exists
- `save_shipping_agent()` (~line 553) — only reachable when `get_smart_send_method_id()` returned non-empty, which requires the order to exist
- `delete_ss_shipping_order_agent()` — already has an explicit `if (! $order)` guard
- `SS_Shipping_Shipment::__construct()` — already checks `!$this->order` / `instanceof WC_Order`
- `includes/frontend/class-ss-shipping-frontend.php` — calls `wc_get_order()` only through the order-class accessors above; `display_ss_shipping_agent()` (email/thank-you display, the reported stack) is fixed by the `get_ss_shipping_order_agent_no()` guard
- Subscriptions integration (`woocommerce_subscriptions_renewal_order_meta_query`) — operates on a meta query string, no `wc_get_order()` involved

## Tests

None of the safety-net characterization tests pinned the old broken behaviour, so no expectations were changed. Added regression tests:

- `tests/Integration/FrontendAgentDisplayTest.php` — renders the agent display (directly and by firing `woocommerce_order_details_after_order_table` / `woocommerce_email_after_order_table` the way the email preview does) with an order that has no database row; asserts no fatal and empty output.
- `tests/Integration/OrderMetaTest.php` — calls every meta accessor with a nonexistent order ID; asserts the getters return their safe fallbacks and the savers no-op instead of fataling.

Full integration suite: 40 passed (216 assertions).

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)
