### PR TITLE
Complete Phase 1 stack merge into develop

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run phpcs
         run: vendor/bin/phpcs
+
+      - name: Run PHP compatibility scan (PHP 7.4+)
+        run: vendor/bin/phpcs --standard=phpcs.compat.xml.dist

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,16 +7,21 @@ on:
 
 jobs:
   pest:
-    name: Pest integration tests (WP ${{ matrix.wp-version }} / WC ${{ matrix.wc-version }})
+    name: Pest integration tests (PHP ${{ matrix.php-version }} / WP ${{ matrix.wp-version }} / WC ${{ matrix.wc-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         # Unlike the browser tests, WordPress + WooCommerce run inside the
-        # Pest process here, so the PHP version is fixed by Pest's own
-        # requirement (8.2+). PHP-version coverage of the plugin comes from
-        # the browser test matrix.
+        # Pest process here, so the matrix floor is Pest's own requirement
+        # (PHP 8.3+). Plugin-code coverage of older PHP (7.4-8.2) comes from
+        # the browser test matrix and the PHPCompatibility scan in the
+        # coding-standards workflow. The test bootstrap turns any PHP
+        # warning/notice/deprecation raised from smart-send-logistics/ into
+        # a test failure, so each matrix leg also proves the plugin runs
+        # warning-free on that PHP version.
+        php-version: ['8.3', '8.4']
         wp-version: ['latest']
         wc-version: ['latest']
 
@@ -26,7 +31,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '${{ matrix.php-version }}'
           coverage: none
           tools: composer
 
@@ -34,8 +39,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-php${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-php${{ matrix.php-version }}-
 
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-progress

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
     "phpcompatibility/phpcompatibility-wp": "^2.1"
   },
   "config": {
+    "platform": {
+      "php": "8.3.0"
+    },
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "digitalrevolution/php-codesniffer-baseline": true,

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "digitalrevolution/php-codesniffer-baseline": "^1.0",
     "pestphp/pest": "^4.0",
-    "pestphp/pest-plugin-browser": "^4.0"
+    "pestphp/pest-plugin-browser": "^4.0",
+    "phpcompatibility/phpcompatibility-wp": "^2.1"
   },
   "config": {
     "allow-plugins": {
@@ -26,6 +27,7 @@
   },
   "scripts": {
     "phpcs": "phpcs",
+    "phpcs:compat": "phpcs --standard=phpcs.compat.xml.dist",
     "phpcs:fix": "phpcbf",
     "test": "pest",
     "test:integration": "pest --testsuite=Integration",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0805613f2ec908f669fff5024049096e",
+    "content-hash": "c246f512c1f089350f791fb8a235bdc3",
     "packages": [],
     "packages-dev": [
         {
@@ -2231,20 +2231,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -2279,15 +2279,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -5542,49 +5542,47 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.1.4",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24"
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
-                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f4c69c9aed03abf933b294257d618bdd9b30a06d",
+                "reference": "f4c69c9aed03abf933b294257d618bdd9b30a06d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "^1.0",
-                "symfony/polyfill-php85": "^1.32",
+                "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.4.6|^8.0.6"
+                "symfony/string": "^7.2|^8.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<8.1",
-                "symfony/event-dispatcher": "<8.1"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/dependency-injection": "^8.1",
-                "symfony/event-dispatcher": "^8.1",
-                "symfony/filesystem": "^7.4|^8.0",
-                "symfony/http-foundation": "^7.4|^8.0",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/lock": "^7.4|^8.0",
-                "symfony/messenger": "^7.4|^8.0",
-                "symfony/mime": "^7.4|^8.0",
-                "symfony/process": "^7.4|^8.0",
-                "symfony/stopwatch": "^7.4|^8.0",
-                "symfony/uid": "^7.4|^8.0",
-                "symfony/validator": "^7.4|^8.0",
-                "symfony/var-dumper": "^7.4|^8.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5618,7 +5616,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.1.4"
+                "source": "https://github.com/symfony/console/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -5638,7 +5636,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-31T12:43:13+00:00"
+            "time": "2026-07-31T12:37:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5713,23 +5711,23 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v8.1.1",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531"
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
-                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/13b38720174286f55d1761152b575a8d1436fc25",
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "symfony/filesystem": "^7.4|^8.0"
+                "symfony/filesystem": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5757,7 +5755,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v8.1.1"
+                "source": "https://github.com/symfony/finder/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5777,7 +5775,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-27T09:05:56+00:00"
+            "time": "2026-06-27T08:31:18+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -6115,101 +6113,21 @@
             "time": "2026-05-27T06:59:30+00:00"
         },
         {
-            "name": "symfony/polyfill-php85",
-            "version": "v1.41.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/255fab485aaa1006ed411040c42aecd7b5302d7a",
-                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php85\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.5+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.41.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-07-01T12:47:55+00:00"
-        },
-        {
             "name": "symfony/process",
-            "version": "v8.1.0",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
-                "reference": "c4a9e58f235a6bf7f97ffbfedae2687353ac79e5",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "autoload": {
@@ -6237,7 +6155,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.1.0"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6257,7 +6175,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6348,34 +6266,35 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.1.2",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc"
+                "reference": "e394af32256bf9e7bf80849d95e589167c10097b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
-                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e394af32256bf9e7bf80849d95e589167c10097b",
+                "reference": "e394af32256bf9e7bf80849d95e589167c10097b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-intl-grapheme": "^1.33",
-                "symfony/polyfill-intl-normalizer": "^1.0",
-                "symfony/polyfill-mbstring": "^1.0"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.4|^8.0",
-                "symfony/http-client": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^7.4|^8.0"
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6414,7 +6333,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.1.2"
+                "source": "https://github.com/symfony/string/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -6434,7 +6353,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-28T07:35:25+00:00"
+            "time": "2026-07-28T07:33:02+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
@@ -6685,5 +6604,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3.0"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95ed35418530ab2e4c64aec2a83a9ae4",
+    "content-hash": "0805613f2ec908f669fff5024049096e",
     "packages": [],
     "packages-dev": [
         {
@@ -3119,6 +3119,219 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-19T17:43:28+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-10-18T00:05:59+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",

--- a/phpcs.compat.xml.dist
+++ b/phpcs.compat.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="Smart Send PHP Compatibility">
+    <description>PHP 7.4+ compatibility scan for the shipped plugin code.</description>
+
+    <!-- The whole shipped plugin, including the bundled API client. -->
+    <file>smart-send-logistics</file>
+
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/local-dev/*</exclude-pattern>
+    <exclude-pattern>*.js</exclude-pattern>
+    <exclude-pattern>*.css</exclude-pattern>
+
+    <arg name="basepath" value="."/>
+    <arg value="ps"/>
+    <arg name="colors"/>
+    <arg name="parallel" value="20"/>
+    <arg name="extensions" value="php"/>
+
+    <!-- Plugin floor is PHP 7.4; open-ended so new PHP deprecations/removals
+         (8.0 through current) are flagged as they are added to the standard. -->
+    <config name="testVersion" value="7.4-"/>
+
+    <rule ref="PHPCompatibilityWP"/>
+</ruleset>

--- a/smart-send-logistics/includes/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-method.php
@@ -11,6 +11,8 @@ if (!class_exists('SS_Shipping_WC_Method')) :
 
         private $shipping_method = array();
 
+		private $return_shipping_method = array();
+
         /**
          * Init and hook in the integration.
          */

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -146,15 +146,23 @@ if (!class_exists('SS_Shipping_WC_Order')) :
                     foreach ($items as $order_id) {
                         $order = wc_get_order($order_id);
 
-                        if (! $order instanceof WC_Order) {
-                            array_push($array_messages_error, array(
-                                'message' => sprintf(__('Order #%s', 'smart-send-logistics'),
-                                        $order_id) . ': ' . __('The order could not be found',
-                                        'smart-send-logistics'),
-                                'type'    => 'error',
-                            ));
-                            continue;
-                        }
+						if ( ! $order instanceof WC_Order ) {
+							array_push(
+								$array_messages_error,
+								array(
+									'message' => sprintf(
+										/* translators: %s: WooCommerce order id */
+										__( 'Order #%s', 'smart-send-logistics' ),
+										$order_id
+									) . ': ' . __(
+										'The order could not be found',
+										'smart-send-logistics'
+									),
+									'type'    => 'error',
+								)
+							);
+							continue;
+						}
 
                         $ss_shipping_method_id = $this->get_smart_send_method_id($order_id);
 
@@ -250,8 +258,8 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 
             // ... rest of the code. $post_or_order_object should not be used directly below this point´
 
-            if (! $order instanceof WC_Order) {
-                return;
+			if ( ! $order instanceof WC_Order ) {
+				return;
             }
 
             $order_id = $order->get_id();
@@ -673,15 +681,20 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          */
         protected function create_label_for_single_order($order_id, $return = false, $setting_save_order_note = true)
         {
-            // Load WC Order
-            $order = wc_get_order($order_id);
+			// Load WC Order
+			$order = wc_get_order( $order_id );
 
-            if (! $order instanceof WC_Order) {
-                return array('error' => sprintf(__('Order #%s', 'smart-send-logistics'), $order_id)
-                    . ': ' . __('The order could not be found', 'smart-send-logistics'));
-            }
+			if ( ! $order instanceof WC_Order ) {
+				return array(
+					'error' => sprintf(
+						/* translators: %s: WooCommerce order id */
+						__( 'Order #%s', 'smart-send-logistics' ),
+						$order_id
+					) . ': ' . __( 'The order could not be found', 'smart-send-logistics' ),
+				);
+			}
 
-            $ss_order_api = new SS_Shipping_Shipment($order, $this);
+			$ss_order_api = new SS_Shipping_Shipment( $order, $this );
 
             if ($ss_order_api->make_single_shipment_api_call( $return )) {
 
@@ -867,15 +880,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          * @param array $parcels
          *
          * @return void
-         */
-        public function save_ss_shipping_order_parcels($order_id, $parcels)
-        {
-            $order = wc_get_order($order_id);
-            if (! $order instanceof WC_Order) {
-                return;
-            }
-            $order->update_meta_data('ss_shipping_order_parcels', $parcels);
-            $order->save();
+		 */
+		public function save_ss_shipping_order_parcels( $order_id, $parcels ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return;
+			}
+			$order->update_meta_data( 'ss_shipping_order_parcels', $parcels );
+			$order->save();
         }
 
         /**
@@ -888,11 +900,11 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          */
         public function get_ss_shipping_order_parcels($order_id)
         {
-            $order = wc_get_order( $order_id );
-            if (! $order instanceof WC_Order) {
-                return false;
-            }
-            return $order->get_meta( 'ss_shipping_order_parcels', true );
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return false;
+			}
+			return $order->get_meta( 'ss_shipping_order_parcels', true );
         }
 
 
@@ -903,15 +915,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          * @param array $agent_no Agent No.
          *
          * @return void
-         */
-        public function save_ss_shipping_order_agent_no($order_id, $agent_no)
-        {
-            $order = wc_get_order($order_id);
-            if (! $order instanceof WC_Order) {
-                return;
-            }
-            $order->update_meta_data('ss_shipping_order_agent_no', $agent_no);
-            $order->save();
+		 */
+		public function save_ss_shipping_order_agent_no( $order_id, $agent_no ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return;
+			}
+			$order->update_meta_data( 'ss_shipping_order_agent_no', $agent_no );
+			$order->save();
         }
 
         /*
@@ -924,16 +935,16 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function get_ss_shipping_order_agent_no($order_id)
         {
             // Fetch agent_no from meta field saved by Smart Send
-            $order = wc_get_order( $order_id );
+			$order = wc_get_order( $order_id );
 
-            // wc_get_order() returns false when the order does not exist, e.g. when
-            // WooCommerce's email preview fires the order-details hooks with a
-            // placeholder order ID. See issue #60.
-            if (! $order instanceof WC_Order) {
-                return null;
-            }
+			// wc_get_order() returns false when the order does not exist, e.g. when
+			// WooCommerce's email preview fires the order-details hooks with a
+			// placeholder order ID. See issue #60.
+			if ( ! $order instanceof WC_Order ) {
+				return null;
+			}
 
-            $ss_agent_number = $order->get_meta( 'ss_shipping_order_agent_no', true );
+			$ss_agent_number = $order->get_meta( 'ss_shipping_order_agent_no', true );
             if ($ss_agent_number) {
                 // Return the agent_no found
                 return $ss_agent_number;
@@ -955,15 +966,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          * @param array $agent Agent Object
          *
          * @return void
-         */
-        public function save_ss_shipping_order_agent($order_id, $agent)
-        {
-            $order = wc_get_order($order_id);
-            if (! $order instanceof WC_Order) {
-                return;
-            }
-            $order->update_meta_data('_ss_shipping_order_agent', $agent);
-            $order->save();
+		 */
+		public function save_ss_shipping_order_agent( $order_id, $agent ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return;
+			}
+			$order->update_meta_data( '_ss_shipping_order_agent', $agent );
+			$order->save();
         }
 
 	    /**
@@ -994,14 +1004,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          */
         public function get_ss_shipping_order_agent($order_id)
         {
-            // Fetch agent info from meta field saved by Smart Send
-            $order = wc_get_order( $order_id );
+			// Fetch agent info from meta field saved by Smart Send
+			$order = wc_get_order( $order_id );
 
-            if (! $order instanceof WC_Order) {
-                return null;
-            }
+			if ( ! $order instanceof WC_Order ) {
+				return null;
+			}
 
-            $ss_agent_info = $order->get_meta( '_ss_shipping_order_agent', true );
+			$ss_agent_info = $order->get_meta( '_ss_shipping_order_agent', true );
             if ($ss_agent_info) {
                 // Return the agent_no found
                 return $ss_agent_info;
@@ -1032,16 +1042,16 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          * @param boolean $return Whether or not the label is return (true) or normal (false)
          *
          * @return void
-         */
-        public function save_ss_shipment_id_in_order_meta($order_id, $shipment_id, $return)
-        {
-            $order = wc_get_order($order_id);
-            if (! $order instanceof WC_Order) {
-                return;
-            }
-            if ($return) {
-                $order->update_meta_data('_ss_shipping_return_label_id', $shipment_id);
-            } else {
+		 */
+		// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.returnFound -- pre-existing public method signature, kept for backwards compatibility.
+		public function save_ss_shipment_id_in_order_meta( $order_id, $shipment_id, $return ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return;
+			}
+			if ( $return ) {
+				$order->update_meta_data( '_ss_shipping_return_label_id', $shipment_id );
+			} else {
                 $order->update_meta_data('_ss_shipping_label_id', $shipment_id);
             }
             $order->save();
@@ -1057,12 +1067,12 @@ if (!class_exists('SS_Shipping_WC_Order')) :
          */
         public function get_label_url_from_order_id($order_id, $return): string
         {
-            $order = wc_get_order( $order_id );
-            if (! $order instanceof WC_Order) {
-                return '';
-            }
-            if ($return) {
-                $shipment_id = $order->get_meta( '_ss_shipping_return_label_id', true );
+			$order = wc_get_order( $order_id );
+			if ( ! $order instanceof WC_Order ) {
+				return '';
+			}
+			if ( $return ) {
+				$shipment_id = $order->get_meta( '_ss_shipping_return_label_id', true );
             } else {
                 $shipment_id = $order->get_meta( '_ss_shipping_label_id', true );
             }

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -6,7 +6,6 @@ if (!defined('ABSPATH')) {
 
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
-use WooCommerce\Classes\WC_Order;
 
 /**
  * WooCommerce Smart Send Shipping Order.
@@ -147,6 +146,16 @@ if (!class_exists('SS_Shipping_WC_Order')) :
                     foreach ($items as $order_id) {
                         $order = wc_get_order($order_id);
 
+                        if (! $order instanceof WC_Order) {
+                            array_push($array_messages_error, array(
+                                'message' => sprintf(__('Order #%s', 'smart-send-logistics'),
+                                        $order_id) . ': ' . __('The order could not be found',
+                                        'smart-send-logistics'),
+                                'type'    => 'error',
+                            ));
+                            continue;
+                        }
+
                         $ss_shipping_method_id = $this->get_smart_send_method_id($order_id);
 
                         if (!empty($ss_shipping_method_id)) {
@@ -240,6 +249,10 @@ if (!class_exists('SS_Shipping_WC_Order')) :
             $order = ( $post_or_order_object instanceof WP_Post ) ? wc_get_order( $post_or_order_object->ID ) : $post_or_order_object;
 
             // ... rest of the code. $post_or_order_object should not be used directly below this point´
+
+            if (! $order instanceof WC_Order) {
+                return;
+            }
 
             $order_id = $order->get_id();
 
@@ -662,7 +675,12 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         {
             // Load WC Order
             $order = wc_get_order($order_id);
-            
+
+            if (! $order instanceof WC_Order) {
+                return array('error' => sprintf(__('Order #%s', 'smart-send-logistics'), $order_id)
+                    . ': ' . __('The order could not be found', 'smart-send-logistics'));
+            }
+
             $ss_order_api = new SS_Shipping_Shipment($order, $this);
 
             if ($ss_order_api->make_single_shipment_api_call( $return )) {
@@ -853,6 +871,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function save_ss_shipping_order_parcels($order_id, $parcels)
         {
             $order = wc_get_order($order_id);
+            if (! $order instanceof WC_Order) {
+                return;
+            }
             $order->update_meta_data('ss_shipping_order_parcels', $parcels);
             $order->save();
         }
@@ -868,6 +889,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function get_ss_shipping_order_parcels($order_id)
         {
             $order = wc_get_order( $order_id );
+            if (! $order instanceof WC_Order) {
+                return false;
+            }
             return $order->get_meta( 'ss_shipping_order_parcels', true );
         }
 
@@ -883,6 +907,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function save_ss_shipping_order_agent_no($order_id, $agent_no)
         {
             $order = wc_get_order($order_id);
+            if (! $order instanceof WC_Order) {
+                return;
+            }
             $order->update_meta_data('ss_shipping_order_agent_no', $agent_no);
             $order->save();
         }
@@ -898,6 +925,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         {
             // Fetch agent_no from meta field saved by Smart Send
             $order = wc_get_order( $order_id );
+
+            // wc_get_order() returns false when the order does not exist, e.g. when
+            // WooCommerce's email preview fires the order-details hooks with a
+            // placeholder order ID. See issue #60.
+            if (! $order instanceof WC_Order) {
+                return null;
+            }
+
             $ss_agent_number = $order->get_meta( 'ss_shipping_order_agent_no', true );
             if ($ss_agent_number) {
                 // Return the agent_no found
@@ -924,6 +959,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function save_ss_shipping_order_agent($order_id, $agent)
         {
             $order = wc_get_order($order_id);
+            if (! $order instanceof WC_Order) {
+                return;
+            }
             $order->update_meta_data('_ss_shipping_order_agent', $agent);
             $order->save();
         }
@@ -957,7 +995,12 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function get_ss_shipping_order_agent($order_id)
         {
             // Fetch agent info from meta field saved by Smart Send
-            $order         = wc_get_order( $order_id );
+            $order = wc_get_order( $order_id );
+
+            if (! $order instanceof WC_Order) {
+                return null;
+            }
+
             $ss_agent_info = $order->get_meta( '_ss_shipping_order_agent', true );
             if ($ss_agent_info) {
                 // Return the agent_no found
@@ -993,6 +1036,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function save_ss_shipment_id_in_order_meta($order_id, $shipment_id, $return)
         {
             $order = wc_get_order($order_id);
+            if (! $order instanceof WC_Order) {
+                return;
+            }
             if ($return) {
                 $order->update_meta_data('_ss_shipping_return_label_id', $shipment_id);
             } else {
@@ -1012,6 +1058,9 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function get_label_url_from_order_id($order_id, $return): string
         {
             $order = wc_get_order( $order_id );
+            if (! $order instanceof WC_Order) {
+                return '';
+            }
             if ($return) {
                 $shipment_id = $order->get_meta( '_ss_shipping_return_label_id', true );
             } else {

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Parcel.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Parcel.php
@@ -2,7 +2,7 @@
 
 namespace Smartsend\Models\Shipment;
 
-use Smartsend\Model\Shipment\Item;
+use Smartsend\Models\Shipment\Item;
 
 require_once 'Item.php';
 

--- a/smart-send-logistics/readme.txt
+++ b/smart-send-logistics/readme.txt
@@ -14,7 +14,7 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Requires Plugins: woocommerce
 WC requires at least: 3.0.0
 WC tested up to: 10.3
-Requires PHP: 5.6.0
+Requires PHP: 7.4
 
 Complete WooCommerce shipping solution for PostNord, GLS, DAO, Burd, Budbee and Bring.
 

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -101,8 +101,8 @@ if (!class_exists('SS_Shipping_WC')) :
 
             $this->define_constants();
             $this->includes();
-            $this->init_hooks();
-        }
+			$this->init_hooks();
+		}
 
         public function declaring_hpos_compatibility()
         {
@@ -135,15 +135,15 @@ if (!class_exists('SS_Shipping_WC')) :
         {
             $upload_dir = wp_upload_dir();
 
-            // Path related defines
-            $this->define('SS_SHIPPING_PLUGIN_FILE', __FILE__);
-            $this->define('SS_SHIPPING_PLUGIN_BASENAME', plugin_basename(__FILE__));
-            $this->define('SS_SHIPPING_PLUGIN_DIR_PATH', untrailingslashit(plugin_dir_path(__FILE__)));
-            $this->define('SS_SHIPPING_PLUGIN_DIR_URL', untrailingslashit(plugins_url('/', __FILE__)));
-            $this->define('SS_SHIPPING_VERSION', $this->version);
-            $this->define('SS_SHIPPING_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/');
-            $this->define('SS_SHIPPING_METHOD_ID', 'smart_send_shipping');
-        }
+			// Path related defines
+			$this->define( 'SS_SHIPPING_PLUGIN_FILE', __FILE__ );
+			$this->define( 'SS_SHIPPING_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+			$this->define( 'SS_SHIPPING_PLUGIN_DIR_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
+			$this->define( 'SS_SHIPPING_PLUGIN_DIR_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
+			$this->define( 'SS_SHIPPING_VERSION', $this->version );
+			$this->define( 'SS_SHIPPING_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );
+			$this->define( 'SS_SHIPPING_METHOD_ID', 'smart_send_shipping' );
+		}
 
         /**
          * Include required core files used in admin and on the frontend.
@@ -176,14 +176,13 @@ if (!class_exists('SS_Shipping_WC')) :
 
         /**
          * Initialize the plugin.
-         */
-        public function init()
-        {
-            // Translated string constants must not be defined before the init
-            // action: since WordPress 6.7 any translation call for our text
-            // domain that runs earlier triggers a _load_textdomain_just_in_time
-            // "called incorrectly" notice.
-            $this->define('SS_BUTTON_TEST_CONNECTION', __('Validate API Token', 'smart-send-logistics'));
+		 */
+		public function init() {
+			// Translated string constants must not be defined before the init
+			// action: since WordPress 6.7 any translation call for our text
+			// domain that runs earlier triggers a _load_textdomain_just_in_time
+			// "called incorrectly" notice.
+			$this->define( 'SS_BUTTON_TEST_CONNECTION', __( 'Validate API Token', 'smart-send-logistics' ) );
 
             // Checks if WooCommerce 2.6 is installed.
             if (defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '2.6', '>=')) {
@@ -344,31 +343,40 @@ if (!class_exists('SS_Shipping_WC')) :
         }
 
         /**
-         * Get Agent Address Format
-         *
-         * Built lazily on first call (not in the constructor): the plugin
-         * bootstraps before the init action, and since WordPress 6.7 any
-         * translation call for our text domain that runs before init triggers
-         * a _load_textdomain_just_in_time "called incorrectly" notice.
-         */
-        public function get_agents_address_format()
-        {
-            if (empty($this->agents_address_format)) {
-                $this->agents_address_format = array(
-                    '1' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street', 'smart-send-logistics'),
-                    '2' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                            'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
-                    '3' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                            'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                    '4' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                            'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics') . ' ' . __('#City',
-                            'smart-send-logistics'),
-                    '5' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
-                    '6' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode',
-                            'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                    '7' => __('#Company', 'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                );
-            }
+		 * Get Agent Address Format
+		 *
+		 * Built lazily on first call (not in the constructor): the plugin
+		 * bootstraps before the init action, and since WordPress 6.7 any
+		 * translation call for our text domain that runs before init triggers
+		 * a _load_textdomain_just_in_time "called incorrectly" notice.
+		 */
+		public function get_agents_address_format() {
+			if ( empty( $this->agents_address_format ) ) {
+				$this->agents_address_format = array(
+					'1' => __( '#Company', 'smart-send-logistics' ) . ', ' . __( '#Street', 'smart-send-logistics' ),
+					'2' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
+						'#Street',
+						'smart-send-logistics'
+					) . ', ' . __( '#Zipcode', 'smart-send-logistics' ),
+					'3' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
+						'#Street',
+						'smart-send-logistics'
+					) . ', ' . __( '#City', 'smart-send-logistics' ),
+					'4' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
+						'#Street',
+						'smart-send-logistics'
+					) . ', ' . __( '#Zipcode', 'smart-send-logistics' ) . ' ' . __(
+						'#City',
+						'smart-send-logistics'
+					),
+					'5' => __( '#Company', 'smart-send-logistics' ) . ', ' . __( '#Zipcode', 'smart-send-logistics' ),
+					'6' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
+						'#Zipcode',
+						'smart-send-logistics'
+					) . ', ' . __( '#City', 'smart-send-logistics' ),
+					'7' => __( '#Company', 'smart-send-logistics' ) . ', ' . __( '#City', 'smart-send-logistics' ),
+				);
+			}
 
             return $this->agents_address_format;
         }

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -102,21 +102,6 @@ if (!class_exists('SS_Shipping_WC')) :
             $this->define_constants();
             $this->includes();
             $this->init_hooks();
-
-            $this->agents_address_format = array(
-                '1' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street', 'smart-send-logistics'),
-                '2' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                        'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
-                '3' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                        'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                '4' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
-                        'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics') . ' ' . __('#City',
-                        'smart-send-logistics'),
-                '5' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
-                '6' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode',
-                        'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-                '7' => __('#Company', 'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
-            );
         }
 
         public function declaring_hpos_compatibility()
@@ -158,7 +143,6 @@ if (!class_exists('SS_Shipping_WC')) :
             $this->define('SS_SHIPPING_VERSION', $this->version);
             $this->define('SS_SHIPPING_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/');
             $this->define('SS_SHIPPING_METHOD_ID', 'smart_send_shipping');
-            $this->define('SS_BUTTON_TEST_CONNECTION', __('Validate API Token', 'smart-send-logistics'));
         }
 
         /**
@@ -195,6 +179,11 @@ if (!class_exists('SS_Shipping_WC')) :
          */
         public function init()
         {
+            // Translated string constants must not be defined before the init
+            // action: since WordPress 6.7 any translation call for our text
+            // domain that runs earlier triggers a _load_textdomain_just_in_time
+            // "called incorrectly" notice.
+            $this->define('SS_BUTTON_TEST_CONNECTION', __('Validate API Token', 'smart-send-logistics'));
 
             // Checks if WooCommerce 2.6 is installed.
             if (defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '2.6', '>=')) {
@@ -356,9 +345,31 @@ if (!class_exists('SS_Shipping_WC')) :
 
         /**
          * Get Agent Address Format
+         *
+         * Built lazily on first call (not in the constructor): the plugin
+         * bootstraps before the init action, and since WordPress 6.7 any
+         * translation call for our text domain that runs before init triggers
+         * a _load_textdomain_just_in_time "called incorrectly" notice.
          */
         public function get_agents_address_format()
         {
+            if (empty($this->agents_address_format)) {
+                $this->agents_address_format = array(
+                    '1' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street', 'smart-send-logistics'),
+                    '2' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
+                            'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
+                    '3' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
+                            'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
+                    '4' => __('#Company', 'smart-send-logistics') . ', ' . __('#Street',
+                            'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics') . ' ' . __('#City',
+                            'smart-send-logistics'),
+                    '5' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode', 'smart-send-logistics'),
+                    '6' => __('#Company', 'smart-send-logistics') . ', ' . __('#Zipcode',
+                            'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
+                    '7' => __('#Company', 'smart-send-logistics') . ', ' . __('#City', 'smart-send-logistics'),
+                );
+            }
+
             return $this->agents_address_format;
         }
 

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -7,6 +7,7 @@
  * Author URI: https://www.smartsend.io
  * Text Domain: smart-send-logistics
  * Version: 8.1.3
+ * Requires PHP: 7.4
  * Requires Plugins: woocommerce
  * WC requires at least: 4.7.0
  * WC tested up to: 10.3
@@ -541,9 +542,9 @@ if (!class_exists('SS_Shipping_WC')) :
 		        $api_token = empty($ss_shipping_settings['api_token']) ? null : $ss_shipping_settings['api_token'];
 	        }
 
-	        if (strpos($api_token, ',') && strpos($api_token, ':')) {
-		        //The API Token field contains multiple tokens in the format:
-		        //site1:apitoken1,site2:apitoken2,....
+			if ( is_string( $api_token ) && strpos( $api_token, ',' ) && strpos( $api_token, ':' ) ) {
+				//The API Token field contains multiple tokens in the format:
+				//site1:apitoken1,site2:apitoken2,....
 		        $tokens = array();
 		        $site_and_tokens = explode(',', $api_token);
 		        foreach ($site_and_tokens as $site_and_token) {

--- a/tests/Integration/EarlyTextdomainTest.php
+++ b/tests/Integration/EarlyTextdomainTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Regression test for issue #58: since WordPress 6.7, any translation call
+ * (__(), esc_html__(), ...) for the smart-send-logistics domain that runs
+ * before the init action triggers a _doing_it_wrong notice for
+ * _load_textdomain_just_in_time. The plugin bootstrap (the SS_Shipping_WC
+ * constructor, executed when the plugin file is loaded — long before init)
+ * must therefore not evaluate any translated string.
+ *
+ * The test bootstrap loads WordPress (and with it the plugin) before any test
+ * code runs, so the original bootstrap-time notice cannot be observed
+ * directly. Instead the pre-init environment is recreated: translations for
+ * the domain are made discoverable (as on a non-English production site —
+ * without a discoverable translation path WordPress never emits the notice,
+ * which is why an en_US dev install hides the bug), the init /
+ * after_setup_theme action counters are temporarily reset, and the plugin
+ * bootstrap is re-run exactly as WordPress runs it when loading the plugin
+ * file.
+ */
+
+it('does not trigger a too-early textdomain notice during plugin bootstrap', function () {
+    global $wp_textdomain_registry;
+
+    // Simulate a Danish site with translations available for our domain.
+    $locale_filter = function () {
+        return 'da_DK';
+    };
+    add_filter('locale', $locale_filter);
+    $wp_textdomain_registry->set('smart-send-logistics', 'da_DK', sys_get_temp_dir());
+
+    // Make the domain lazily-loadable again (reloadable, so the just-in-time
+    // loader is not short-circuited by the unload).
+    unload_textdomain('smart-send-logistics', true);
+
+    // Pretend the request has not reached init yet, as is the case while
+    // WordPress loads plugin files. (WP 6.7 keys the too-early check on the
+    // init action; newer versions on after_setup_theme — reset both.)
+    $saved_actions = [];
+    foreach (['init', 'after_setup_theme'] as $action) {
+        $saved_actions[$action] = $GLOBALS['wp_actions'][$action] ?? null;
+        unset($GLOBALS['wp_actions'][$action]);
+    }
+
+    $notices = [];
+    $capture = function ($function_name, $message) use (&$notices) {
+        if ($function_name === '_load_textdomain_just_in_time'
+            && strpos((string) $message, 'smart-send-logistics') !== false
+        ) {
+            $notices[] = $message;
+        }
+    };
+    add_action('doing_it_wrong_run', $capture, 10, 2);
+    add_filter('doing_it_wrong_trigger_error', '__return_false');
+
+    try {
+        // Re-run the plugin bootstrap. Before the fix this evaluated
+        // translated strings in the constructor / define_constants() and
+        // fired the notice; after the fix it must not translate anything.
+        new SS_Shipping_WC();
+    } finally {
+        remove_action('doing_it_wrong_run', $capture);
+        remove_filter('doing_it_wrong_trigger_error', '__return_false');
+
+        foreach ($saved_actions as $action => $count) {
+            if ($count !== null) {
+                $GLOBALS['wp_actions'][$action] = $count;
+            }
+        }
+
+        // Undo the simulated Danish locale so later tests run untouched.
+        $wp_textdomain_registry->set('smart-send-logistics', 'da_DK', false);
+        remove_filter('locale', $locale_filter);
+    }
+
+    expect($notices)->toBe([]);
+});

--- a/tests/Integration/FrontendAgentDisplayTest.php
+++ b/tests/Integration/FrontendAgentDisplayTest.php
@@ -60,6 +60,23 @@ it('renders nothing for an order without an agent', function () {
     expect(capture_agent_display($order))->toBe('');
 });
 
+it('renders nothing for an order that does not exist in the database', function () {
+    // Regression for #60: WooCommerce's email preview fires the order-details
+    // hooks (woocommerce_email_after_order_table etc.) with a placeholder
+    // order that has no database row, so wc_get_order() returns false inside
+    // the meta accessors. This used to fatal with
+    // "Call to a member function get_meta() on bool".
+    $ghost = new WC_Order(); // Unsaved: get_id() is 0 and wc_get_order(0) is false.
+
+    expect(capture_agent_display($ghost))->toBe('');
+
+    // Fire the actual hooks the way the email templates do.
+    ob_start();
+    do_action('woocommerce_order_details_after_order_table', $ghost);
+    do_action('woocommerce_email_after_order_table', $ghost, false);
+    expect(ob_get_clean())->toBe('');
+});
+
 it('survives deleting the agent meta of an order that no longer exists', function () {
     // Invalid-order guard (#60): the deleted_post_meta hook can fire for
     // orders that were already removed; the handler must not fatal.

--- a/tests/Integration/OrderMetaTest.php
+++ b/tests/Integration/OrderMetaTest.php
@@ -110,6 +110,28 @@ it('falls back to the vConnect meta for agent no and agent object', function () 
         ->and($agent->country)->toBe('DK');
 });
 
+it('handles a missing order in every meta accessor without fatals', function () {
+    // Regression for #60: wc_get_order() returns false for order IDs that do
+    // not exist (e.g. WooCommerce's email preview placeholder); every
+    // accessor must guard instead of calling methods on false.
+    $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+    $missing = 999999999;
+
+    expect($handler->get_ss_shipping_order_agent_no($missing))->toBeNull()
+        ->and($handler->get_ss_shipping_order_agent($missing))->toBeNull()
+        ->and($handler->get_ss_shipping_order_parcels($missing))->toBeFalse()
+        ->and($handler->get_label_url_from_order_id($missing, false))->toBe('')
+        ->and($handler->get_label_url_from_order_id($missing, true))->toBe('');
+
+    // The savers no-op instead of fataling.
+    $handler->save_ss_shipping_order_agent_no($missing, '1234');
+    $handler->save_ss_shipping_order_agent($missing, sample_agent());
+    $handler->save_ss_shipping_order_parcels($missing, []);
+    $handler->save_ss_shipment_id_in_order_meta($missing, 'shipment-1', false);
+
+    expect($handler->get_ss_shipping_order_agent_no($missing))->toBeNull();
+});
+
 it('detects the Smart Send shipping method on an order', function () {
     $handler = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
     $product = create_simple_product(['price' => 100, 'weight' => 1]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -67,6 +67,38 @@ define('WP_USE_THEMES', false);
 
 require_once $wpLoad;
 
+/*
+|--------------------------------------------------------------------------
+| Warnings-to-failures (plugin code only)
+|--------------------------------------------------------------------------
+|
+| Any PHP warning, notice, or deprecation raised from a file inside
+| smart-send-logistics/ is converted into an ErrorException so the test
+| that triggered it fails. Noise from WordPress core, WooCommerce, or
+| other plugins is left to PHPUnit's regular reporting. Registered after
+| wp-load.php on purpose: loading WordPress itself is not ours to police.
+|
+*/
+
+const SS_STRICT_ERRNO = E_WARNING | E_NOTICE | E_DEPRECATED | E_USER_WARNING | E_USER_NOTICE | E_USER_DEPRECATED;
+
+function ss_strict_error_handler(int $errno, string $errstr, string $errfile = '', int $errline = 0): bool
+{
+    if (! (error_reporting() & $errno)) {
+        return false; // @-suppressed
+    }
+
+    $pluginDir = DIRECTORY_SEPARATOR . 'smart-send-logistics' . DIRECTORY_SEPARATOR;
+
+    if (($errno & SS_STRICT_ERRNO) && str_contains($errfile, $pluginDir)) {
+        throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+    }
+
+    return false; // defer to the default / PHPUnit handler
+}
+
+set_error_handler('ss_strict_error_handler');
+
 // Keep database driver noise out of the test output. With the SQLite dev
 // store, WooCommerce's coupon-hold "SELECT ... FOR UPDATE" queries fail (the
 // driver does not support row locks) and would otherwise print a full error


### PR DESCRIPTION
PRs #76, #77 and #78 were merged while `feature/issue-70-test-safety-net` still existed, so GitHub retargeted them onto that branch instead of `develop` (the branch wasn't deleted after #75 merged). This PR brings those already-reviewed, already-green commits the rest of the way into `develop`. No new changes.

Contains: #76 (wc_get_order guards, closes #60), #77 (textdomain deferral, closes #58), #78 (PHP 7.4–8.4 compatibility sweep, closes #71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)