### PR TITLE
PHP 7.4–8.4 compatibility sweep

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run phpcs
         run: vendor/bin/phpcs
+
+      - name: Run PHP compatibility scan (PHP 7.4+)
+        run: vendor/bin/phpcs --standard=phpcs.compat.xml.dist

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,16 +7,21 @@ on:
 
 jobs:
   pest:
-    name: Pest integration tests (WP ${{ matrix.wp-version }} / WC ${{ matrix.wc-version }})
+    name: Pest integration tests (PHP ${{ matrix.php-version }} / WP ${{ matrix.wp-version }} / WC ${{ matrix.wc-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         # Unlike the browser tests, WordPress + WooCommerce run inside the
-        # Pest process here, so the PHP version is fixed by Pest's own
-        # requirement (8.2+). PHP-version coverage of the plugin comes from
-        # the browser test matrix.
+        # Pest process here, so the matrix floor is Pest's own requirement
+        # (PHP 8.3+). Plugin-code coverage of older PHP (7.4-8.2) comes from
+        # the browser test matrix and the PHPCompatibility scan in the
+        # coding-standards workflow. The test bootstrap turns any PHP
+        # warning/notice/deprecation raised from smart-send-logistics/ into
+        # a test failure, so each matrix leg also proves the plugin runs
+        # warning-free on that PHP version.
+        php-version: ['8.3', '8.4']
         wp-version: ['latest']
         wc-version: ['latest']
 
@@ -26,7 +31,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '${{ matrix.php-version }}'
           coverage: none
           tools: composer
 
@@ -34,8 +39,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-php${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-php${{ matrix.php-version }}-
 
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-progress

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
     "phpcompatibility/phpcompatibility-wp": "^2.1"
   },
   "config": {
+    "platform": {
+      "php": "8.3.0"
+    },
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "digitalrevolution/php-codesniffer-baseline": true,

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "digitalrevolution/php-codesniffer-baseline": "^1.0",
     "pestphp/pest": "^4.0",
-    "pestphp/pest-plugin-browser": "^4.0"
+    "pestphp/pest-plugin-browser": "^4.0",
+    "phpcompatibility/phpcompatibility-wp": "^2.1"
   },
   "config": {
     "allow-plugins": {
@@ -26,6 +27,7 @@
   },
   "scripts": {
     "phpcs": "phpcs",
+    "phpcs:compat": "phpcs --standard=phpcs.compat.xml.dist",
     "phpcs:fix": "phpcbf",
     "test": "pest",
     "test:integration": "pest --testsuite=Integration",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0805613f2ec908f669fff5024049096e",
+    "content-hash": "c246f512c1f089350f791fb8a235bdc3",
     "packages": [],
     "packages-dev": [
         {
@@ -2231,20 +2231,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -2279,15 +2279,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -5542,49 +5542,47 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.1.4",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24"
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
-                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4c69c9aed03abf933b294257d618bdd9b30a06d",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "^1.0",
-                "symfony/polyfill-php85": "^1.32",
+                "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.4.6|^8.0.6"
+                "symfony/string": "^7.2|^8.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<8.1",
-                "symfony/event-dispatcher": "<8.1"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/dependency-injection": "^8.1",
-                "symfony/event-dispatcher": "^8.1",
-                "symfony/filesystem": "^7.4|^8.0",
-                "symfony/http-foundation": "^7.4|^8.0",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/lock": "^7.4|^8.0",
-                "symfony/messenger": "^7.4|^8.0",
-                "symfony/mime": "^7.4|^8.0",
-                "symfony/process": "^7.4|^8.0",
-                "symfony/stopwatch": "^7.4|^8.0",
-                "symfony/uid": "^7.4|^8.0",
-                "symfony/validator": "^7.4|^8.0",
-                "symfony/var-dumper": "^7.4|^8.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5618,7 +5616,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.1.4"
+                "source": "https://github.com/symfony/console/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -5638,7 +5636,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-31T12:43:13+00:00"
+            "time": "2026-07-31T12:37:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5713,23 +5711,23 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v8.1.1",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531"
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
-                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/13b38720174286f55d1761152b575a8d1436fc25",
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "symfony/filesystem": "^7.4|^8.0"
+                "symfony/filesystem": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5757,7 +5755,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v8.1.1"
+                "source": "https://github.com/symfony/finder/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5777,7 +5775,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-27T09:05:56+00:00"
+            "time": "2026-06-27T08:31:18+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -6115,101 +6113,21 @@
             "time": "2026-05-27T06:59:30+00:00"
         },
         {
-            "name": "symfony/polyfill-php85",
-            "version": "v1.41.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/255fab485aaa1006ed411040c42aecd7b5302d7a",
-                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php85\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.5+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.41.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-07-01T12:47:55+00:00"
-        },
-        {
             "name": "symfony/process",
-            "version": "v8.1.0",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
-                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "autoload": {
@@ -6237,7 +6155,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.1.0"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6257,7 +6175,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6348,34 +6266,35 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.1.2",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc"
+                "reference": "e394af32256bf9e7bf80849d95e589167c10097b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
-                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e394af32256bf9e7bf80849d95e589167c10097b",
+                "reference": "e394af32256bf9e7bf80849d95e589167c10097b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-intl-grapheme": "^1.33",
-                "symfony/polyfill-intl-normalizer": "^1.0",
-                "symfony/polyfill-mbstring": "^1.0"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.4|^8.0",
-                "symfony/http-client": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^7.4|^8.0"
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6414,7 +6333,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.1.2"
+                "source": "https://github.com/symfony/string/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -6434,7 +6353,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-28T07:35:25+00:00"
+            "time": "2026-07-28T07:33:02+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
@@ -6685,5 +6604,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3.0"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95ed35418530ab2e4c64aec2a83a9ae4",
+    "content-hash": "0805613f2ec908f669fff5024049096e",
     "packages": [],
     "packages-dev": [
         {
@@ -3119,6 +3119,219 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-19T17:43:28+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-10-18T00:05:59+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",

--- a/phpcs.compat.xml.dist
+++ b/phpcs.compat.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="Smart Send PHP Compatibility">
+    <description>PHP 7.4+ compatibility scan for the shipped plugin code.</description>
+
+    <!-- The whole shipped plugin, including the bundled API client. -->
+    <file>smart-send-logistics</file>
+
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/local-dev/*</exclude-pattern>
+    <exclude-pattern>*.js</exclude-pattern>
+    <exclude-pattern>*.css</exclude-pattern>
+
+    <arg name="basepath" value="."/>
+    <arg value="ps"/>
+    <arg name="colors"/>
+    <arg name="parallel" value="20"/>
+    <arg name="extensions" value="php"/>
+
+    <!-- Plugin floor is PHP 7.4; open-ended so new PHP deprecations/removals
+         (8.0 through current) are flagged as they are added to the standard. -->
+    <config name="testVersion" value="7.4-"/>
+
+    <rule ref="PHPCompatibilityWP"/>
+</ruleset>

--- a/smart-send-logistics/includes/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-method.php
@@ -11,6 +11,8 @@ if (!class_exists('SS_Shipping_WC_Method')) :
 
         private $shipping_method = array();
 
+		private $return_shipping_method = array();
+
         /**
          * Init and hook in the integration.
          */

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Parcel.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Parcel.php
@@ -2,7 +2,7 @@
 
 namespace Smartsend\Models\Shipment;
 
-use Smartsend\Model\Shipment\Item;
+use Smartsend\Models\Shipment\Item;
 
 require_once 'Item.php';
 

--- a/smart-send-logistics/readme.txt
+++ b/smart-send-logistics/readme.txt
@@ -14,7 +14,7 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Requires Plugins: woocommerce
 WC requires at least: 3.0.0
 WC tested up to: 10.3
-Requires PHP: 5.6.0
+Requires PHP: 7.4
 
 Complete WooCommerce shipping solution for PostNord, GLS, DAO, Burd, Budbee and Bring.
 

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -7,6 +7,7 @@
  * Author URI: https://www.smartsend.io
  * Text Domain: smart-send-logistics
  * Version: 8.1.3
+ * Requires PHP: 7.4
  * Requires Plugins: woocommerce
  * WC requires at least: 4.7.0
  * WC tested up to: 10.3
@@ -541,9 +542,9 @@ if (!class_exists('SS_Shipping_WC')) :
 		        $api_token = empty($ss_shipping_settings['api_token']) ? null : $ss_shipping_settings['api_token'];
 	        }
 
-	        if (strpos($api_token, ',') && strpos($api_token, ':')) {
-		        //The API Token field contains multiple tokens in the format:
-		        //site1:apitoken1,site2:apitoken2,....
+			if ( is_string( $api_token ) && strpos( $api_token, ',' ) && strpos( $api_token, ':' ) ) {
+				//The API Token field contains multiple tokens in the format:
+				//site1:apitoken1,site2:apitoken2,....
 		        $tokens = array();
 		        $site_and_tokens = explode(',', $api_token);
 		        foreach ($site_and_tokens as $site_and_token) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -67,6 +67,38 @@ define('WP_USE_THEMES', false);
 
 require_once $wpLoad;
 
+/*
+|--------------------------------------------------------------------------
+| Warnings-to-failures (plugin code only)
+|--------------------------------------------------------------------------
+|
+| Any PHP warning, notice, or deprecation raised from a file inside
+| smart-send-logistics/ is converted into an ErrorException so the test
+| that triggered it fails. Noise from WordPress core, WooCommerce, or
+| other plugins is left to PHPUnit's regular reporting. Registered after
+| wp-load.php on purpose: loading WordPress itself is not ours to police.
+|
+*/
+
+const SS_STRICT_ERRNO = E_WARNING | E_NOTICE | E_DEPRECATED | E_USER_WARNING | E_USER_NOTICE | E_USER_DEPRECATED;
+
+function ss_strict_error_handler(int $errno, string $errstr, string $errfile = '', int $errline = 0): bool
+{
+    if (! (error_reporting() & $errno)) {
+        return false; // @-suppressed
+    }
+
+    $pluginDir = DIRECTORY_SEPARATOR . 'smart-send-logistics' . DIRECTORY_SEPARATOR;
+
+    if (($errno & SS_STRICT_ERRNO) && str_contains($errfile, $pluginDir)) {
+        throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+    }
+
+    return false; // defer to the default / PHPUnit handler
+}
+
+set_error_handler('ss_strict_error_handler');
+
 // Keep database driver noise out of the test output. With the SQLite dev
 // store, WooCommerce's coupon-hold "SELECT ... FOR UPDATE" queries fail (the
 // driver does not support row locks) and would otherwise print a full error


### PR DESCRIPTION
Implements #71. **Top of the stack**: targets `bugfix/issue-58-early-textdomain` (#77), which sits on `bugfix/issue-60-wc-get-order-guard` (#76), which sits on `feature/issue-70-test-safety-net` (#75).

## Floor bump

Per the decision on #71, the minimum PHP for v9 is **7.4**:

- `smart-send-logistics/readme.txt`: `Requires PHP: 5.6.0` → `7.4`
- `smart-send-logistics/smart-send-logistics.php`: new `Requires PHP: 7.4` plugin header (there was none)

## Warnings-to-failures

`tests/bootstrap.php` now registers an error handler (after `wp-load.php`) that converts any PHP warning, notice, or deprecation raised **from a file under `smart-send-logistics/`** into an `ErrorException`, failing the test that triggered it. `@`-suppressed errors and noise from WordPress core / WooCommerce / other plugins are deferred to the default handling. Every CI matrix leg therefore also proves the plugin runs warning-free on that PHP version.

## Warnings fixed (surfaced by the strict suite on PHP 8.5)

| Category | Count | Fix |
|---|---|---|
| Dynamic property creation (`SS_Shipping_WC_Method::$return_shipping_method`) | 12 test hits | explicit `private $return_shipping_method = array();` declaration |
| `strpos(): Passing null to parameter #1` in `get_api_token_setting()` when no API token is configured | 18 test hits | `is_string()` guard; same return value in every case (still returns `null` when unset) |

## Bogus import found

`Smartsend\Models\Shipment\Parcel` had `use Smartsend\Model\Shipment\Item;` (`Model` vs `Models`) — the same silent-breakage pattern as the `use WooCommerce\Classes\WC_Order;` removed in #76. It made the `addItem(Item $item)` type hint reference a nonexistent class, so passing a real `Item` would have thrown a `TypeError`. Corrected to `Smartsend\Models\Shipment\Item`. All other `use` statements in the plugin were audited and resolve to real classes.

## Static pass / CI

- New dev dependency `phpcompatibility/phpcompatibility-wp` and ruleset `phpcs.compat.xml.dist` (`testVersion 7.4-`, scans all of `smart-send-logistics/` **including** the bundled `lib/`, which the WPCS ruleset excludes). Scan is clean. Runnable via `composer phpcs:compat`.
- `coding-standards.yml`: added the compatibility scan as a step.
- `integration-tests.yml`: PHP matrix `8.3` / `8.4` (Pest 4 requires PHP ≥ 8.3, so the in-process suite cannot go lower); per-PHP composer cache keys. Coverage of the 7.4–8.2 range for *plugin* code stays with the existing browser-test matrix (already 7.4–8.4, matching the new floor — unchanged) and the PHPCompatibility scan.

## Behaviour preservation

- No behaviour changes; the #75 characterization suite is green throughout (55 passed, 217 assertions, zero deprecations).
- The `strpos()` fix preserves the current contract exactly: with no token configured the method still returns `null`.
- The `Parcel::addItem()` import fix technically *changes* behaviour (from guaranteed `TypeError` to working), but the method is currently unreachable with a valid argument — the plugin itself only uses `setItems()` — so nothing observable changes.
- phpcs (WPCS + baseline) reports the same violation count as the base branch — this PR adds zero new violations (pre-existing red on the stack is owned by the PRs below).

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)