### PR TITLE
Stabilize browser CI: fpm restart on retry, drop segfaulting PHP 8.1/8.2

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -147,9 +147,13 @@ jobs:
           WP_BASE_URL: http://127.0.0.1:8181
         # The tests are self-contained, so retry the suite once to absorb
         # rare fpm worker crashes; persistent failures still fail both runs.
+        # Restart php-fpm before the retry: a crashed worker can leave the
+        # pool wedged, making the retry hang until the step timeout (#79).
         run: |
           vendor/bin/pest --testsuite=Browser || {
-            echo "::warning::Browser test run failed - retrying once"
+            echo "::warning::Browser test run failed - restarting php-fpm and retrying once"
+            sudo service "php${{ matrix.php-version }}-fpm" restart
+            sleep 2
             vendor/bin/pest --testsuite=Browser
           }
 

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -20,7 +20,12 @@ jobs:
         # PHP 7.4 is the floor for the latest WooCommerce; testing the plugin's
         # older declared support (PHP 5.6+) would require pinning older
         # WP/WC versions via extra include entries.
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        # PHP 8.1 and 8.2 are temporarily removed: since 2026-08-11 ~20:00 UTC
+        # the runner environment deterministically segfaults php-fpm workers
+        # on those versions while rendering stock wp-admin pages (SIGSEGV in
+        # pool www, "recv() failed (104)" in nginx), on code that was green
+        # the same morning. Re-add once the environment recovers — see #79.
+        php-version: ['7.4', '8.0', '8.3', '8.4']
         wp-version: ['latest']
         wc-version: ['latest']
 


### PR DESCRIPTION
## What

Two changes to the browser-test workflow, both tracked in #79:

1. **Restart php-fpm before the retry attempt.** The existing retry-once wrapper reran the suite against a wedged fpm pool after a worker crash, so the retry hung until the 10-minute step timeout instead of recovering.
2. **Temporarily drop PHP 8.1 and 8.2 from the matrix.** Since 2026-08-11 ~20:00 UTC the hosted-runner environment deterministically segfaults php-fpm workers on those two versions while rendering stock wp-admin pages (`SIGSEGV` in pool www, `recv() failed (104)` in nginx) — reproduced on this branch (pre-existing plugin code, mitigation 1 active) and on PR #78, while the same code was green on 8.1/8.2 earlier the same day. No WP/WC release occurred in the window; the changed variable is the runner environment (image/PPA build), which cannot be pinned. Re-add the versions once #79 confirms the environment recovered.

## Evidence

- Green: #75/#76/#77 browser jobs on 8.1/8.2 between ~18:30–19:40 UTC
- Red (identical signature, 6 consecutive jobs): #76 rerun 8.2 (19:49), #78 attempt 1+2 on 8.1+8.2 (19:57, 20:05), this branch 8.1+8.2 (20:11) — fpm log: `child exited on signal 11 (SIGSEGV) after ~8s from start` on `GET /wp-admin/plugins.php`, `wp-login.php`, `wc-admin`

Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)