### PR TITLE
Add dedicated static logger with structured format

### DIFF
--- a/smart-send-logistics/includes/class-ss-shipping-logger.php
+++ b/smart-send-logistics/includes/class-ss-shipping-logger.php
@@ -110,41 +110,6 @@ class SS_Shipping_Logger {
 	}
 
 	/**
-	 * Log a debug trace message and surface it in WooCommerce's shipping
-	 * debug mode.
-	 *
-	 * The message is always written to the log like {@see log()}. When the
-	 * merchant has enabled WooCommerce → Settings → Shipping → "Enable debug
-	 * mode", the message is additionally shown as a checkout notice next to
-	 * core's own "Customer matched zone ..." notice, using the same gating
-	 * WooCommerce core applies (never during checkout submission or AJAX
-	 * requests, and never twice for the same message).
-	 *
-	 * @param string $message Message to log and show as a debug notice.
-	 */
-	public static function debug_notice( $message ) {
-		self::log( $message );
-
-		if ( 'yes' !== get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
-			return;
-		}
-
-		if ( defined( 'WOOCOMMERCE_CHECKOUT' ) || defined( 'WC_DOING_AJAX' ) ) {
-			return;
-		}
-
-		if ( ! function_exists( 'wc_add_notice' ) || ! function_exists( 'wc_has_notice' ) ) {
-			return;
-		}
-
-		if ( wc_has_notice( $message ) ) {
-			return;
-		}
-
-		wc_add_notice( $message );
-	}
-
-	/**
 	 * Log an API request/response cycle as reported by the Smartsend client.
 	 *
 	 * Emits one concise line per request ("POST /shipments → 422 (312ms)")

--- a/smart-send-logistics/includes/class-ss-shipping-logger.php
+++ b/smart-send-logistics/includes/class-ss-shipping-logger.php
@@ -1,66 +1,182 @@
 <?php
+/**
+ * Smart Send logger.
+ *
+ * @package SmartSendLogistics
+ */
 
-if (!defined('ABSPATH')) {
-    exit;
-} // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
-class SS_Shipping_Logger
-{
+/**
+ * Static logger modeled on WC_Stripe_Logger.
+ *
+ * The class owns all logging concerns: it checks the plugin's debug setting,
+ * formats every entry consistently (version-stamped header, optional timing
+ * block) and writes through WC_Logger under a single source name.
+ *
+ * Whether an entry is written can be forced on/off with the
+ * `smart_send_logging` filter.
+ */
+class SS_Shipping_Logger {
 
-    /**
-     * @var String
-     */
-    private $debug;
+	/**
+	 * The shared WC_Logger instance.
+	 *
+	 * @var WC_Logger_Interface
+	 */
+	public static $logger;
 
-    /**
-     * SS_Shipping_Logger constructor.
-     *
-     * @param bool $debug
-     */
-    public function __construct($debug)
-    {
-        $this->debug = $debug;
-    }
+	const WC_LOG_FILENAME = 'smart-send-logistics';
 
-    /**
-     * Check if logging is enabled
-     *
-     * @return bool
-     */
-    public function is_enabled()
-    {
+	/**
+	 * Log a debug trace message.
+	 *
+	 * Written at the `debug` level and only when the plugin's "Debug Log"
+	 * setting is enabled (unless forced via the `smart_send_logging` filter).
+	 *
+	 * @param string   $message    Message to log.
+	 * @param int|null $start_time Optional start timestamp for a timing block.
+	 * @param int|null $end_time   Optional end timestamp for a timing block.
+	 */
+	public static function log( $message, $start_time = null, $end_time = null ) {
+		self::write( 'debug', $message, self::is_enabled(), $start_time, $end_time );
+	}
 
-        // Check if debug is on
-        if ('yes' === $this->debug) {
-            return true;
-        }
+	/**
+	 * Log an error message.
+	 *
+	 * Written at the `error` level and logged even when the plugin's debug
+	 * setting is off (unless suppressed via the `smart_send_logging` filter).
+	 *
+	 * @param string   $message    Message to log.
+	 * @param int|null $start_time Optional start timestamp for a timing block.
+	 * @param int|null $end_time   Optional end timestamp for a timing block.
+	 */
+	public static function error( $message, $start_time = null, $end_time = null ) {
+		self::write( 'error', $message, true, $start_time, $end_time );
+	}
 
-        return false;
-    }
+	/**
+	 * Log an API request/response cycle as reported by the Smartsend client.
+	 *
+	 * Successful calls are logged as debug traces (respecting the debug
+	 * setting); failed calls are logged at the `error` level even when the
+	 * debug setting is off.
+	 *
+	 * @param array $context {
+	 *     Request/response data from \Smartsend\Client.
+	 *
+	 *     @type string      $method        HTTP verb (GET, POST, ...).
+	 *     @type string      $endpoint      Full request URL.
+	 *     @type string|null $request_body  JSON request body, if any.
+	 *     @type int|string  $status_code   HTTP status code of the response.
+	 *     @type string      $response_body Raw response body.
+	 *     @type bool        $success       Whether the client deemed the call successful.
+	 *     @type int|null    $start_time    Timestamp when the request started.
+	 *     @type int|null    $end_time      Timestamp when the request finished.
+	 * }
+	 */
+	public static function log_api_request( $context ) {
+		$status_code = isset( $context['status_code'] ) && '' !== $context['status_code'] && null !== $context['status_code']
+			? $context['status_code']
+			: 'n/a';
 
-    /**
-     * Write the message to log
-     *
-     * @param String $message
-     */
-    public function write($message)
-    {
+		$message = ( isset( $context['method'] ) ? $context['method'] : '' )
+			. ' ' . self::redact_endpoint( isset( $context['endpoint'] ) ? $context['endpoint'] : '' )
+			. ' [HTTP ' . $status_code . ']';
 
-        // Check if enabled
-        if ($this->is_enabled()) {
+		if ( ! empty( $context['request_body'] ) ) {
+			$message .= "\n" . 'Request body: ' . $context['request_body'];
+		}
 
-            // Logger object
-            $wc_logger = new WC_Logger();
+		$message .= "\n" . 'Response body: ' . ( isset( $context['response_body'] ) && '' !== $context['response_body'] ? $context['response_body'] : '(empty)' );
 
-            // Add to logger
-            $wc_logger->add('Smart_Send', $message);
-        }
+		$start_time = isset( $context['start_time'] ) ? $context['start_time'] : null;
+		$end_time   = isset( $context['end_time'] ) ? $context['end_time'] : null;
 
-    }
+		if ( ! empty( $context['success'] ) ) {
+			self::log( $message, $start_time, $end_time );
+		} else {
+			self::error( $message, $start_time, $end_time );
+		}
+	}
 
-    public function get_log_url()
-    {
-        return admin_url('admin.php?page=wc-status&tab=logs');
-    }
+	/**
+	 * Check if debug logging is enabled in the plugin settings.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		$settings = get_option( 'woocommerce_' . SS_SHIPPING_METHOD_ID . '_settings' );
+		$ss_debug = isset( $settings['ss_debug'] ) ? $settings['ss_debug'] : 'yes';
 
+		return 'yes' === $ss_debug;
+	}
+
+	/**
+	 * Get the WooCommerce log screen URL.
+	 *
+	 * @return string
+	 */
+	public static function get_log_url() {
+		return admin_url( 'admin.php?page=wc-status&tab=logs' );
+	}
+
+	/**
+	 * Format and write an entry through WC_Logger.
+	 *
+	 * @param string   $level      WC log level (debug, info, error, ...).
+	 * @param string   $message    Message to log.
+	 * @param bool     $enabled    Whether logging is enabled for this entry (before the filter).
+	 * @param int|null $start_time Optional start timestamp for a timing block.
+	 * @param int|null $end_time   Optional end timestamp for a timing block.
+	 */
+	private static function write( $level, $message, $enabled, $start_time = null, $end_time = null ) {
+		if ( ! class_exists( 'WC_Logger' ) || ! function_exists( 'wc_get_logger' ) ) {
+			return;
+		}
+
+		/**
+		 * Force Smart Send logging on or off, or inspect messages.
+		 *
+		 * @param bool   $enabled Whether this entry will be written.
+		 * @param string $message The message being logged.
+		 * @param string $level   The WC log level of the entry.
+		 */
+		if ( ! apply_filters( 'smart_send_logging', $enabled, $message, $level ) ) {
+			return;
+		}
+
+		if ( empty( self::$logger ) ) {
+			self::$logger = wc_get_logger();
+		}
+
+		$log_entry = "\n" . '====Smart Send Version: ' . SS_SHIPPING_VERSION . '====' . "\n";
+
+		if ( ! is_null( $start_time ) ) {
+			$formatted_start_time = date_i18n( get_option( 'date_format' ) . ' g:ia', $start_time );
+			$end_time             = is_null( $end_time ) ? time() : $end_time;
+			$formatted_end_time   = date_i18n( get_option( 'date_format' ) . ' g:ia', $end_time );
+			$elapsed_time         = round( abs( $end_time - $start_time ) / 60, 2 );
+
+			$log_entry .= '====Start Log ' . $formatted_start_time . '====' . "\n" . $message . "\n";
+			$log_entry .= '====End Log ' . $formatted_end_time . ' (' . $elapsed_time . ')====' . "\n\n";
+		} else {
+			$log_entry .= '====Start Log====' . "\n" . $message . "\n" . '====End Log====' . "\n\n";
+		}
+
+		self::$logger->log( $level, $log_entry, array( 'source' => self::WC_LOG_FILENAME ) );
+	}
+
+	/**
+	 * Strip the API token from an endpoint URL before logging it.
+	 *
+	 * @param string $endpoint Request URL, possibly containing an api_token query parameter.
+	 * @return string
+	 */
+	private static function redact_endpoint( $endpoint ) {
+		return preg_replace( '/([?&]api_token=)[^&]*/', '${1}[REDACTED]', (string) $endpoint );
+	}
 }

--- a/smart-send-logistics/includes/class-ss-shipping-logger.php
+++ b/smart-send-logistics/includes/class-ss-shipping-logger.php
@@ -10,14 +10,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Static logger modeled on WC_Stripe_Logger.
+ * Static logger delegating to WooCommerce's native logging.
  *
- * The class owns all logging concerns: it checks the plugin's debug setting,
- * formats every entry consistently (version-stamped header, optional timing
- * block) and writes through WC_Logger under a single source name.
+ * The class is a thin wrapper around wc_get_logger(): it owns the plugin's
+ * debug gate, the `smart_send_logging` filter, the single log source name
+ * and the API-token redaction — everything else (levels, retention, the
+ * log viewer's context rendering) is left to WooCommerce core.
  *
- * Whether an entry is written can be forced on/off with the
- * `smart_send_logging` filter.
+ * Entries are concise single-line messages; structured data (plugin
+ * version, endpoint, HTTP status, request/response bodies, timing) travels
+ * in the `$context` array, which the WooCommerce log viewer renders
+ * natively.
+ *
+ * The `debug` and `info` levels are gated on the plugin's "Debug Log"
+ * setting; `warning`, `error` and `critical` always log. The
+ * `smart_send_logging` filter applies to all levels and can force logging
+ * on or off.
  */
 class SS_Shipping_Logger {
 
@@ -33,34 +41,105 @@ class SS_Shipping_Logger {
 	/**
 	 * Log a debug trace message.
 	 *
-	 * Written at the `debug` level and only when the plugin's "Debug Log"
-	 * setting is enabled (unless forced via the `smart_send_logging` filter).
+	 * Alias of {@see debug()} kept for the existing call sites.
 	 *
-	 * @param string   $message    Message to log.
-	 * @param int|null $start_time Optional start timestamp for a timing block.
-	 * @param int|null $end_time   Optional end timestamp for a timing block.
+	 * @param string $message Message to log.
+	 * @param array  $context Optional structured context.
 	 */
-	public static function log( $message, $start_time = null, $end_time = null ) {
-		self::write( 'debug', $message, self::is_enabled(), $start_time, $end_time );
+	public static function log( $message, $context = array() ) {
+		self::debug( $message, is_array( $context ) ? $context : array() );
 	}
 
 	/**
-	 * Log an error message.
+	 * Log a debug trace message (gated on the plugin's debug setting).
 	 *
-	 * Written at the `error` level and logged even when the plugin's debug
-	 * setting is off (unless suppressed via the `smart_send_logging` filter).
-	 *
-	 * @param string   $message    Message to log.
-	 * @param int|null $start_time Optional start timestamp for a timing block.
-	 * @param int|null $end_time   Optional end timestamp for a timing block.
+	 * @param string $message Message to log.
+	 * @param array  $context Optional structured context.
 	 */
-	public static function error( $message, $start_time = null, $end_time = null ) {
-		self::write( 'error', $message, true, $start_time, $end_time );
+	public static function debug( $message, $context = array() ) {
+		self::write( 'debug', $message, $context, self::is_enabled() );
+	}
+
+	/**
+	 * Log an informational message (gated on the plugin's debug setting).
+	 *
+	 * @param string $message Message to log.
+	 * @param array  $context Optional structured context.
+	 */
+	public static function info( $message, $context = array() ) {
+		self::write( 'info', $message, $context, self::is_enabled() );
+	}
+
+	/**
+	 * Log a warning. Always logged, regardless of the debug setting.
+	 *
+	 * @param string $message Message to log.
+	 * @param array  $context Optional structured context.
+	 */
+	public static function warning( $message, $context = array() ) {
+		self::write( 'warning', $message, $context, true );
+	}
+
+	/**
+	 * Log an error. Always logged, regardless of the debug setting.
+	 *
+	 * @param string $message Message to log.
+	 * @param array  $context Optional structured context.
+	 */
+	public static function error( $message, $context = array() ) {
+		self::write( 'error', $message, is_array( $context ) ? $context : array(), true );
+	}
+
+	/**
+	 * Log a critical failure. Always logged, regardless of the debug setting.
+	 *
+	 * @param string $message Message to log.
+	 * @param array  $context Optional structured context.
+	 */
+	public static function critical( $message, $context = array() ) {
+		self::write( 'critical', $message, $context, true );
+	}
+
+	/**
+	 * Log a debug trace message and surface it in WooCommerce's shipping
+	 * debug mode.
+	 *
+	 * The message is always written to the log like {@see log()}. When the
+	 * merchant has enabled WooCommerce → Settings → Shipping → "Enable debug
+	 * mode", the message is additionally shown as a checkout notice next to
+	 * core's own "Customer matched zone ..." notice, using the same gating
+	 * WooCommerce core applies (never during checkout submission or AJAX
+	 * requests, and never twice for the same message).
+	 *
+	 * @param string $message Message to log and show as a debug notice.
+	 */
+	public static function debug_notice( $message ) {
+		self::log( $message );
+
+		if ( 'yes' !== get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
+			return;
+		}
+
+		if ( defined( 'WOOCOMMERCE_CHECKOUT' ) || defined( 'WC_DOING_AJAX' ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'wc_add_notice' ) || ! function_exists( 'wc_has_notice' ) ) {
+			return;
+		}
+
+		if ( wc_has_notice( $message ) ) {
+			return;
+		}
+
+		wc_add_notice( $message );
 	}
 
 	/**
 	 * Log an API request/response cycle as reported by the Smartsend client.
 	 *
+	 * Emits one concise line per request ("POST /shipments → 422 (312ms)")
+	 * with the full detail (endpoint, bodies, error) in the context array.
 	 * Successful calls are logged as debug traces (respecting the debug
 	 * setting); failed calls are logged at the `error` level even when the
 	 * debug setting is off.
@@ -74,8 +153,9 @@ class SS_Shipping_Logger {
 	 *     @type int|string  $status_code   HTTP status code of the response.
 	 *     @type string      $response_body Raw response body.
 	 *     @type bool        $success       Whether the client deemed the call successful.
-	 *     @type int|null    $start_time    Timestamp when the request started.
-	 *     @type int|null    $end_time      Timestamp when the request finished.
+	 *     @type object|null $error         Smartsend\Models\Error describing the failure, if any.
+	 *     @type float|null  $start_time    Timestamp when the request started.
+	 *     @type float|null  $end_time      Timestamp when the request finished.
 	 * }
 	 */
 	public static function log_api_request( $context ) {
@@ -83,23 +163,43 @@ class SS_Shipping_Logger {
 			? $context['status_code']
 			: 'n/a';
 
-		$message = ( isset( $context['method'] ) ? $context['method'] : '' )
-			. ' ' . self::redact_endpoint( isset( $context['endpoint'] ) ? $context['endpoint'] : '' )
-			. ' [HTTP ' . $status_code . ']';
+		$endpoint = self::redact_endpoint( isset( $context['endpoint'] ) ? $context['endpoint'] : '' );
+		$path     = wp_parse_url( $endpoint, PHP_URL_PATH );
 
-		if ( ! empty( $context['request_body'] ) ) {
-			$message .= "\n" . 'Request body: ' . $context['request_body'];
+		$message = ( isset( $context['method'] ) ? $context['method'] : '' )
+			. ' ' . ( $path ? $path : $endpoint )
+			. ' → ' . $status_code;
+
+		$log_context = array(
+			'endpoint'    => $endpoint,
+			'status_code' => isset( $context['status_code'] ) ? $context['status_code'] : null,
+		);
+
+		if ( isset( $context['start_time'], $context['end_time'] ) && is_numeric( $context['start_time'] ) && is_numeric( $context['end_time'] ) ) {
+			$duration_ms                = (int) round( abs( $context['end_time'] - $context['start_time'] ) * 1000 );
+			$message                   .= ' (' . $duration_ms . 'ms)';
+			$log_context['duration_ms'] = $duration_ms;
 		}
 
-		$message .= "\n" . 'Response body: ' . ( isset( $context['response_body'] ) && '' !== $context['response_body'] ? $context['response_body'] : '(empty)' );
+		if ( ! empty( $context['request_body'] ) ) {
+			$log_context['request_body'] = $context['request_body'];
+		}
 
-		$start_time = isset( $context['start_time'] ) ? $context['start_time'] : null;
-		$end_time   = isset( $context['end_time'] ) ? $context['end_time'] : null;
+		$log_context['response_body'] = isset( $context['response_body'] ) && '' !== $context['response_body'] ? $context['response_body'] : '';
+
+		if ( empty( $context['success'] ) && ! empty( $context['error'] ) && is_object( $context['error'] ) ) {
+			$error_code    = isset( $context['error']->code ) && is_scalar( $context['error']->code ) ? (string) $context['error']->code : '';
+			$error_message = isset( $context['error']->message ) && is_scalar( $context['error']->message ) ? (string) $context['error']->message : '';
+
+			if ( '' !== $error_code || '' !== $error_message ) {
+				$log_context['error'] = trim( $error_code . ' - ' . $error_message, ' -' );
+			}
+		}
 
 		if ( ! empty( $context['success'] ) ) {
-			self::log( $message, $start_time, $end_time );
+			self::debug( $message, $log_context );
 		} else {
-			self::error( $message, $start_time, $end_time );
+			self::error( $message, $log_context );
 		}
 	}
 
@@ -125,16 +225,15 @@ class SS_Shipping_Logger {
 	}
 
 	/**
-	 * Format and write an entry through WC_Logger.
+	 * Write an entry through wc_get_logger().
 	 *
-	 * @param string   $level      WC log level (debug, info, error, ...).
-	 * @param string   $message    Message to log.
-	 * @param bool     $enabled    Whether logging is enabled for this entry (before the filter).
-	 * @param int|null $start_time Optional start timestamp for a timing block.
-	 * @param int|null $end_time   Optional end timestamp for a timing block.
+	 * @param string $level   WC log level (debug, info, warning, error, critical).
+	 * @param string $message Message to log.
+	 * @param array  $context Structured context for the entry.
+	 * @param bool   $enabled Whether logging is enabled for this entry (before the filter).
 	 */
-	private static function write( $level, $message, $enabled, $start_time = null, $end_time = null ) {
-		if ( ! class_exists( 'WC_Logger' ) || ! function_exists( 'wc_get_logger' ) ) {
+	private static function write( $level, $message, $context, $enabled ) {
+		if ( ! function_exists( 'wc_get_logger' ) ) {
 			return;
 		}
 
@@ -153,21 +252,13 @@ class SS_Shipping_Logger {
 			self::$logger = wc_get_logger();
 		}
 
-		$log_entry = "\n" . '====Smart Send Version: ' . SS_SHIPPING_VERSION . '====' . "\n";
+		$context = array_merge(
+			array( 'version' => SS_SHIPPING_VERSION ),
+			is_array( $context ) ? $context : array(),
+			array( 'source' => self::WC_LOG_FILENAME )
+		);
 
-		if ( ! is_null( $start_time ) ) {
-			$formatted_start_time = date_i18n( get_option( 'date_format' ) . ' g:ia', $start_time );
-			$end_time             = is_null( $end_time ) ? time() : $end_time;
-			$formatted_end_time   = date_i18n( get_option( 'date_format' ) . ' g:ia', $end_time );
-			$elapsed_time         = round( abs( $end_time - $start_time ) / 60, 2 );
-
-			$log_entry .= '====Start Log ' . $formatted_start_time . '====' . "\n" . $message . "\n";
-			$log_entry .= '====End Log ' . $formatted_end_time . ' (' . $elapsed_time . ')====' . "\n\n";
-		} else {
-			$log_entry .= '====Start Log====' . "\n" . $message . "\n" . '====End Log====' . "\n\n";
-		}
-
-		self::$logger->log( $level, $log_entry, array( 'source' => self::WC_LOG_FILENAME ) );
+		self::$logger->log( $level, $message, $context );
 	}
 
 	/**

--- a/smart-send-logistics/includes/class-ss-shipping-logger.php
+++ b/smart-send-logistics/includes/class-ss-shipping-logger.php
@@ -24,8 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * The `debug` and `info` levels are gated on the plugin's "Debug Log"
  * setting; `warning`, `error` and `critical` always log. The
- * `smart_send_logging` filter applies to all levels and can force logging
- * on or off.
+ * `smart_send_logging` filter applies to all levels: it receives the
+ * message and may rewrite it, or suppress the entry by returning null or
+ * false.
  */
 class SS_Shipping_Logger {
 
@@ -36,7 +37,15 @@ class SS_Shipping_Logger {
 	 */
 	public static $logger;
 
-	const WC_LOG_FILENAME = 'smart-send-logistics';
+	private const LOG_SOURCE = 'smart-send-logistics';
+
+	/**
+	 * The WC log levels the logger dispatches to, matching wc_get_logger()'s
+	 * level wrapper methods.
+	 *
+	 * @var string[]
+	 */
+	private const LEVELS = array( 'debug', 'info', 'warning', 'error', 'critical' );
 
 	/**
 	 * Log a debug trace message.
@@ -237,14 +246,29 @@ class SS_Shipping_Logger {
 			return;
 		}
 
+		if ( ! $enabled || ! in_array( $level, self::LEVELS, true ) ) {
+			return;
+		}
+
+		$context = array_merge(
+			array( 'version' => SS_SHIPPING_VERSION ),
+			is_array( $context ) ? $context : array(),
+			array( 'source' => self::LOG_SOURCE )
+		);
+
 		/**
-		 * Force Smart Send logging on or off, or inspect messages.
+		 * Rewrite or suppress Smart Send log entries.
 		 *
-		 * @param bool   $enabled Whether this entry will be written.
+		 * Return a modified string to rewrite the message, or null/false to
+		 * suppress the entry entirely.
+		 *
 		 * @param string $message The message being logged.
 		 * @param string $level   The WC log level of the entry.
+		 * @param array  $context The context array of the entry.
 		 */
-		if ( ! apply_filters( 'smart_send_logging', $enabled, $message, $level ) ) {
+		$message = apply_filters( 'smart_send_logging', $message, $level, $context );
+
+		if ( null === $message || false === $message ) {
 			return;
 		}
 
@@ -252,13 +276,7 @@ class SS_Shipping_Logger {
 			self::$logger = wc_get_logger();
 		}
 
-		$context = array_merge(
-			array( 'version' => SS_SHIPPING_VERSION ),
-			is_array( $context ) ? $context : array(),
-			array( 'source' => self::WC_LOG_FILENAME )
-		);
-
-		self::$logger->log( $level, $message, $context );
+		self::$logger->{$level}( $message, $context );
 	}
 
 	/**

--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -480,26 +480,16 @@ if (!class_exists('SS_Shipping_Shipment')) :
                 ->setCurrency($order_currency ?: null);
         }
 
-        /**
-         * Call Smart Send Shipment API, log response
-         *
-         * @return void
-         */
-        protected function make_single_shipment_api_request()
-        {
-            // Make API Request
-            SS_SHIPPING_WC()->get_api_handle()->createShipmentAndLabels($this->shipment);
-
-            // Log API request
-            SS_SHIPPING_WC()->log_msg('Called "createShipmentAndLabels" with arguments: ' . SS_SHIPPING_WC()->get_api_handle()->getRequestBody());
-
-            // Log API response
-            if (SS_SHIPPING_WC()->get_api_handle()->isSuccessful()) {
-                SS_SHIPPING_WC()->log_msg('Response from "createShipmentAndLabels" : ' . SS_SHIPPING_WC()->get_api_handle()->getResponseBody());
-            } else {
-                SS_SHIPPING_WC()->log_msg('Error response from "createShipmentAndLabels" : ' . SS_SHIPPING_WC()->get_api_handle()->getResponseBody());
-            }
-        }
+		/**
+		 * Call Smart Send Shipment API, log response
+		 *
+		 * @return void
+		 */
+		protected function make_single_shipment_api_request() {
+			// Make API Request. The request and response (incl. HTTP status
+			// code and endpoint) are logged by the client's request logger.
+			SS_SHIPPING_WC()->get_api_handle()->createShipmentAndLabels( $this->shipment );
+		}
 
         /**
          * Get the order id

--- a/smart-send-logistics/includes/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-method.php
@@ -269,15 +269,14 @@ if (!class_exists('SS_Shipping_WC_Method')) :
             wp_localize_script('smart-send-test-connection', 'ss_test_connection_obj', $test_con_data);
         }
 
-        /**
-         * Initialize integration settings form fields.
-         *
-         * @return void
-         */
-        public function init_form_fields()
-        {
-            $log_path = SS_SHIPPING_WC()->get_log_url();
-            $agents_address_format = SS_SHIPPING_WC()->get_agents_address_format();
+		/**
+		 * Initialize integration settings form fields.
+		 *
+		 * @return void
+		 */
+		public function init_form_fields() {
+			$log_path              = SS_Shipping_Logger::get_log_url();
+			$agents_address_format = SS_SHIPPING_WC()->get_agents_address_format();
 
             $this->form_fields = array(
                 'api_token'                         => array(
@@ -973,9 +972,9 @@ if (!class_exists('SS_Shipping_WC_Method')) :
                 'package'   => $package,
             );
 
-            // write id of shipping method to log
-            SS_SHIPPING_WC()->log_msg('Handling shipping rate <' . $rate['id'] . '> with title: ' . $rate['label']);
-            SS_SHIPPING_WC()->log_msg('Rate details (json decode for details): ' . json_encode($rate));
+			// write id of shipping method to log.
+			SS_Shipping_Logger::log( 'Handling shipping rate <' . $rate['id'] . '> with title: ' . $rate['label'] );
+			SS_Shipping_Logger::log( 'Rate details (json decode for details): ' . wp_json_encode( $rate ) );
 
             // Set tax status based on selection otherwise always taxed
             $this->tax_status = $this->get_option('tax_status');
@@ -983,10 +982,10 @@ if (!class_exists('SS_Shipping_WC_Method')) :
             // Check if free shipping, otherwise claculate based on weight and evaluate formulas
             if ($this->is_free_shipping($package)) {
 
-                $rate['cost'] = $this->get_option('flatfee_cost');
-                $this->add_rate($rate);
-                // write to log, that shipping rate is added
-                SS_SHIPPING_WC()->log_msg('Free shipping rate added');
+				$rate['cost'] = $this->get_option( 'flatfee_cost' );
+				$this->add_rate( $rate );
+				// write to log, that shipping rate is added.
+				SS_Shipping_Logger::log( 'Free shipping rate added' );
 
             } else {
                 $cart_weight = WC()->cart->get_cart_contents_weight();
@@ -1007,10 +1006,10 @@ if (!class_exists('SS_Shipping_WC_Method')) :
                                         'cost' => $package['contents_cost'],
                                     ));
 
-                                    $this->add_rate($rate);
-                                    // write to log, that shipping rate is added
-                                    SS_SHIPPING_WC()->log_msg('Weight based shipping rate added (json decode for details): ' . json_encode($rate));
-                                }
+									$this->add_rate( $rate );
+									// write to log, that shipping rate is added.
+									SS_Shipping_Logger::log( 'Weight based shipping rate added (json decode for details): ' . wp_json_encode( $rate ) );
+								}
                             }
                         }
                     }
@@ -1089,12 +1088,12 @@ if (!class_exists('SS_Shipping_WC_Method')) :
                     }
                 }
 
-                if (!empty($class_log_message)) {
-                    if ($is_available) {
-                        SS_SHIPPING_WC()->log_msg('Shipping method IS available' . $class_log_message);
-                    } else {
-                        SS_SHIPPING_WC()->log_msg('Shipping method is NOT available' . $class_log_message);
-                    }
+				if ( ! empty( $class_log_message ) ) {
+					if ( $is_available ) {
+						SS_Shipping_Logger::log( 'Shipping method IS available' . $class_log_message );
+					} else {
+						SS_Shipping_Logger::log( 'Shipping method is NOT available' . $class_log_message );
+					}
                 }
 
                 // Exclude customer roles
@@ -1114,8 +1113,8 @@ if (!class_exists('SS_Shipping_WC_Method')) :
                         if (in_array($customer_role, $exclude_roles)) {
                             $is_available = false;
 
-                            SS_SHIPPING_WC()->log_msg('Shipping method available NOT available, because customer role "' . $customer_role . '"is being excluded.');
-                            break;
+							SS_Shipping_Logger::log( 'Shipping method available NOT available, because customer role "' . $customer_role . '"is being excluded.' );
+							break;
                         }
                     }
                 }
@@ -1203,12 +1202,12 @@ if (!class_exists('SS_Shipping_WC_Method')) :
                     break;
             }
 
-            if ($free_log_message) {
-                if ($is_available) {
-                    SS_SHIPPING_WC()->log_msg('Flat rate shipping IS available' . $free_log_message);
-                } else {
-                    SS_SHIPPING_WC()->log_msg('Flat rate shipping is NOT available' . $free_log_message);
-                }
+			if ( $free_log_message ) {
+				if ( $is_available ) {
+					SS_Shipping_Logger::log( 'Flat rate shipping IS available' . $free_log_message );
+				} else {
+					SS_Shipping_Logger::log( 'Flat rate shipping is NOT available' . $free_log_message );
+				}
             }
 
             return apply_filters('woocommerce_shipping_' . $this->id . '_is_free_shipping', $is_available, $package,

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -576,19 +576,17 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 
                 if (!empty($shipping_method_carrier) && !empty($shipping_address['country'])) {
 
-                    SS_SHIPPING_WC()->log_msg('Called "getAgentByAgentNo" with carrier = ' . $shipping_method_carrier . ', country = ' . $shipping_address['country'] . ', ss_shipping_agent_no = ' . $ss_shipping_agent_no);
-                    // API call to get agent info by agent no.
-                    if (SS_SHIPPING_WC()->get_api_handle()->getAgentByAgentNo($shipping_method_carrier,
-                        $shipping_address['country'], $ss_shipping_agent_no)) {
+					// API call to get agent info by agent no.
+					if ( SS_SHIPPING_WC()->get_api_handle()->getAgentByAgentNo( $shipping_method_carrier, $shipping_address['country'], $ss_shipping_agent_no ) ) {
 
-                        SS_SHIPPING_WC()->log_msg('Agent found and saved.');
+						SS_Shipping_Logger::log( 'Agent found and saved.' );
 
                         $this->save_ss_shipping_order_agent($post_id,
                             SS_SHIPPING_WC()->get_api_handle()->getData());
                         return true;
                     } else {
 
-                        SS_SHIPPING_WC()->log_msg('Agent NOT found.');
+						SS_Shipping_Logger::log( 'Agent NOT found.' );
 
                         $error_msg = sprintf(__('The agent number entered, %s, was not found.',
                             'smart-send-logistics'), $ss_shipping_agent_no);
@@ -984,10 +982,10 @@ if (!class_exists('SS_Shipping_WC_Order')) :
         public function delete_ss_shipping_order_agent($order_id) {
             $order = wc_get_order( $order_id );
 
-            // There are situations where the order has been deleted and cannot be found.
-            // We should gracefully handle this situation of failing to load the order.
-            if (! $order ) {
-                SS_SHIPPING_WC()->log_msg('Failed to load WooCommerce order: '.$order_id);
+			// There are situations where the order has been deleted and cannot be found.
+			// We should gracefully handle this situation of failing to load the order.
+			if ( ! $order ) {
+				SS_Shipping_Logger::log( 'Failed to load WooCommerce order: ' . $order_id );
 
                 return;
             }
@@ -1169,9 +1167,6 @@ if (!class_exists('SS_Shipping_WC_Order')) :
                     $combined_shipments = SS_SHIPPING_WC()->get_api_handle()->combineLabelsForShipments(wp_list_pluck($array_shipment_ids,
                         'shipment_id'));
 
-                    // Write API request to log
-                    SS_SHIPPING_WC()->log_msg('Called "combineLabelsForShipments" with arguments: ' . SS_SHIPPING_WC()->get_api_handle()->getRequestBody());
-
                     if (SS_SHIPPING_WC()->get_api_handle()->isSuccessful()) {
 
                         $response = SS_SHIPPING_WC()->get_api_handle()->getData();
@@ -1190,19 +1185,17 @@ if (!class_exists('SS_Shipping_WC_Order')) :
                         // Get the combined label link
                         $combo_url = $response->pdf->link;
 
-                        // Write API response to log
-                        SS_SHIPPING_WC()->log_msg('Response from "combineLabelsForShipments" : ' . SS_SHIPPING_WC()->get_api_handle()->getResponseBody());
-
-                    } else {
-                        SS_SHIPPING_WC()->log_msg('Error response from "combineLabelsForShipments" : ' . SS_SHIPPING_WC()->get_api_handle()->getResponseBody());
-                        array_push($array_messages, array(
-                            'message' => __('Error combining shipping labels:',
-                                    'smart-send-logistics') . ' ' . SS_SHIPPING_WC()->get_api_handle()->getErrorString(),
-                            'type'    => 'error',
-                        ));
-                    }
-                }
-            }
+					} else {
+						array_push(
+							$array_messages,
+							array(
+								'message' => __( 'Error combining shipping labels:', 'smart-send-logistics' ) . ' ' . SS_SHIPPING_WC()->get_api_handle()->getErrorString(),
+								'type'    => 'error',
+							)
+						);
+					}
+				}
+			}
 
             if (!empty($combo_url)) {
                 $order_id_list = wp_list_pluck($array_shipment_ids, 'order_id');

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -111,36 +111,32 @@ if (!class_exists('SS_Shipping_Frontend')) :
             }
         }
 
-	    /**
-	     * Find the closest agents by address
-         *
-         * @param $carrier string | unique carrier code
-         * @param $country string | ISO3166-A2 Country code
-         * @param $postal_code string
-         * @param $city string
-         * @param $street string
-         *
-         * @return array
-	     */
-        public function find_closest_agents_by_address($carrier, $country, $postal_code, $city, $street)
-        {
-	        SS_SHIPPING_WC()->log_msg('Called "findClosestAgentByAddress" for website ' . SS_SHIPPING_WC()->get_website_url() . ' with carrier = "' . $carrier . '", country = "' . $country . '", postcode = "' . $postal_code . '", city = "' . $city . '", street = "' . $street . '"');
+		/**
+		 * Find the closest agents by address
+		 *
+		 * @param $carrier string | unique carrier code
+		 * @param $country string | ISO3166-A2 Country code
+		 * @param $postal_code string
+		 * @param $city string
+		 * @param $street string
+		 *
+		 * @return array
+		 */
+		public function find_closest_agents_by_address( $carrier, $country, $postal_code, $city, $street ) {
+			// The request and response (incl. HTTP status code and endpoint)
+			// are logged by the client's request logger.
+			if ( SS_SHIPPING_WC()->get_api_handle()->findClosestAgentByAddress( $carrier, $country, $postal_code, $city, $street ) ) {
 
-	        if (SS_SHIPPING_WC()->get_api_handle()->findClosestAgentByAddress($carrier, $country, $postal_code, $city, $street)) {
+				$ss_agents = SS_SHIPPING_WC()->get_api_handle()->getData();
 
-		        $ss_agents = SS_SHIPPING_WC()->get_api_handle()->getData();
+				// Save all of the agents in sessions.
+				WC()->session->set( 'ss_shipping_agents', $ss_agents );
 
-		        SS_SHIPPING_WC()->log_msg('Response from "findClosestAgentByAddress": ' . SS_SHIPPING_WC()->get_api_handle()->getResponseBody());
-		        // Save all of the agents in sessions
-		        WC()->session->set('ss_shipping_agents', $ss_agents);
-
-		        return $ss_agents;
-	        } else {
-		        SS_SHIPPING_WC()->log_msg( 'Response from "findClosestAgentByAddress": ' . SS_SHIPPING_WC()->get_api_handle()->getErrorString() );
-
-		        return array();
-	        }
-        }
+				return $ss_agents;
+			} else {
+				return array();
+			}
+		}
 
         /**
          * Get the formatted address to display on the frontend

--- a/smart-send-logistics/includes/lib/Smartsend/Client.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Client.php
@@ -281,7 +281,7 @@ class Client
             'success'       => (bool) $this->success,
             'error'         => $this->error,
             'start_time'    => $this->request_started_at,
-            'end_time'      => time(),
+            'end_time'      => microtime(true),
         ));
     }
 
@@ -438,7 +438,7 @@ class Client
 	    }
 
 	    // Make request
-	    $this->request_started_at = time();
+	    $this->request_started_at = microtime(true);
 	    $res = wp_remote_request($this->request_endpoint, array(
 		    'method'     => strtoupper($http_verb),
 		    'user-agent' => $this->getUserAgent(),

--- a/smart-send-logistics/includes/lib/Smartsend/Client.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Client.php
@@ -29,6 +29,8 @@ class Client
     protected $data;
     protected $links;
     protected $error;
+    private $request_logger;
+    private $request_started_at;
 
     public function __construct($api_token, $website, $demo=false)
     {
@@ -241,6 +243,49 @@ class Client
     }
 
     /**
+     * Inject a callable that is invoked after every HTTP request with the
+     * request/response data. This keeps the client free of any logging
+     * concerns - the consumer decides what (if anything) to do with the data.
+     *
+     * The callable receives a single associative array:
+     * method, endpoint, request_body, status_code, response_body, success,
+     * error, start_time, end_time.
+     *
+     * @param   callable|null $request_logger
+     * @return  void
+     */
+    public function setRequestLogger($request_logger)
+    {
+        $this->request_logger = $request_logger;
+    }
+
+    /**
+     * Invoke the injected request logger (if any) with the current
+     * request/response state.
+     *
+     * @param   string $http_verb The HTTP verb used for the request
+     * @return  void
+     */
+    private function logRequest($http_verb)
+    {
+        if (!is_callable($this->request_logger)) {
+            return;
+        }
+
+        call_user_func($this->request_logger, array(
+            'method'        => strtoupper($http_verb),
+            'endpoint'      => $this->request_endpoint,
+            'request_body'  => $this->request_body,
+            'status_code'   => $this->http_status_code,
+            'response_body' => $this->response_body,
+            'success'       => (bool) $this->success,
+            'error'         => $this->error,
+            'start_time'    => $this->request_started_at,
+            'end_time'      => time(),
+        ));
+    }
+
+    /**
      * Was the API response contain link to next page of results
      * @return  boolean
      */
@@ -269,6 +314,7 @@ class Client
         $this->http_status_code = null;
         $this->content_type = null;
         $this->debug = null;
+        $this->request_started_at = null;
     }
 
     /**
@@ -392,6 +438,7 @@ class Client
 	    }
 
 	    // Make request
+	    $this->request_started_at = time();
 	    $res = wp_remote_request($this->request_endpoint, array(
 		    'method'     => strtoupper($http_verb),
 		    'user-agent' => $this->getUserAgent(),
@@ -429,6 +476,7 @@ class Client
 
             $error->errors = array();
             $this->error = $error;
+            $this->logRequest($http_verb);
             return $this->success;
         }
 
@@ -468,6 +516,7 @@ class Client
                 $this->error = $error;
             }
 
+            $this->logRequest($http_verb);
             return $this->success;
         }
 
@@ -516,6 +565,7 @@ class Client
             $this->data = $this->response->data;
         }
 
+        $this->logRequest($http_verb);
         return $this->success;
     }
 

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -66,13 +66,6 @@ if (!class_exists('SS_Shipping_WC')) :
         protected $ss_shipping_frontend = null;
 
         /**
-         * Smart Send Shipping Order for label and tracking.
-         *
-         * @var SS_Shipping_Logger
-         */
-        protected $logger = null;
-
-        /**
          * Smart Send agent address formats
          *
          * @var array
@@ -314,36 +307,6 @@ if (!class_exists('SS_Shipping_WC')) :
         }
 
         /**
-         * Log debug message
-         */
-        public function log_msg($msg)
-        {
-            $shipping_ss_settings = $this->get_ss_shipping_settings();
-            $ss_debug = isset($shipping_ss_settings['ss_debug']) ? $shipping_ss_settings['ss_debug'] : 'yes';
-
-            if (!$this->logger) {
-                $this->logger = new SS_Shipping_Logger($ss_debug);
-            }
-
-            $this->logger->write($msg);
-        }
-
-        /**
-         * Get debug log file URL
-         */
-        public function get_log_url()
-        {
-            $shipping_ss_settings = $this->get_ss_shipping_settings();
-            $ss_debug = isset($shipping_ss_settings['ss_debug']) ? $shipping_ss_settings['ss_debug'] : 'yes';
-
-            if (!$this->logger) {
-                $this->logger = new SS_Shipping_Logger($ss_debug);
-            }
-
-            return $this->logger->get_log_url();
-        }
-
-        /**
 		 * Get Agent Address Format
 		 *
 		 * Built lazily on first call (not in the constructor): the plugin
@@ -488,7 +451,10 @@ if (!class_exists('SS_Shipping_WC')) :
                 $website_url = $this->get_website_url();
                 $this->api_handle = new \Smartsend\Api($api_token, $website_url, $demo_mode);
 
-            }
+				// Log every API request/response (incl. HTTP status code and
+				// endpoint) through the plugin's logger.
+				$this->api_handle->setRequestLogger( array( 'SS_Shipping_Logger', 'log_api_request' ) );
+			}
 
             return $this->api_handle;
         }
@@ -603,7 +569,7 @@ if (!class_exists('SS_Shipping_WC')) :
                 $error = 1;
             }
 
-            $this->log_msg($connection_msg);
+			SS_Shipping_Logger::log( $connection_msg );
 
             wp_send_json(array(
                 'message'    => $connection_msg,
@@ -658,9 +624,9 @@ if (!class_exists('SS_Shipping_WC')) :
                 // use the prices to sort the rates
                 array_multisort($prices, $available_shipping_methods);
 
-                // write to log
-                $this->log_msg('Shipping methods sorted by cost');
-            }
+				// write to log.
+				SS_Shipping_Logger::log( 'Shipping methods sorted by cost' );
+			}
 
             // return the rates
             return $available_shipping_methods;

--- a/tests/Integration/LoggerTest.php
+++ b/tests/Integration/LoggerTest.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * Tests for the static SS_Shipping_Logger (modeled on WC_Stripe_Logger):
+ * the debug setting is checked inside the class, the smart_send_logging
+ * filter can force logging on/off, errors are logged at the error level
+ * even when the debug setting is off, and API requests made through
+ * Smartsend\Client produce entries with method, endpoint and HTTP status.
+ */
+
+/**
+ * Replace the logger's WC_Logger with a spy that records every entry.
+ * Restored automatically after the test.
+ */
+function spy_on_logger(): object
+{
+    $spy = new class {
+        public array $entries = [];
+
+        public function log($level, $message, $context = []): void
+        {
+            $this->entries[] = ['level' => $level, 'message' => $message, 'context' => $context];
+        }
+    };
+
+    SS_Shipping_Logger::$logger = $spy;
+
+    remember_cleanup_callback(function (): void {
+        SS_Shipping_Logger::$logger = null;
+    });
+
+    return $spy;
+}
+
+/**
+ * Add a smart_send_logging filter callback, removed after the test.
+ */
+function with_smart_send_logging_filter(callable $callback, int $accepted_args = 3): void
+{
+    add_filter('smart_send_logging', $callback, 10, $accepted_args);
+
+    remember_cleanup_callback(function () use ($callback): void {
+        remove_filter('smart_send_logging', $callback, 10);
+    });
+}
+
+/**
+ * A Smartsend API client wired to the plugin's logger, like
+ * SS_Shipping_WC::get_api_handle() does it.
+ */
+function create_logging_api_client(string $token = 'secret-token-123'): \Smartsend\Api
+{
+    $api = new \Smartsend\Api($token, 'example.test', true);
+    $api->setRequestLogger(['SS_Shipping_Logger', 'log_api_request']);
+
+    return $api;
+}
+
+it('writes a version-stamped debug entry under the plugin log source when debug is enabled', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+
+    SS_Shipping_Logger::log('Hello from the test');
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['level'])->toBe('debug');
+    expect($spy->entries[0]['message'])->toContain('====Smart Send Version: ' . SS_SHIPPING_VERSION . '====');
+    expect($spy->entries[0]['message'])->toContain('====Start Log====');
+    expect($spy->entries[0]['message'])->toContain('Hello from the test');
+    expect($spy->entries[0]['message'])->toContain('====End Log====');
+    expect($spy->entries[0]['context'])->toBe(['source' => 'smart-send-logistics']);
+});
+
+it('adds a timing block when a start time is given', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+
+    SS_Shipping_Logger::log('Timed message', time() - 120, time());
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['message'])->toContain('====Start Log ');
+    expect($spy->entries[0]['message'])->toMatch('/====End Log .* \(2\)====/');
+});
+
+it('does not write debug entries when the debug setting is off', function () {
+    with_ss_settings(['ss_debug' => 'no']);
+    $spy = spy_on_logger();
+
+    SS_Shipping_Logger::log('Should not appear');
+
+    expect($spy->entries)->toBeEmpty();
+});
+
+it('can be force-enabled through the smart_send_logging filter', function () {
+    with_ss_settings(['ss_debug' => 'no']);
+    $spy = spy_on_logger();
+    with_smart_send_logging_filter('__return_true', 1);
+
+    SS_Shipping_Logger::log('Forced on');
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['message'])->toContain('Forced on');
+});
+
+it('can be suppressed through the smart_send_logging filter', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+    with_smart_send_logging_filter('__return_false', 1);
+
+    SS_Shipping_Logger::log('Suppressed');
+    SS_Shipping_Logger::error('Suppressed error');
+
+    expect($spy->entries)->toBeEmpty();
+});
+
+it('passes the message and level to the smart_send_logging filter', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    spy_on_logger();
+    $seen = [];
+    with_smart_send_logging_filter(function ($enabled, $message, $level) use (&$seen) {
+        $seen[] = ['enabled' => $enabled, 'message' => $message, 'level' => $level];
+
+        return $enabled;
+    });
+
+    SS_Shipping_Logger::log('A trace');
+    SS_Shipping_Logger::error('A failure');
+
+    expect($seen)->toHaveCount(2);
+    expect($seen[0])->toBe(['enabled' => true, 'message' => 'A trace', 'level' => 'debug']);
+    expect($seen[1])->toBe(['enabled' => true, 'message' => 'A failure', 'level' => 'error']);
+});
+
+it('logs errors at the error level even when the debug setting is off', function () {
+    with_ss_settings(['ss_debug' => 'no']);
+    $spy = spy_on_logger();
+
+    SS_Shipping_Logger::error('Something broke');
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['level'])->toBe('error');
+    expect($spy->entries[0]['message'])->toContain('Something broke');
+});
+
+it('logs successful API calls with method, endpoint and HTTP status', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => ss_api_shipment_data(['shipment_id' => 'log-test-shipment'])]);
+    });
+
+    create_logging_api_client()->getAuthenticatedUser();
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['level'])->toBe('debug');
+    expect($spy->entries[0]['message'])->toContain('GET https://app.smartsend.io/api/v1/demo/website/example.test/');
+    expect($spy->entries[0]['message'])->toContain('[HTTP 200]');
+    expect($spy->entries[0]['message'])->toContain('log-test-shipment');
+});
+
+it('redacts the API token from the logged endpoint', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+    mock_smart_send_api();
+
+    create_logging_api_client('secret-token-123')->getAuthenticatedUser();
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['message'])->toContain('api_token=[REDACTED]');
+    expect($spy->entries[0]['message'])->not->toContain('secret-token-123');
+});
+
+it('logs failed API calls at the error level even when the debug setting is off', function () {
+    with_ss_settings(['ss_debug' => 'no']);
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(422, ss_api_error_body('The given data was invalid.'));
+    });
+
+    create_logging_api_client()->getAuthenticatedUser();
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['level'])->toBe('error');
+    expect($spy->entries[0]['message'])->toContain('[HTTP 422]');
+    expect($spy->entries[0]['message'])->toContain('The given data was invalid.');
+});
+
+it('logs the request body of POST requests', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+    mock_smart_send_api();
+
+    create_logging_api_client()->combineLabelsForShipments(['shipment-1', 'shipment-2']);
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['message'])->toContain('POST ');
+    expect($spy->entries[0]['message'])->toContain('Request body: ');
+    expect($spy->entries[0]['message'])->toContain('shipment-1');
+});
+
+it('exposes the WooCommerce log screen URL', function () {
+    expect(SS_Shipping_Logger::get_log_url())->toContain('page=wc-status&tab=logs');
+});

--- a/tests/Integration/LoggerTest.php
+++ b/tests/Integration/LoggerTest.php
@@ -259,34 +259,6 @@ it('includes the request body of POST requests in the context', function () {
     expect($spy->entries[0]['context']['request_body'])->toContain('shipment-1');
 });
 
-it('logs and shows a checkout notice via debug_notice when WooCommerce shipping debug mode is on', function () {
-    with_ss_settings(['ss_debug' => 'yes']);
-    $spy = spy_on_logger();
-    with_option('woocommerce_shipping_debug_mode', 'yes');
-    WC()->session->set('wc_notices', null);
-    remember_cleanup_callback(function (): void {
-        WC()->session->set('wc_notices', null);
-    });
-
-    SS_Shipping_Logger::debug_notice('A shipping debug notice');
-
-    expect($spy->entries)->toHaveCount(1);
-    expect($spy->entries[0]['message'])->toBe('A shipping debug notice');
-    expect(wc_has_notice('A shipping debug notice'))->toBeTrue();
-});
-
-it('does not add a checkout notice via debug_notice when shipping debug mode is off', function () {
-    with_ss_settings(['ss_debug' => 'yes']);
-    $spy = spy_on_logger();
-    with_option('woocommerce_shipping_debug_mode', 'no');
-    WC()->session->set('wc_notices', null);
-
-    SS_Shipping_Logger::debug_notice('A hidden debug notice');
-
-    expect($spy->entries)->toHaveCount(1);
-    expect(wc_has_notice('A hidden debug notice'))->toBeFalse();
-});
-
 it('exposes the WooCommerce log screen URL', function () {
     expect(SS_Shipping_Logger::get_log_url())->toContain('page=wc-status&tab=logs');
 });

--- a/tests/Integration/LoggerTest.php
+++ b/tests/Integration/LoggerTest.php
@@ -1,11 +1,13 @@
 <?php
 
 /*
- * Tests for the static SS_Shipping_Logger (modeled on WC_Stripe_Logger):
- * the debug setting is checked inside the class, the smart_send_logging
- * filter can force logging on/off, errors are logged at the error level
- * even when the debug setting is off, and API requests made through
- * Smartsend\Client produce entries with method, endpoint and HTTP status.
+ * Tests for the static SS_Shipping_Logger, a thin wrapper around
+ * wc_get_logger(): the debug setting gates debug/info inside the class
+ * while warning/error/critical always log, the smart_send_logging filter
+ * can force logging on/off for all levels, structured data travels in the
+ * context array (rendered natively by the WC log viewer), and API requests
+ * made through Smartsend\Client produce one concise entry with method,
+ * endpoint, HTTP status and timing.
  */
 
 /**
@@ -56,7 +58,7 @@ function create_logging_api_client(string $token = 'secret-token-123'): \Smartse
     return $api;
 }
 
-it('writes a version-stamped debug entry under the plugin log source when debug is enabled', function () {
+it('writes a debug entry with the plugin version and source in the context when debug is enabled', function () {
     with_ss_settings(['ss_debug' => 'yes']);
     $spy = spy_on_logger();
 
@@ -64,31 +66,44 @@ it('writes a version-stamped debug entry under the plugin log source when debug 
 
     expect($spy->entries)->toHaveCount(1);
     expect($spy->entries[0]['level'])->toBe('debug');
-    expect($spy->entries[0]['message'])->toContain('====Smart Send Version: ' . SS_SHIPPING_VERSION . '====');
-    expect($spy->entries[0]['message'])->toContain('====Start Log====');
-    expect($spy->entries[0]['message'])->toContain('Hello from the test');
-    expect($spy->entries[0]['message'])->toContain('====End Log====');
-    expect($spy->entries[0]['context'])->toBe(['source' => 'smart-send-logistics']);
+    expect($spy->entries[0]['message'])->toBe('Hello from the test');
+    expect($spy->entries[0]['context']['source'])->toBe('smart-send-logistics');
+    expect($spy->entries[0]['context']['version'])->toBe(SS_SHIPPING_VERSION);
 });
 
-it('adds a timing block when a start time is given', function () {
+it('merges caller-provided context into the entry', function () {
     with_ss_settings(['ss_debug' => 'yes']);
     $spy = spy_on_logger();
 
-    SS_Shipping_Logger::log('Timed message', time() - 120, time());
+    SS_Shipping_Logger::debug('With context', ['order_id' => 42]);
 
     expect($spy->entries)->toHaveCount(1);
-    expect($spy->entries[0]['message'])->toContain('====Start Log ');
-    expect($spy->entries[0]['message'])->toMatch('/====End Log .* \(2\)====/');
+    expect($spy->entries[0]['context']['order_id'])->toBe(42);
+    expect($spy->entries[0]['context']['source'])->toBe('smart-send-logistics');
 });
 
-it('does not write debug entries when the debug setting is off', function () {
+it('gates debug and info on the debug setting but always logs warning, error and critical', function () {
     with_ss_settings(['ss_debug' => 'no']);
     $spy = spy_on_logger();
 
-    SS_Shipping_Logger::log('Should not appear');
+    SS_Shipping_Logger::log('gated');
+    SS_Shipping_Logger::debug('gated');
+    SS_Shipping_Logger::info('gated');
+    SS_Shipping_Logger::warning('a warning');
+    SS_Shipping_Logger::error('an error');
+    SS_Shipping_Logger::critical('a critical failure');
 
-    expect($spy->entries)->toBeEmpty();
+    expect(array_column($spy->entries, 'level'))->toBe(['warning', 'error', 'critical']);
+});
+
+it('logs debug and info when the debug setting is on', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+
+    SS_Shipping_Logger::debug('a trace');
+    SS_Shipping_Logger::info('an info line');
+
+    expect(array_column($spy->entries, 'level'))->toBe(['debug', 'info']);
 });
 
 it('can be force-enabled through the smart_send_logging filter', function () {
@@ -99,16 +114,17 @@ it('can be force-enabled through the smart_send_logging filter', function () {
     SS_Shipping_Logger::log('Forced on');
 
     expect($spy->entries)->toHaveCount(1);
-    expect($spy->entries[0]['message'])->toContain('Forced on');
+    expect($spy->entries[0]['message'])->toBe('Forced on');
 });
 
-it('can be suppressed through the smart_send_logging filter', function () {
+it('can be suppressed through the smart_send_logging filter for all levels', function () {
     with_ss_settings(['ss_debug' => 'yes']);
     $spy = spy_on_logger();
     with_smart_send_logging_filter('__return_false', 1);
 
     SS_Shipping_Logger::log('Suppressed');
     SS_Shipping_Logger::error('Suppressed error');
+    SS_Shipping_Logger::critical('Suppressed critical');
 
     expect($spy->entries)->toBeEmpty();
 });
@@ -139,10 +155,10 @@ it('logs errors at the error level even when the debug setting is off', function
 
     expect($spy->entries)->toHaveCount(1);
     expect($spy->entries[0]['level'])->toBe('error');
-    expect($spy->entries[0]['message'])->toContain('Something broke');
+    expect($spy->entries[0]['message'])->toBe('Something broke');
 });
 
-it('logs successful API calls with method, endpoint and HTTP status', function () {
+it('logs successful API calls as one concise line with method, path, HTTP status and timing', function () {
     with_ss_settings(['ss_debug' => 'yes']);
     $spy = spy_on_logger();
     mock_smart_send_api(function () {
@@ -153,12 +169,17 @@ it('logs successful API calls with method, endpoint and HTTP status', function (
 
     expect($spy->entries)->toHaveCount(1);
     expect($spy->entries[0]['level'])->toBe('debug');
-    expect($spy->entries[0]['message'])->toContain('GET https://app.smartsend.io/api/v1/demo/website/example.test/');
-    expect($spy->entries[0]['message'])->toContain('[HTTP 200]');
-    expect($spy->entries[0]['message'])->toContain('log-test-shipment');
+    expect($spy->entries[0]['message'])->toMatch('#^GET /api/v1/demo/website/example\.test/ → 200 \(\d+ms\)$#u');
+
+    $context = $spy->entries[0]['context'];
+    expect($context['source'])->toBe('smart-send-logistics');
+    expect($context['status_code'])->toBe(200);
+    expect($context['endpoint'])->toContain('https://app.smartsend.io/api/v1/demo/website/example.test/');
+    expect($context['duration_ms'])->toBeInt();
+    expect($context['response_body'])->toContain('log-test-shipment');
 });
 
-it('redacts the API token from the logged endpoint', function () {
+it('redacts the API token in both the message and the context', function () {
     with_ss_settings(['ss_debug' => 'yes']);
     $spy = spy_on_logger();
     mock_smart_send_api();
@@ -166,11 +187,12 @@ it('redacts the API token from the logged endpoint', function () {
     create_logging_api_client('secret-token-123')->getAuthenticatedUser();
 
     expect($spy->entries)->toHaveCount(1);
-    expect($spy->entries[0]['message'])->toContain('api_token=[REDACTED]');
     expect($spy->entries[0]['message'])->not->toContain('secret-token-123');
+    expect($spy->entries[0]['context']['endpoint'])->toContain('api_token=[REDACTED]');
+    expect(json_encode($spy->entries[0]['context']))->not->toContain('secret-token-123');
 });
 
-it('logs failed API calls at the error level even when the debug setting is off', function () {
+it('logs failed API calls at the error level with the error detail in context even when debug is off', function () {
     with_ss_settings(['ss_debug' => 'no']);
     $spy = spy_on_logger();
     mock_smart_send_api(function () {
@@ -181,11 +203,15 @@ it('logs failed API calls at the error level even when the debug setting is off'
 
     expect($spy->entries)->toHaveCount(1);
     expect($spy->entries[0]['level'])->toBe('error');
-    expect($spy->entries[0]['message'])->toContain('[HTTP 422]');
-    expect($spy->entries[0]['message'])->toContain('The given data was invalid.');
+    expect($spy->entries[0]['message'])->toContain('→ 422');
+
+    $context = $spy->entries[0]['context'];
+    expect($context['status_code'])->toBe(422);
+    expect($context['error'])->toContain('The given data was invalid.');
+    expect($context['response_body'])->toContain('The given data was invalid.');
 });
 
-it('logs the request body of POST requests', function () {
+it('includes the request body of POST requests in the context', function () {
     with_ss_settings(['ss_debug' => 'yes']);
     $spy = spy_on_logger();
     mock_smart_send_api();
@@ -193,9 +219,36 @@ it('logs the request body of POST requests', function () {
     create_logging_api_client()->combineLabelsForShipments(['shipment-1', 'shipment-2']);
 
     expect($spy->entries)->toHaveCount(1);
-    expect($spy->entries[0]['message'])->toContain('POST ');
-    expect($spy->entries[0]['message'])->toContain('Request body: ');
-    expect($spy->entries[0]['message'])->toContain('shipment-1');
+    expect($spy->entries[0]['message'])->toStartWith('POST ');
+    expect($spy->entries[0]['context']['request_body'])->toContain('shipment-1');
+});
+
+it('logs and shows a checkout notice via debug_notice when WooCommerce shipping debug mode is on', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    WC()->session->set('wc_notices', null);
+    remember_cleanup_callback(function (): void {
+        WC()->session->set('wc_notices', null);
+    });
+
+    SS_Shipping_Logger::debug_notice('A shipping debug notice');
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['message'])->toBe('A shipping debug notice');
+    expect(wc_has_notice('A shipping debug notice'))->toBeTrue();
+});
+
+it('does not add a checkout notice via debug_notice when shipping debug mode is off', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+    with_option('woocommerce_shipping_debug_mode', 'no');
+    WC()->session->set('wc_notices', null);
+
+    SS_Shipping_Logger::debug_notice('A hidden debug notice');
+
+    expect($spy->entries)->toHaveCount(1);
+    expect(wc_has_notice('A hidden debug notice'))->toBeFalse();
 });
 
 it('exposes the WooCommerce log screen URL', function () {

--- a/tests/Integration/LoggerTest.php
+++ b/tests/Integration/LoggerTest.php
@@ -4,7 +4,7 @@
  * Tests for the static SS_Shipping_Logger, a thin wrapper around
  * wc_get_logger(): the debug setting gates debug/info inside the class
  * while warning/error/critical always log, the smart_send_logging filter
- * can force logging on/off for all levels, structured data travels in the
+ * can rewrite or suppress entries at all levels, structured data travels in the
  * context array (rendered natively by the WC log viewer), and API requests
  * made through Smartsend\Client produce one concise entry with method,
  * endpoint, HTTP status and timing.
@@ -22,6 +22,15 @@ function spy_on_logger(): object
         public function log($level, $message, $context = []): void
         {
             $this->entries[] = ['level' => $level, 'message' => $message, 'context' => $context];
+        }
+
+        /**
+         * The logger dispatches to wc_get_logger()'s level wrapper methods
+         * (debug(), error(), ...); record them like log() calls.
+         */
+        public function __call(string $level, array $args): void
+        {
+            $this->log($level, $args[0], $args[1] ?? []);
         }
     };
 
@@ -106,18 +115,7 @@ it('logs debug and info when the debug setting is on', function () {
     expect(array_column($spy->entries, 'level'))->toBe(['debug', 'info']);
 });
 
-it('can be force-enabled through the smart_send_logging filter', function () {
-    with_ss_settings(['ss_debug' => 'no']);
-    $spy = spy_on_logger();
-    with_smart_send_logging_filter('__return_true', 1);
-
-    SS_Shipping_Logger::log('Forced on');
-
-    expect($spy->entries)->toHaveCount(1);
-    expect($spy->entries[0]['message'])->toBe('Forced on');
-});
-
-it('can be suppressed through the smart_send_logging filter for all levels', function () {
+it('can be suppressed by returning false from the smart_send_logging filter', function () {
     with_ss_settings(['ss_debug' => 'yes']);
     $spy = spy_on_logger();
     with_smart_send_logging_filter('__return_false', 1);
@@ -129,22 +127,60 @@ it('can be suppressed through the smart_send_logging filter for all levels', fun
     expect($spy->entries)->toBeEmpty();
 });
 
-it('passes the message and level to the smart_send_logging filter', function () {
+it('can be suppressed by returning null from the smart_send_logging filter', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+    with_smart_send_logging_filter('__return_null', 1);
+
+    SS_Shipping_Logger::log('Suppressed');
+    SS_Shipping_Logger::error('Suppressed error');
+
+    expect($spy->entries)->toBeEmpty();
+});
+
+it('can rewrite the message through the smart_send_logging filter', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+    with_smart_send_logging_filter(function ($message) {
+        return '[rewritten] ' . $message;
+    }, 1);
+
+    SS_Shipping_Logger::log('A trace');
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['message'])->toBe('[rewritten] A trace');
+});
+
+it('does not suppress the message "0"', function () {
+    with_ss_settings(['ss_debug' => 'yes']);
+    $spy = spy_on_logger();
+
+    SS_Shipping_Logger::log('0');
+
+    expect($spy->entries)->toHaveCount(1);
+    expect($spy->entries[0]['message'])->toBe('0');
+});
+
+it('passes the message, level and context to the smart_send_logging filter', function () {
     with_ss_settings(['ss_debug' => 'yes']);
     spy_on_logger();
     $seen = [];
-    with_smart_send_logging_filter(function ($enabled, $message, $level) use (&$seen) {
-        $seen[] = ['enabled' => $enabled, 'message' => $message, 'level' => $level];
+    with_smart_send_logging_filter(function ($message, $level, $context) use (&$seen) {
+        $seen[] = ['message' => $message, 'level' => $level, 'context' => $context];
 
-        return $enabled;
+        return $message;
     });
 
-    SS_Shipping_Logger::log('A trace');
+    SS_Shipping_Logger::log('A trace', ['order_id' => 7]);
     SS_Shipping_Logger::error('A failure');
 
     expect($seen)->toHaveCount(2);
-    expect($seen[0])->toBe(['enabled' => true, 'message' => 'A trace', 'level' => 'debug']);
-    expect($seen[1])->toBe(['enabled' => true, 'message' => 'A failure', 'level' => 'error']);
+    expect($seen[0]['message'])->toBe('A trace');
+    expect($seen[0]['level'])->toBe('debug');
+    expect($seen[0]['context']['order_id'])->toBe(7);
+    expect($seen[0]['context']['source'])->toBe('smart-send-logistics');
+    expect($seen[1]['message'])->toBe('A failure');
+    expect($seen[1]['level'])->toBe('error');
 });
 
 it('logs errors at the error level even when the debug setting is off', function () {


### PR DESCRIPTION
## Summary

Implements the debug-log refactor from #22 as the first PR of the v9 Phase 2 stack: one static `SS_Shipping_Logger` now owns all logging concerns — the enabled/disabled gate, the `smart_send_logging` filter, the single WC log source `smart-send-logistics` (private `LOG_SOURCE` constant), and API-token redaction — and delegates the actual writing to WooCommerce's native logger.

**Scope:** the logger's scope is purely the WC log — levels, filter, redaction. The WooCommerce shipping debug-mode checkout notice is explicitly **out of scope**: it is a WC-core surface with a different audience, handled by a dedicated class introduced upstack in #87 (issue #5). Part of the wider "Refactor what we log and where" effort tracked in #92.

## Design

**Thin wrapper over `wc_get_logger()`** (reworked per review to follow the [WooCommerce logging best practices](https://developer.woocommerce.com/docs/best-practices/data-management/logging/) instead of the Stripe-style banner format):
- `SS_Shipping_Logger::debug()/info()/warning()/error()/critical( $message, $context = array() )` dispatch to `wc_get_logger()`'s level wrapper methods (`$logger->debug()`, `$logger->error()`, ...) per the best-practices doc, after validating the level against the five-level whitelist. `log()` is an alias of `debug()` for the existing call sites.
- **Wrapper-vs-direct rationale:** the class deliberately adds nothing WooCommerce already does — no custom format, file handling, or retention. It exists only as the single home for the plugin's debug gate, the `smart_send_logging` filter, the source constant and token redaction; WC core handles levels, retention and context rendering in the log viewer.
- Messages are concise single lines; structured data (plugin `version`, `endpoint`, `status_code`, request/response bodies, `duration_ms`) travels in the `$context` array alongside `'source' => 'smart-send-logistics'`, which the WC log viewer renders natively and core retention applies per source.
- **Gating:** `debug` and `info` are gated on the plugin's `ss_debug` setting *inside* the class; `warning`/`error`/`critical` always log.
- **Filter:** `smart_send_logging` is a dual-purpose message filter — `$message = apply_filters( 'smart_send_logging', $message, $level, $context )`. Returning a modified string rewrites the entry; returning `null` or `false` (strict check, so a literal `"0"` message survives) suppresses it. It applies to all levels; the debug-setting gate stays separate and internal.

**Seam chosen for HTTP logging:** an injected callable on the API client. `Smartsend\Client` gains `setRequestLogger( callable )` and invokes it once per HTTP request (on every exit path of `makeRequest()`) with a plain array: method, endpoint, request body, HTTP status code, response body, success flag, error, `microtime(true)` start/end. The `includes/lib/Smartsend/` layer stays WordPress-free — it knows nothing about logging or WordPress; `SS_Shipping_WC::get_api_handle()` wires the callable to `SS_Shipping_Logger::log_api_request()`, which emits one concise line per request:

```
POST /api/v1/demo/website/example.test/shipments → 422 (312ms)
```

with the full redacted endpoint, status code, duration, request/response bodies and error detail in context. The **`api_token` query parameter is redacted** before the endpoint reaches message or context.

## Deliberate behaviour changes

- **API failures are logged at the `error` level even when the debug setting is off.** Previously a failed API call left no trace unless debug logging was enabled.
- **API request/response entries now include the HTTP status code, endpoint and timing.** The old per-call-site lines (`Called "createShipmentAndLabels" with arguments: ...` / `Response from ... :`) in `SS_Shipping_Shipment`, `SS_Shipping_WC_Order` and `SS_Shipping_Frontend` are removed — the client-level hook logs every request/response once, consistently, instead.
- Log source name changed from `Smart_Send` to `smart-send-logistics`, and entries use proper PSR-3-style WC levels instead of `WC_Logger::add()`'s single level.

No characterization test asserted the old log lines, so none needed updating.

## Call sites migrated

All `SS_SHIPPING_WC()->log_msg()` / `->get_log_url()` calls (the wrapper methods, the `$logger` property and the constructor-flag pattern are deleted):
- `smart-send-logistics.php` — test-connection message, sort-by-cost trace, `get_api_handle()` wiring
- `includes/class-ss-shipping-wc-method.php` — rate handling/availability traces, settings-page log URL (`SS_Shipping_Logger::get_log_url()`)
- `includes/class-ss-shipping-wc-order.php` — agent found/not found, failed order load; request/response lines replaced by the client hook
- `includes/class-ss-shipping-shipment.php`, `includes/frontend/class-ss-shipping-frontend.php` — request/response lines replaced by the client hook

Every baselined line touched (and the neighbours whose baseline signatures were invalidated) was brought fully up to WPCS.

## Tests

`tests/Integration/LoggerTest.php` (15 tests) using the suite factories and `pre_http_request` mocks:
- context carries source + plugin version; caller context is merged
- debug/info gated on the setting, warning/error/critical always log
- `smart_send_logging` filter: suppress via `false`, suppress via `null`, message rewrite, `"0"` not suppressed, and the `($message, $level, $context)` payload
- mocked API calls produce one concise line with method, path, HTTP status and timing, full detail in context; failures log at `error` with debug off; token redacted in **both** message and context; POST request body in context

`composer test:integration` — 70 passed (265 assertions). `vendor/bin/phpcs` and `composer phpcs:compat` — clean.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)