### PR TITLE
Defer early translation calls to fix _load_textdomain_just_in_time notice

### DIFF
--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -101,8 +101,8 @@ if (!class_exists('SS_Shipping_WC')) :
 
             $this->define_constants();
             $this->includes();
-            $this->init_hooks();
-        }
+			$this->init_hooks();
+		}
 
         public function declaring_hpos_compatibility()
         {
@@ -135,15 +135,15 @@ if (!class_exists('SS_Shipping_WC')) :
         {
             $upload_dir = wp_upload_dir();
 
-            // Path related defines
-            $this->define('SS_SHIPPING_PLUGIN_FILE', __FILE__);
-            $this->define('SS_SHIPPING_PLUGIN_BASENAME', plugin_basename(__FILE__));
-            $this->define('SS_SHIPPING_PLUGIN_DIR_PATH', untrailingslashit(plugin_dir_path(__FILE__)));
-            $this->define('SS_SHIPPING_PLUGIN_DIR_URL', untrailingslashit(plugins_url('/', __FILE__)));
-            $this->define('SS_SHIPPING_VERSION', $this->version);
-            $this->define('SS_SHIPPING_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/');
-            $this->define('SS_SHIPPING_METHOD_ID', 'smart_send_shipping');
-        }
+			// Path related defines
+			$this->define( 'SS_SHIPPING_PLUGIN_FILE', __FILE__ );
+			$this->define( 'SS_SHIPPING_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+			$this->define( 'SS_SHIPPING_PLUGIN_DIR_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
+			$this->define( 'SS_SHIPPING_PLUGIN_DIR_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
+			$this->define( 'SS_SHIPPING_VERSION', $this->version );
+			$this->define( 'SS_SHIPPING_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );
+			$this->define( 'SS_SHIPPING_METHOD_ID', 'smart_send_shipping' );
+		}
 
         /**
          * Include required core files used in admin and on the frontend.
@@ -176,14 +176,13 @@ if (!class_exists('SS_Shipping_WC')) :
 
         /**
          * Initialize the plugin.
-         */
-        public function init()
-        {
-            // Translated string constants must not be defined before the init
-            // action: since WordPress 6.7 any translation call for our text
-            // domain that runs earlier triggers a _load_textdomain_just_in_time
-            // "called incorrectly" notice.
-            $this->define('SS_BUTTON_TEST_CONNECTION', __('Validate API Token', 'smart-send-logistics'));
+		 */
+		public function init() {
+			// Translated string constants must not be defined before the init
+			// action: since WordPress 6.7 any translation call for our text
+			// domain that runs earlier triggers a _load_textdomain_just_in_time
+			// "called incorrectly" notice.
+			$this->define( 'SS_BUTTON_TEST_CONNECTION', __( 'Validate API Token', 'smart-send-logistics' ) );
 
             // Checks if WooCommerce 2.6 is installed.
             if (defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '2.6', '>=')) {
@@ -344,31 +343,40 @@ if (!class_exists('SS_Shipping_WC')) :
         }
 
         /**
-         * Get Agent Address Format
-         *
-         * Built lazily on first call (not in the constructor): the plugin
-         * bootstraps before the init action, and since WordPress 6.7 any
-         * translation call for our text domain that runs before init triggers
-         * a _load_textdomain_just_in_time "called incorrectly" notice.
-         */
-        public function get_agents_address_format()
-        {
-            if (empty($this->agents_address_format)) {
-                $this->agents_address_format = array(
-                    '1' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street', 'smart-send-logistics'),
-                    '2' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                            'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
-                    '3' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                            'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                    '4' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                            'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics') . ' ' . __('#City',
-                            'smart-send-logistics'),
-                    '5' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
-                    '6' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode',
-                            'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                    '7' => __('#Company', 'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                );
-            }
+		 * Get Agent Address Format
+		 *
+		 * Built lazily on first call (not in the constructor): the plugin
+		 * bootstraps before the init action, and since WordPress 6.7 any
+		 * translation call for our text domain that runs before init triggers
+		 * a _load_textdomain_just_in_time "called incorrectly" notice.
+		 */
+		public function get_agents_address_format() {
+			if ( empty( $this->agents_address_format ) ) {
+				$this->agents_address_format = array(
+					'1' => __( '#Company', 'smart-send-logistics' ) . ', ' . __( '#Street', 'smart-send-logistics' ),
+					'2' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
+						'#Street',
+						'smart-send-logistics'
+					) . ', ' . __( '#Zipcode', 'smart-send-logistics' ),
+					'3' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
+						'#Street',
+						'smart-send-logistics'
+					) . ', ' . __( '#City', 'smart-send-logistics' ),
+					'4' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
+						'#Street',
+						'smart-send-logistics'
+					) . ', ' . __( '#Zipcode', 'smart-send-logistics' ) . ' ' . __(
+						'#City',
+						'smart-send-logistics'
+					),
+					'5' => __( '#Company', 'smart-send-logistics' ) . ', ' . __( '#Zipcode', 'smart-send-logistics' ),
+					'6' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
+						'#Zipcode',
+						'smart-send-logistics'
+					) . ', ' . __( '#City', 'smart-send-logistics' ),
+					'7' => __( '#Company', 'smart-send-logistics' ) . ', ' . __( '#City', 'smart-send-logistics' ),
+				);
+			}
 
             return $this->agents_address_format;
         }

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -102,21 +102,6 @@ if (!class_exists('SS_Shipping_WC')) :
             $this->define_constants();
             $this->includes();
             $this->init_hooks();
-
-            $this->agents_address_format = array(
-                '1' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street', 'smart-send-logistics'),
-                '2' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                        'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
-                '3' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                        'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                '4' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                        'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics') . ' ' . __('#City',
-                        'smart-send-logistics'),
-                '5' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
-                '6' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode',
-                        'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                '7' => __('#Company', 'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-            );
         }
 
         public function declaring_hpos_compatibility()
@@ -158,7 +143,6 @@ if (!class_exists('SS_Shipping_WC')) :
             $this->define('SS_SHIPPING_VERSION', $this->version);
             $this->define('SS_SHIPPING_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/');
             $this->define('SS_SHIPPING_METHOD_ID', 'smart_send_shipping');
-            $this->define('SS_BUTTON_TEST_CONNECTION', __('Validate API Token', 'smart-send-logistics'));
         }
 
         /**
@@ -195,6 +179,11 @@ if (!class_exists('SS_Shipping_WC')) :
          */
         public function init()
         {
+            // Translated string constants must not be defined before the init
+            // action: since WordPress 6.7 any translation call for our text
+            // domain that runs earlier triggers a _load_textdomain_just_in_time
+            // "called incorrectly" notice.
+            $this->define('SS_BUTTON_TEST_CONNECTION', __('Validate API Token', 'smart-send-logistics'));
 
             // Checks if WooCommerce 2.6 is installed.
             if (defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '2.6', '>=')) {
@@ -356,9 +345,31 @@ if (!class_exists('SS_Shipping_WC')) :
 
         /**
          * Get Agent Address Format
+         *
+         * Built lazily on first call (not in the constructor): the plugin
+         * bootstraps before the init action, and since WordPress 6.7 any
+         * translation call for our text domain that runs before init triggers
+         * a _load_textdomain_just_in_time "called incorrectly" notice.
          */
         public function get_agents_address_format()
         {
+            if (empty($this->agents_address_format)) {
+                $this->agents_address_format = array(
+                    '1' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street', 'smart-send-logistics'),
+                    '2' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
+                            'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
+                    '3' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
+                            'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
+                    '4' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
+                            'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics') . ' ' . __('#City',
+                            'smart-send-logistics'),
+                    '5' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
+                    '6' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode',
+                            'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
+                    '7' => __('#Company', 'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
+                );
+            }
+
             return $this->agents_address_format;
         }
 

--- a/tests/Integration/EarlyTextdomainTest.php
+++ b/tests/Integration/EarlyTextdomainTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Regression test for issue #58: since WordPress 6.7, any translation call
+ * (__(), esc_html__(), ...) for the smart-send-logistics domain that runs
+ * before the init action triggers a _doing_it_wrong notice for
+ * _load_textdomain_just_in_time. The plugin bootstrap (the SS_Shipping_WC
+ * constructor, executed when the plugin file is loaded — long before init)
+ * must therefore not evaluate any translated string.
+ *
+ * The test bootstrap loads WordPress (and with it the plugin) before any test
+ * code runs, so the original bootstrap-time notice cannot be observed
+ * directly. Instead the pre-init environment is recreated: translations for
+ * the domain are made discoverable (as on a non-English production site —
+ * without a discoverable translation path WordPress never emits the notice,
+ * which is why an en_US dev install hides the bug), the init /
+ * after_setup_theme action counters are temporarily reset, and the plugin
+ * bootstrap is re-run exactly as WordPress runs it when loading the plugin
+ * file.
+ */
+
+it('does not trigger a too-early textdomain notice during plugin bootstrap', function () {
+    global $wp_textdomain_registry;
+
+    // Simulate a Danish site with translations available for our domain.
+    $locale_filter = function () {
+        return 'da_DK';
+    };
+    add_filter('locale', $locale_filter);
+    $wp_textdomain_registry->set('smart-send-logistics', 'da_DK', sys_get_temp_dir());
+
+    // Make the domain lazily-loadable again (reloadable, so the just-in-time
+    // loader is not short-circuited by the unload).
+    unload_textdomain('smart-send-logistics', true);
+
+    // Pretend the request has not reached init yet, as is the case while
+    // WordPress loads plugin files. (WP 6.7 keys the too-early check on the
+    // init action; newer versions on after_setup_theme — reset both.)
+    $saved_actions = [];
+    foreach (['init', 'after_setup_theme'] as $action) {
+        $saved_actions[$action] = $GLOBALS['wp_actions'][$action] ?? null;
+        unset($GLOBALS['wp_actions'][$action]);
+    }
+
+    $notices = [];
+    $capture = function ($function_name, $message) use (&$notices) {
+        if ($function_name === '_load_textdomain_just_in_time'
+            && strpos((string) $message, 'smart-send-logistics') !== false
+        ) {
+            $notices[] = $message;
+        }
+    };
+    add_action('doing_it_wrong_run', $capture, 10, 2);
+    add_filter('doing_it_wrong_trigger_error', '__return_false');
+
+    try {
+        // Re-run the plugin bootstrap. Before the fix this evaluated
+        // translated strings in the constructor / define_constants() and
+        // fired the notice; after the fix it must not translate anything.
+        new SS_Shipping_WC();
+    } finally {
+        remove_action('doing_it_wrong_run', $capture);
+        remove_filter('doing_it_wrong_trigger_error', '__return_false');
+
+        foreach ($saved_actions as $action => $count) {
+            if ($count !== null) {
+                $GLOBALS['wp_actions'][$action] = $count;
+            }
+        }
+
+        // Undo the simulated Danish locale so later tests run untouched.
+        $wp_textdomain_registry->set('smart-send-logistics', 'da_DK', false);
+        remove_filter('locale', $locale_filter);
+    }
+
+    expect($notices)->toBe([]);
+});


### PR DESCRIPTION
## Root cause

Since WordPress 6.7, any translation call for the `smart-send-logistics` domain that runs before the `init` action triggers a `_doing_it_wrong` notice for `_load_textdomain_just_in_time`. `load_plugin_textdomain()` is already correctly hooked on `init` — the trigger is translated strings evaluated during plugin bootstrap.

Audit of all early code paths (main plugin file, `SS_Shipping_WC` constructor and hook registrations, classes constructed on `plugins_loaded` / `woocommerce_shipping_init`, frontend/order/product/screen-updates constructors) found exactly two pre-init translation sites, both in `smart-send-logistics.php` and both executed on **every** request while WordPress loads plugin files:

| Early translation site | Fix |
| --- | --- |
| `agents_address_format` array built with 15 `__()` calls in the `SS_Shipping_WC` constructor | Built lazily on the first `get_agents_address_format()` call (its only consumer is `SS_Shipping_WC_Method::init_form_fields()`, which runs post-init) |
| `SS_BUTTON_TEST_CONNECTION` constant defined via `__()` in `define_constants()` | Defined in the existing `init` callback (priority 0), still ahead of both consumers (settings form fields, `wp_ajax_ss_test_connection` callback) |

Everything else is safe: the frontend/order/product/screen-updates classes are instantiated inside the `init` callback, `SS_Shipping_WC_Method` is instantiated by WooCommerce after init, and the PSR-style `Smartsend` API layer contains no translation calls. No string text changed.

## Repro test

`tests/Integration/EarlyTextdomainTest.php`. The test bootstrap loads WordPress (and the plugin) before test code runs, so the original bootstrap-time notice can't be observed directly. The test instead recreates the pre-init environment and re-runs the exact bootstrap code path:

1. simulates a Danish site with a discoverable translation path for our domain via the `locale` filter + `WP_Textdomain_Registry::set()` (on an en_US install the registry returns no path, so WordPress never emits the notice — which is why the dev store hides the bug), and `unload_textdomain($domain, true)` so the domain is lazily-loadable again;
2. temporarily resets the `init` / `after_setup_theme` action counters (WP 6.7 keys the too-early check on `init`, current WP on `after_setup_theme`);
3. runs `new SS_Shipping_WC()` — exactly what WordPress executes when loading the plugin file — while capturing `doing_it_wrong_run`;
4. asserts no `_load_textdomain_just_in_time` notice mentioning our domain fired, then restores all global state.

Before the fix the test fails with the verbatim customer-reported notice; after the fix it passes.

## Testing

- Full `composer test:integration`: 41 passed (217 assertions), including the PR #75 safety net.
- Manual post-init sanity check: `SS_BUTTON_TEST_CONNECTION` is defined, the `api_token_validate` form field title still renders "Validate API Token", and `get_agents_address_format()` still returns all 7 formats.

## Stack

Stacked on #76 (← #75); base is `bugfix/issue-60-wc-get-order-guard`, not `develop`. Merge those first.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)