### PR TITLE
Refactor admin notices to transient-backed component

### DIFF
--- a/smart-send-logistics/includes/class-ss-shipping-admin-notices.php
+++ b/smart-send-logistics/includes/class-ss-shipping-admin-notices.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Smart Send admin notices.
+ *
+ * @package SmartSendLogistics
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Transient-backed one-time admin notices ("flash messages").
+ *
+ * Owns the full lifecycle: push notices during an admin action, mark the
+ * post-action redirect URL with a query parameter, render the pending
+ * notices exactly once on the next page load, and clear them.
+ *
+ * Storage is the WordPress Transients API keyed per user, so notices are
+ * only ever shown to the user who triggered the action. Retrieval is gated
+ * on the marker query parameter: admin requests that did not just perform a
+ * Smart Send action never touch the transient.
+ *
+ * Rendering uses the plain `admin_notices` hook rather than WooCommerce's
+ * `WC_Admin_Notices`: that API stores notices site-wide in a single option
+ * and keeps them until dismissed, which does not fit per-user render-once
+ * flash messages.
+ */
+class SS_Shipping_Admin_Notices {
+
+	/**
+	 * Query parameter added to post-action redirect URLs. Pending notices
+	 * are only looked up when this parameter is present on the request.
+	 */
+	const QUERY_ARG = 'ss_shipping_notices';
+
+	/**
+	 * Prefix for the per-user transient key holding the pending notices.
+	 */
+	const TRANSIENT_PREFIX = 'ss_shipping_notices_';
+
+	/**
+	 * How long pending notices are kept before the transient expires.
+	 * A safety net for notices that are pushed but never rendered
+	 * (e.g. the user closes the tab before the redirect completes).
+	 */
+	const EXPIRATION = HOUR_IN_SECONDS;
+
+	/**
+	 * Hook the renderer into the admin.
+	 */
+	public function init_hooks() {
+		add_action( 'admin_notices', array( $this, 'maybe_render' ) );
+	}
+
+	/**
+	 * Queue notices to be shown once to a user on their next marked request.
+	 *
+	 * @param array<array{message: string, type: string, dismissible?: bool}> $messages Notices to queue.
+	 * @param int|null                                                        $user_id  User to queue for. Defaults to the current user.
+	 */
+	public function push( array $messages, $user_id = null ) {
+		if ( empty( $messages ) ) {
+			return;
+		}
+
+		$pending = $this->get_pending( $user_id );
+
+		set_transient(
+			$this->get_transient_key( $user_id ),
+			array_merge( $pending, array_values( $messages ) ),
+			self::EXPIRATION
+		);
+	}
+
+	/**
+	 * Add the marker query parameter to a redirect URL so the next request
+	 * knows to look for pending notices.
+	 *
+	 * @param string $url Redirect URL.
+	 * @return string
+	 */
+	public function add_notices_query_arg( $url ) {
+		return add_query_arg( self::QUERY_ARG, '1', $url );
+	}
+
+	/**
+	 * Render the current user's pending notices when the marker query
+	 * parameter is present, then clear them.
+	 *
+	 * Without the marker parameter this is a no-op: no transient lookup
+	 * happens on unrelated admin requests.
+	 */
+	public function maybe_render() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- presence check of a display-only marker; no action is taken based on it.
+		if ( empty( $_GET[ self::QUERY_ARG ] ) ) {
+			return;
+		}
+
+		$messages = $this->get_pending();
+
+		if ( empty( $messages ) ) {
+			return;
+		}
+
+		$this->print_notices( $messages );
+
+		$this->clear();
+	}
+
+	/**
+	 * Get the pending notices for a user.
+	 *
+	 * @param int|null $user_id User to read for. Defaults to the current user.
+	 * @return array<array{message: string, type: string, dismissible?: bool}>
+	 */
+	public function get_pending( $user_id = null ) {
+		$messages = get_transient( $this->get_transient_key( $user_id ) );
+
+		return is_array( $messages ) ? $messages : array();
+	}
+
+	/**
+	 * Delete the pending notices for a user.
+	 *
+	 * @param int|null $user_id User to clear for. Defaults to the current user.
+	 */
+	public function clear( $user_id = null ) {
+		delete_transient( $this->get_transient_key( $user_id ) );
+	}
+
+	/**
+	 * Print the given notices as admin notice markup.
+	 *
+	 * @param array<array{message: string, type: string, dismissible?: bool}> $messages Notices to print.
+	 */
+	protected function print_notices( array $messages ) {
+		foreach ( $messages as $message ) {
+			switch ( isset( $message['type'] ) ? $message['type'] : '' ) {
+				case 'error':
+					$type = 'error';
+					break;
+				case 'success':
+					$type = 'success';
+					break;
+				default:
+					$type = 'warning';
+			}
+
+			printf(
+				'<div class="notice notice-%1$s %2$s"><p>%3$s</p></div>',
+				esc_attr( $type ), // One of info/warning/error/success.
+				( isset( $message['dismissible'] ) && $message['dismissible'] ) ? 'is-dismissible' : '',
+				wp_kses_post( $message['message'] )
+			);
+		}
+	}
+
+	/**
+	 * Get the transient key holding a user's pending notices.
+	 *
+	 * @param int|null $user_id User id. Defaults to the current user.
+	 * @return string
+	 */
+	protected function get_transient_key( $user_id = null ) {
+		if ( null === $user_id ) {
+			$user_id = get_current_user_id();
+		}
+
+		return self::TRANSIENT_PREFIX . $user_id;
+	}
+}

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -17,20 +17,35 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableControlle
 
 if (!class_exists('SS_Shipping_WC_Order')) :
 
-    class SS_Shipping_WC_Order
-    {
-        const ADMIN_FLASH_MESSAGE_OPTION_KEY = '_ss_shipping_bulk_action_confirmation';
+	class SS_Shipping_WC_Order {
 
-        protected $label_prefix = 'smart-send-label-';
+		protected $label_prefix = 'smart-send-label-';
 
-        /**
-         * Init and hook in the integration.
-         */
-        public function __construct()
-        {
-            $this->define_constants();
-            $this->init_hooks();
-        }
+		/**
+		 * Admin notices component used to flash one-time notices after
+		 * label-generation actions.
+		 *
+		 * @var SS_Shipping_Admin_Notices
+		 */
+		protected $admin_notices;
+
+		/**
+		 * Init and hook in the integration.
+		 */
+		public function __construct() {
+			$this->admin_notices = new SS_Shipping_Admin_Notices();
+			$this->define_constants();
+			$this->init_hooks();
+		}
+
+		/**
+		 * Get the admin notices component.
+		 *
+		 * @return SS_Shipping_Admin_Notices
+		 */
+		public function get_admin_notices() {
+			return $this->admin_notices;
+		}
 
         /**
          * Define constants
@@ -65,12 +80,12 @@ if (!class_exists('SS_Shipping_WC_Order')) :
                     array($this, 'woocommerce_subscriptions_renewal_order_meta_query'), 10);
             }
 
-            // add bulk actions to the Orders screen table bulk action drop-downs
-            $this->register_bulk_order_actions();
+			// Add bulk actions to the Orders screen table bulk action drop-downs.
+			$this->register_bulk_order_actions();
 
-            // display admin notices for bulk actions
-            add_action('admin_notices', array($this, 'render_admin_messages'));
-        }
+			// Display pending admin notices pushed by bulk actions.
+			$this->admin_notices->init_hooks();
+		}
 
         /**
          * Register bulk order actions.
@@ -219,11 +234,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 
                 }
 
-                $this->add_admin_flash_messages(get_current_user_id(), $array_messages);
-            }
+				if ( ! empty( $array_messages ) ) {
+					$this->admin_notices->push( $array_messages );
+					$sendback = $this->admin_notices->add_notices_query_arg( $sendback );
+				}
+			}
 
-            return $sendback;
-        }
+			return $sendback;
+		}
 
         /**
          * Add the meta box for shipment info on the order page
@@ -1228,175 +1246,37 @@ if (!class_exists('SS_Shipping_WC_Order')) :
             return hash('sha256', $shipment_ids_str);
         }
 
-        /**
-         * Display messages on order view screen.
-         */
-        public function render_admin_messages($current_screen = null)
-        {
-            if (! $current_screen instanceof WP_Screen) {
-                $current_screen = get_current_screen();
-            }
+		/**
+		 * Get an orders total weight.
+		 *
+		 * @param WC_Order $order The order.
+		 * @return float weight in kg
+		 */
+		// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- pre-existing method name, kept for backwards compatibility.
+		protected function getOrderWeight( $order ) {
+			$weight_total = 0;
 
-//            if (! isset($current_screen->id) || ! in_array($current_screen->id, array('shop_order', 'edit-shop_order'), true)) {
-//                return;
-//            }
+			// Get order item specific data.
+			$ordered_items = $order->get_items();
+			if ( ! empty( $ordered_items ) ) {
+				foreach ( $ordered_items as $key => $item ) {
+					$product = wc_get_product( $item['product_id'] );
+					if ( ! empty( $item['variation_id'] ) ) {
+						$product_variation = wc_get_product( $item['variation_id'] );
+					} else {
+						$product_variation = $product;
+					}
 
-            $messages = $this->get_admin_flash_messages(get_current_user_id());
-
-            if (empty($messages)) {
-                return;
-            }
-
-            // remove first element from array and verify if it is the user id
-            //$user_id = array_shift($bulk_action_message_opt);
-            //if (get_current_user_id() !== (int)$user_id) {
-            //    return;
-            //}
-
-            $this->print_admin_flash_messages($messages);
-
-            $this->set_admin_flash_messages(get_current_user_id(), []);
-        }
-
-        /*
-         * Get an orders total weight
-         *
-         * @param WC_Order | $order
-         * @return float weight in kg
-         */
-        protected function getOrderWeight($order)
-        {
-            $weight_total = 0;
-
-            // Get order item specific data
-            $ordered_items = $order->get_items();
-            if (!empty($ordered_items)) {
-                foreach ($ordered_items as $key => $item) {
-                    $product = wc_get_product($item['product_id']);
-                    if (!empty($item['variation_id'])) {
-                        $product_variation = wc_get_product($item['variation_id']);
-                    } else {
-                        $product_variation = $product;
-                    }
-
-                    if ($product_variation) {//null|false if unable to load product
-                        $product_weight = round(wc_get_weight($product_variation->get_weight(), 'kg'), 2);
-                        if ($product_weight) {
-                            $weight_total += ($item['qty'] * $product_weight);
-                        }
-                    }
-                }
-            }
-            return $weight_total;
-        }
-
-        /**
-         * Display messages on order view screen.
-         *
-         * @see https://webprogramo.com/admin-notices-after-a-page-refresh-on-wordpress/1183/
-         */
-        protected function print_admin_flash_messages(array $messages)
-        {
-            foreach ($messages as $message) {
-                switch (wp_kses_post($message['type'])) {
-                    case 'error':
-                        $type = 'error';
-                        break;
-                    case 'success':
-                        $type = 'success';
-                        break;
-                    default:
-                        $type = 'warning';
-                }
-
-                printf('<div class="notice notice-%1$s %2$s"><p>%3$s</p></div>',
-                    $type, // info/warning/error/success
-                    ($message['dismissible'] ?? false) ? 'is-dismissible' : '',
-                    wp_kses_post($message['message'])
-                );
-            }
-        }
-
-        /**
-         * This is the options key used to store the flash messages.
-         *
-         * The option can contain multiple bags. This could cause race condition issues
-         * if multiple users are performing admin actions at the same time because they
-         * all read and write to the same option key.
-         *
-         * @return string
-         */
-        protected function get_admin_flash_message_option_key()
-        {
-            return self::ADMIN_FLASH_MESSAGE_OPTION_KEY;
-        }
-
-        protected function get_admin_flash_bags()
-        {
-            return get_option($this->get_admin_flash_message_option_key(), array());
-        }
-
-        protected function set_admin_flash_bags(array $bags)
-        {
-            update_option($this->get_admin_flash_message_option_key(), $bags);
-        }
-
-        protected function get_admin_flash_messages(string $bag)
-        {
-            return $this->get_admin_flash_bags()[$bag] ?? [];
-        }
-
-        /**
-         * @param string $bag is the option key
-         * @param array<array{message: string, type: string, dismissible: bool}> $messages
-         * @return void
-         */
-        protected function set_admin_flash_messages(string $bag, array $messages)
-        {
-            $bags = $this->get_admin_flash_bags();
-
-            $bags[$bag] = $messages;
-
-            $this->set_admin_flash_bags($bags);
-        }
-
-        /**
-         * Add a flash notice to {prefix}options table until a full page refresh is done
-         *
-         * @param string $bag is the option key
-         * @param string $message our notice message
-         * @param string $type This can be "info", "warning", "error" or "success", "warning" as default
-         * @param boolean $dismissible set this to TRUE to add is-dismissible functionality to your notice
-         * @return void
-         */
-
-        protected function add_admin_flash_message(string $bag, $message, $type = "warning", $dismissible = true)
-        {
-            $this->add_admin_flash_messages($bag, array(array(
-                'message' => $message,
-                'type' => $type,
-                'dismissible' => $dismissible
-            )));
-        }
-
-        /**
-         * @param string $bag is the option key
-         * @param array<array{message: string, type: string, dismissible: bool}> $messages
-         * @return void
-         */
-
-        protected function add_admin_flash_messages(string $bag, array $messages)
-        {
-            $bags = $this->get_admin_flash_bags();
-
-            if (! is_array($bags[$bag])) {
-                $bags[$bag] = [];
-            }
-
-            array_push( $bags[$bag], ...$messages)  ;
-
-            $this->set_admin_flash_bags($bags);
-        }
-    }
+					if ( $product_variation ) { // null|false if unable to load product.
+						$product_weight = round( wc_get_weight( $product_variation->get_weight(), 'kg' ), 2 );
+						if ( $product_weight ) {
+							$weight_total += ( $item['qty'] * $product_weight );
+						}
+					}
+				}
+			}
+			return $weight_total;
+		}
+	}
 
 endif;

--- a/tests/Integration/AdminNoticesTest.php
+++ b/tests/Integration/AdminNoticesTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * Tests for SS_Shipping_Admin_Notices: transient-backed one-time admin
+ * notices pushed after label-generation actions. Covers the full lifecycle
+ * (push → marked redirect → rendered once → cleared), the query-parameter
+ * gate that prevents transient lookups on unrelated admin requests, and
+ * per-user isolation of pending notices.
+ */
+
+/**
+ * A clean notices component for the current user; pending notices and the
+ * marker query parameter are wiped again after the test.
+ */
+function clean_admin_notices(): SS_Shipping_Admin_Notices
+{
+    $notices = SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_admin_notices();
+
+    $notices->clear();
+
+    remember_cleanup_callback(function () use ($notices): void {
+        $notices->clear();
+        unset($_GET[SS_Shipping_Admin_Notices::QUERY_ARG]);
+    });
+
+    return $notices;
+}
+
+it('registers the renderer on the admin_notices hook', function () {
+    $notices = SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_admin_notices();
+
+    expect(has_action('admin_notices', [$notices, 'maybe_render']))->not->toBeFalse();
+});
+
+it('stores pushed notices in a per-user transient', function () {
+    $notices = clean_admin_notices();
+
+    $notices->push([['message' => 'First notice', 'type' => 'success']]);
+    $notices->push([['message' => 'Second notice', 'type' => 'error']]);
+
+    $stored = get_transient(SS_Shipping_Admin_Notices::TRANSIENT_PREFIX . get_current_user_id());
+
+    expect($stored)->toBe([
+        ['message' => 'First notice', 'type' => 'success'],
+        ['message' => 'Second notice', 'type' => 'error'],
+    ]);
+});
+
+it('does not create a transient when pushing an empty message list', function () {
+    $notices = clean_admin_notices();
+
+    $notices->push([]);
+
+    expect(get_transient(SS_Shipping_Admin_Notices::TRANSIENT_PREFIX . get_current_user_id()))->toBeFalse();
+});
+
+it('adds the marker query parameter to redirect URLs', function () {
+    $notices = SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_admin_notices();
+
+    expect($notices->add_notices_query_arg('/wp-admin/edit.php'))
+        ->toBe('/wp-admin/edit.php?ss_shipping_notices=1');
+    expect($notices->add_notices_query_arg('/wp-admin/edit.php?post_type=shop_order'))
+        ->toBe('/wp-admin/edit.php?post_type=shop_order&ss_shipping_notices=1');
+});
+
+it('renders pending notices exactly once and clears them when the marker parameter is present', function () {
+    $notices = clean_admin_notices();
+
+    $notices->push([
+        ['message' => 'Label created <a href="https://example.test/label.pdf">Download</a>', 'type' => 'success'],
+        ['message' => 'Order #2: something failed', 'type' => 'error', 'dismissible' => true],
+        ['message' => 'Heads up', 'type' => 'unknown-type'],
+    ]);
+
+    $_GET[SS_Shipping_Admin_Notices::QUERY_ARG] = '1';
+
+    ob_start();
+    $notices->maybe_render();
+    $output = ob_get_clean();
+
+    expect($output)->toContain('notice-success')
+        ->toContain('<a href="https://example.test/label.pdf">Download</a>')
+        ->toContain('notice-error')
+        ->toContain('is-dismissible')
+        // Unknown types fall back to a warning notice.
+        ->toContain('notice-warning');
+
+    // The transient is gone and a second render outputs nothing.
+    expect(get_transient(SS_Shipping_Admin_Notices::TRANSIENT_PREFIX . get_current_user_id()))->toBeFalse();
+
+    ob_start();
+    $notices->maybe_render();
+    expect(ob_get_clean())->toBe('');
+});
+
+it('does not look up pending notices without the marker parameter', function () {
+    $notices = clean_admin_notices();
+
+    $notices->push([['message' => 'Pending notice', 'type' => 'success']]);
+
+    unset($_GET[SS_Shipping_Admin_Notices::QUERY_ARG]);
+
+    // get_transient() runs the pre_transient_{name} filter on every lookup;
+    // count invocations to prove maybe_render() never touches storage.
+    $lookups = 0;
+    $counter = function ($pre) use (&$lookups) {
+        $lookups++;
+
+        return $pre;
+    };
+    $filter = 'pre_transient_' . SS_Shipping_Admin_Notices::TRANSIENT_PREFIX . get_current_user_id();
+    add_filter($filter, $counter);
+    remember_cleanup_callback(function () use ($filter, $counter): void {
+        remove_filter($filter, $counter);
+    });
+
+    ob_start();
+    $notices->maybe_render();
+    $output = ob_get_clean();
+
+    expect($output)->toBe('')
+        ->and($lookups)->toBe(0);
+
+    // The notices stay pending for the marked request.
+    expect($notices->get_pending())->toHaveCount(1);
+});
+
+it('keeps notices isolated per user', function () {
+    $notices = clean_admin_notices();
+
+    $user_a = get_current_user_id();
+    $user_b = wp_insert_user([
+        'user_login' => 'ss-notices-' . uniqid(),
+        'user_pass'  => wp_generate_password(),
+        'role'       => 'shop_manager',
+    ]);
+    expect($user_b)->toBeInt();
+
+    remember_cleanup_callback(function () use ($user_b, $user_a, $notices): void {
+        $notices->clear($user_b);
+        wp_set_current_user($user_a);
+        require_once ABSPATH . 'wp-admin/includes/user.php';
+        wp_delete_user($user_b);
+    });
+
+    $notices->push([['message' => 'Notice for user A', 'type' => 'success']], $user_a);
+
+    // User B sees nothing on a marked request, and user A's notice survives.
+    wp_set_current_user($user_b);
+    $_GET[SS_Shipping_Admin_Notices::QUERY_ARG] = '1';
+
+    ob_start();
+    $notices->maybe_render();
+    $output = ob_get_clean();
+
+    expect($output)->toBe('')
+        ->and($notices->get_pending($user_a))->toHaveCount(1);
+
+    // Back as user A the notice renders.
+    wp_set_current_user($user_a);
+
+    ob_start();
+    $notices->maybe_render();
+    $output = ob_get_clean();
+
+    expect($output)->toContain('Notice for user A')
+        ->and($notices->get_pending($user_a))->toBe([]);
+});

--- a/tests/Integration/LabelGenerationTest.php
+++ b/tests/Integration/LabelGenerationTest.php
@@ -21,14 +21,21 @@ function create_labels_for(int $order_id, bool $return = false, bool $save_order
 }
 
 /**
- * Reset the bulk-action flash message option and restore it afterwards.
+ * Clear pending admin notices for the current user and leave a clean state
+ * (no pending transient, no marker query parameter) after the test.
  */
-function with_empty_flash_messages(): void
+function with_empty_flash_messages(): SS_Shipping_Admin_Notices
 {
-    // Seed an empty bag for the current user: add_admin_flash_messages()
-    // reads $bags[$bag] without an isset() check and would emit an
-    // "Undefined array key" warning on a completely empty option.
-    with_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY, [get_current_user_id() => []]);
+    $notices = SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_admin_notices();
+
+    $notices->clear();
+
+    remember_cleanup_callback(function () use ($notices): void {
+        $notices->clear();
+        unset($_GET[SS_Shipping_Admin_Notices::QUERY_ARG]);
+    });
+
+    return $notices;
 }
 
 /**
@@ -164,7 +171,7 @@ it('creates only a return label when explicitly requested', function () {
 });
 
 it('generates labels for two orders via the bulk action and flashes a combined-pdf notice', function () {
-    with_empty_flash_messages();
+    $notices = with_empty_flash_messages();
 
     $order_a = create_labelable_order();
     $order_b = create_labelable_order();
@@ -185,35 +192,32 @@ it('generates labels for two orders via the bulk action and flashes a combined-p
         $order_b->get_id(),
     ]);
 
-    expect($sendback)->toBe('/wp-admin/edit.php');
+    // The redirect URL is marked so the next request looks up the notices.
+    expect($sendback)->toBe('/wp-admin/edit.php?ss_shipping_notices=1');
 
-    // The flash messages are stored per user id until rendered.
-    $bags = get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY);
-    $messages = $bags[get_current_user_id()];
+    // The notices are stored in a per-user transient until rendered.
+    $messages = $notices->get_pending();
     expect($messages)->toHaveCount(1)
         ->and($messages[0]['type'])->toBe('success')
         ->and($messages[0]['message'])->toContain('Shipping labels created by Smart Send for 2 orders')
         ->toContain('https://api.example.test/labels/combined.pdf')
         ->toContain('Download combined pdf');
 
-    // render_admin_messages() prints the notices and clears the bag. The
-    // screen helpers are admin-only, so load them on demand.
-    if (!function_exists('convert_to_screen')) {
-        require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
-        require_once ABSPATH . 'wp-admin/includes/screen.php';
-        require_once ABSPATH . 'wp-admin/includes/template.php';
-    }
+    // maybe_render() prints the notices and clears the transient when the
+    // marker query parameter is present.
+    $_GET[SS_Shipping_Admin_Notices::QUERY_ARG] = '1';
     ob_start();
-    $handler->render_admin_messages(convert_to_screen('edit-shop_order'));
+    $notices->maybe_render();
     $output = ob_get_clean();
 
     expect($output)->toContain('notice-success')
         ->toContain('Download combined pdf');
-    expect(get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY)[get_current_user_id()])->toBe([]);
+    expect($notices->get_pending())->toBe([])
+        ->and(get_transient(SS_Shipping_Admin_Notices::TRANSIENT_PREFIX . get_current_user_id()))->toBeFalse();
 });
 
 it('flashes an error for bulk label generation on an order without a Smart Send method', function () {
-    with_empty_flash_messages();
+    $notices = with_empty_flash_messages();
 
     $product = create_simple_product(['price' => 100, 'weight' => 1]);
     $order   = create_order(['products' => [$product]]);
@@ -223,7 +227,7 @@ it('flashes an error for bulk label generation on an order without a Smart Send 
     SS_SHIPPING_WC()->get_ss_shipping_wc_order()
         ->handle_bulk_order_actions('/wp-admin/edit.php', 'ss_shipping_label_bulk', [$order->get_id()]);
 
-    $messages = get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY)[get_current_user_id()];
+    $messages = $notices->get_pending();
     expect($messages)->toHaveCount(1)
         ->and($messages[0]['type'])->toBe('error')
         // (sic) "Send Smart" typo is current v8 behaviour.
@@ -231,7 +235,7 @@ it('flashes an error for bulk label generation on an order without a Smart Send 
 });
 
 it('flashes the API error per order when bulk label generation fails', function () {
-    with_empty_flash_messages();
+    $notices = with_empty_flash_messages();
 
     $order = create_labelable_order();
     mock_smart_send_api(function () {
@@ -241,7 +245,7 @@ it('flashes the API error per order when bulk label generation fails', function 
     SS_SHIPPING_WC()->get_ss_shipping_wc_order()
         ->handle_bulk_order_actions('/wp-admin/edit.php', 'ss_shipping_label_bulk', [$order->get_id()]);
 
-    $messages = get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY)[get_current_user_id()];
+    $messages = $notices->get_pending();
     expect($messages)->toHaveCount(1)
         ->and($messages[0]['type'])->toBe('error')
         ->and($messages[0]['message'])->toContain('Order #' . $order->get_order_number())
@@ -249,14 +253,14 @@ it('flashes the API error per order when bulk label generation fails', function 
 });
 
 it('rejects bulk label generation for more than five orders', function () {
-    with_empty_flash_messages();
+    $notices = with_empty_flash_messages();
 
     $capture = mock_smart_send_api();
 
     SS_SHIPPING_WC()->get_ss_shipping_wc_order()
         ->handle_bulk_order_actions('/wp-admin/edit.php', 'ss_shipping_label_bulk', [1, 2, 3, 4, 5, 6]);
 
-    $messages = get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY)[get_current_user_id()];
+    $messages = $notices->get_pending();
     expect($messages)->toHaveCount(1)
         ->and($messages[0]['type'])->toBe('error')
         ->and($messages[0]['message'])->toContain('not possible to create labels for more than 5 orders')
@@ -264,7 +268,7 @@ it('rejects bulk label generation for more than five orders', function () {
 });
 
 it('ignores bulk actions that are not Smart Send actions', function () {
-    with_empty_flash_messages();
+    $notices = with_empty_flash_messages();
 
     $result = SS_SHIPPING_WC()->get_ss_shipping_wc_order()
         ->handle_bulk_order_actions('/wp-admin/edit.php', 'mark_processing', [1]);
@@ -272,6 +276,5 @@ it('ignores bulk actions that are not Smart Send actions', function () {
     // v8 oddity: for foreign actions the handler returns null instead of
     // passing $sendback through.
     expect($result)->toBeNull()
-        ->and(get_option(SS_Shipping_WC_Order::ADMIN_FLASH_MESSAGE_OPTION_KEY))
-        ->toBe([get_current_user_id() => []]);
+        ->and($notices->get_pending())->toBe([]);
 });


### PR DESCRIPTION
## Design

New class `SS_Shipping_Admin_Notices` (`smart-send-logistics/includes/class-ss-shipping-admin-notices.php`, autoloadable via the `SS_Shipping_*` convention) owns the full one-time admin notice lifecycle:

- **`push( $messages, $user_id = null )`** — queue notices during an admin action
- **`add_notices_query_arg( $url )`** — mark the post-action redirect URL with `ss_shipping_notices=1`
- **`maybe_render()`** (hooked on `admin_notices`) — render pending notices exactly once, then clear
- **`get_pending()` / `clear()`** — storage accessors

**Storage**: WordPress Transients API, keyed per user — `ss_shipping_notices_{user_id}` with a 1-hour expiry as a safety net for notices that are pushed but never rendered. This replaces the shared `_ss_shipping_bulk_action_confirmation` option (which held all users' bags in one row and was a documented race-condition risk).

**Query-parameter gate**: `maybe_render()` returns immediately unless `ss_shipping_notices=1` is on the request, so no transient lookup happens on admin requests that didn't just perform a Smart Send action. The bulk handler appends the parameter to `$sendback` only when it actually pushed notices.

**Why not `WC_Admin_Notices`**: it stores notices site-wide in a single option and keeps them until dismissed — it doesn't fit per-user render-once flash messages, so the plain `admin_notices` hook is used as the issue's fallback path (and `wc_add_notice` is storefront-only, per the issue).

## What moved out of `SS_Shipping_WC_Order`

Removed entirely: `ADMIN_FLASH_MESSAGE_OPTION_KEY`, `render_admin_messages()`, `print_admin_flash_messages()`, `get_admin_flash_message_option_key()`, `get/set_admin_flash_bags()`, `get/set/add_admin_flash_message(s)()`. The order class now only constructs the component, exposes it via `get_admin_notices()`, and pushes messages in `handle_bulk_order_actions()`. All notice contents (per-order success with label link, combined-PDF link, >5-orders error, non-SS-order error, per-order API errors) are unchanged.

This also makes characterization oddity #11 from #75 moot: the old `add_admin_flash_messages()` read `$bags[$bag]` without `isset()` and warned on a fresh option; the transient path has no such state to seed.

## Test changes

- `tests/Integration/AdminNoticesTest.php` (new): push → per-user transient; redirect URL marking; rendered once → cleared → second render empty; **no transient lookup without the query param** (proven by counting `pre_transient_*` filter invocations); per-user isolation (user B sees nothing, user A's notice survives and renders).
- `tests/Integration/LabelGenerationTest.php`: only storage-internal assertions changed — reads through `get_pending()`/`get_transient()` instead of the removed option key, renders via `maybe_render()` + `$_GET` marker instead of `render_admin_messages(convert_to_screen(...))`, and the bulk test now expects `$sendback` to carry `?ss_shipping_notices=1`. The `with_empty_flash_messages()` helper no longer needs to pre-seed an empty bag (oddity #11 above). All user-visible notice content assertions are untouched, and the `v8 oddity` null-sendback expectation for foreign bulk actions stays as-is.

Results: `composer test:integration` 90 passed (366 assertions); `vendor/bin/phpcs` clean; `composer phpcs:compat` clean. `phpcs.baseline.xml` untouched — lines whose baseline signatures were invalidated by adjacent edits (end of `getOrderWeight()`, class braces) were brought fully up to WPCS instead.

Closes #45

> Stacked PR: based on #85 (`feature/issue-38-http-error-handling`), which is based on #84 (`feature/issue-22-logger`). Merge those first; this PR targets #85's branch, not `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)