### PR TITLE
Surface pick-up point lookup failure reasons in shipping debug mode

### DIFF
--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -148,8 +148,10 @@ if (!class_exists('SS_Shipping_Frontend')) :
 		 * text whenever no agents are available. That fallback hides several
 		 * distinct causes, so this classifies the failure (transport error,
 		 * API error response, empty result) and reports it: always to the log
-		 * (error level for failures, debug level for an empty result) and as
-		 * a checkout debug notice when WooCommerce shipping debug mode is on.
+		 * (error level for failures, debug level for an empty result) and via
+		 * SS_Shipping_Checkout_Debug::add_notice() when WooCommerce shipping
+		 * debug mode is on (a no-op during checkout AJAX requests, matching
+		 * core - the log entry is then the only trace).
 		 *
 		 * @param string      $carrier Unique carrier code the lookup ran for.
 		 * @param object|null $error   Smartsend\Models\Error describing the failure, if any.
@@ -161,7 +163,10 @@ if (!class_exists('SS_Shipping_Frontend')) :
 			if ( 'NoResults' === $code ) {
 				// Not an error: the API answered, there are just no pick-up
 				// points near the entered address.
-				SS_Shipping_Logger::debug_notice( 'Smart Send: no ' . $carrier . ' pick-up points found near the entered address - falling back to "Shipping to closest pick-up point".' );
+				$reason = 'Smart Send: no ' . $carrier . ' pick-up points found near the entered address - falling back to "Shipping to closest pick-up point".';
+
+				SS_Shipping_Logger::debug( $reason );
+				SS_Shipping_Checkout_Debug::add_notice( $reason );
 
 				return;
 			}
@@ -177,7 +182,7 @@ if (!class_exists('SS_Shipping_Frontend')) :
 			$reason .= ' Falling back to "Shipping to closest pick-up point".';
 
 			SS_Shipping_Logger::error( $reason );
-			SS_Shipping_Logger::debug_notice( $reason );
+			SS_Shipping_Checkout_Debug::add_notice( $reason );
 		}
 
         /**

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -134,8 +134,50 @@ if (!class_exists('SS_Shipping_Frontend')) :
 
 				return $ss_agents;
 			} else {
+				$this->report_agent_lookup_failure( $carrier, SS_SHIPPING_WC()->get_api_handle()->getError() );
+
 				return array();
 			}
+		}
+
+		/**
+		 * Log why a pick-up point lookup failed and surface the reason in
+		 * WooCommerce's shipping debug mode.
+		 *
+		 * The checkout falls back to the "Shipping to closest pick-up point"
+		 * text whenever no agents are available. That fallback hides several
+		 * distinct causes, so this classifies the failure (transport error,
+		 * API error response, empty result) and reports it: always to the log
+		 * (error level for failures, debug level for an empty result) and as
+		 * a checkout debug notice when WooCommerce shipping debug mode is on.
+		 *
+		 * @param string      $carrier Unique carrier code the lookup ran for.
+		 * @param object|null $error   Smartsend\Models\Error describing the failure, if any.
+		 */
+		protected function report_agent_lookup_failure( $carrier, $error ) {
+			$code    = ( is_object( $error ) && isset( $error->code ) && is_scalar( $error->code ) ) ? (string) $error->code : '';
+			$message = ( is_object( $error ) && isset( $error->message ) && is_scalar( $error->message ) ) ? (string) $error->message : '';
+
+			if ( 'NoResults' === $code ) {
+				// Not an error: the API answered, there are just no pick-up
+				// points near the entered address.
+				SS_Shipping_Logger::debug_notice( 'Smart Send: no ' . $carrier . ' pick-up points found near the entered address - falling back to "Shipping to closest pick-up point".' );
+
+				return;
+			}
+
+			if ( 0 === strpos( $code, 'transport-' ) ) {
+				$reason = 'Smart Send: pick-up point lookup for ' . $carrier . ' failed with a transport error (' . $code . '): ' . $message;
+			} elseif ( '' !== $code || '' !== $message ) {
+				$reason = 'Smart Send: pick-up point lookup for ' . $carrier . ' failed with an API error (' . $code . '): ' . $message;
+			} else {
+				$reason = 'Smart Send: pick-up point lookup for ' . $carrier . ' failed for an unknown reason.';
+			}
+
+			$reason .= ' Falling back to "Shipping to closest pick-up point".';
+
+			SS_Shipping_Logger::error( $reason );
+			SS_Shipping_Logger::debug_notice( $reason );
 		}
 
         /**

--- a/tests/Integration/PickupLookupDebugTest.php
+++ b/tests/Integration/PickupLookupDebugTest.php
@@ -1,0 +1,210 @@
+<?php
+
+/*
+ * Pick-up point lookup failure reasons (#47): when the agents request at
+ * checkout fails, the shopper still sees the unchanged "Shipping to closest
+ * pick-up point" fallback, while the classified reason (transport error,
+ * API error response, empty result) is logged - error level for failures,
+ * debug level for an empty result - and, with WooCommerce shipping debug
+ * mode enabled, surfaced as a checkout debug notice.
+ *
+ * NOTE: like ShippingDebugModeTest, these tests assert on checkout notices
+ * and therefore must run before the WC_DOING_AJAX-defining test in
+ * ShippingDebugModeTest.php (alphabetical file order guarantees this).
+ */
+
+/**
+ * Render the pick-up point block for a Smart Send agent rate the way
+ * checkout does: is_checkout() forced true, a posted shipping address, the
+ * rate chosen in the session.
+ */
+function pickup_debug_render(): string
+{
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+
+    add_filter('woocommerce_is_checkout', '__return_true');
+    $_POST = array_merge($_POST, [
+        's_country'  => 'DK',
+        's_postcode' => '2300',
+        's_city'     => 'Copenhagen',
+        's_address'  => 'Islands Brygge 39',
+    ]);
+    WC()->session->set('chosen_shipping_methods', ['smart_send_shipping:1']);
+
+    remember_cleanup_callback(function (): void {
+        remove_filter('woocommerce_is_checkout', '__return_true');
+        unset($_POST['s_country'], $_POST['s_postcode'], $_POST['s_city'], $_POST['s_address']);
+        WC()->session->set('chosen_shipping_methods', null);
+        WC()->session->set('ss_shipping_agents', null);
+    });
+
+    $rate = new WC_Shipping_Rate('smart_send_shipping:1', 'Smart Send', 49.0, [], 'smart_send_shipping', 1);
+    $rate->add_meta_data('smart_send_shipping_method', 'postnord_agent');
+
+    ob_start();
+    (new SS_Shipping_Frontend())->display_ss_pickup_points($rate, 0);
+
+    return ob_get_clean();
+}
+
+/**
+ * All queued notices of the default "success" type wc_add_notice() uses,
+ * matching WooCommerce core's own shipping debug notices.
+ */
+function pickup_debug_notice_texts(): array
+{
+    return array_map(
+        fn (array $notice): string => (string) $notice['notice'],
+        wc_get_notices('success')
+    );
+}
+
+/**
+ * The logged messages of a given level recorded by the logger spy.
+ */
+function pickup_debug_logged(object $spy, string $level): array
+{
+    $messages = [];
+    foreach ($spy->entries as $entry) {
+        if ($entry['level'] === $level) {
+            $messages[] = $entry['message'];
+        }
+    }
+
+    return $messages;
+}
+
+const PICKUP_DEBUG_FALLBACK = '<div class="woocommerce-info ss-agent-info">Shipping to closest pick-up point</div>';
+
+beforeEach(function (): void {
+    with_ss_settings();
+
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+    wc_clear_notices();
+    remember_cleanup_callback(function (): void {
+        wc_clear_notices();
+    });
+});
+
+it('surfaces a transport failure as a debug notice and logs it at error level', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return new WP_Error('http_request_failed', 'cURL error 28: Operation timed out after 30001 milliseconds');
+    });
+
+    $output = pickup_debug_render();
+
+    $expected = 'Smart Send: pick-up point lookup for postnord failed with a transport error (transport-timeout): '
+        . 'The connection to the Smart Send API timed out. Please try again. If the problem persists, ask your host '
+        . 'whether outgoing requests to app.smartsend.io are blocked or slow.'
+        . ' Falling back to "Shipping to closest pick-up point".';
+
+    // The customer-facing fallback is byte-for-byte unchanged.
+    expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
+        ->and(pickup_debug_notice_texts())->toContain($expected)
+        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected);
+});
+
+it('surfaces an API error response as a debug notice and logs it at error level', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(401, [
+            'code'    => 'Unauthenticated',
+            'message' => 'The API token is invalid.',
+        ]);
+    });
+
+    $output = pickup_debug_render();
+
+    $expected = 'Smart Send: pick-up point lookup for postnord failed with an API error (Unauthenticated): '
+        . 'The API token is invalid. Falling back to "Shipping to closest pick-up point".';
+
+    expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
+        ->and(pickup_debug_notice_texts())->toContain($expected)
+        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected);
+});
+
+it('falls back to the HTTP status when a validation error body has no code', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(422, ['message' => 'The given data was invalid.']);
+    });
+
+    $output = pickup_debug_render();
+
+    expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
+        ->and(pickup_debug_notice_texts())->toContain(
+            'Smart Send: pick-up point lookup for postnord failed with an API error (422): '
+            . 'The given data was invalid. Falling back to "Shipping to closest pick-up point".'
+        );
+});
+
+it('reports an empty agent list as a debug notice and logs it at debug level only', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    with_ss_settings(['ss_debug' => 'yes']); // Debug-level log entries require the plugin debug setting.
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => []]);
+    });
+
+    $output = pickup_debug_render();
+
+    $expected = 'Smart Send: no postnord pick-up points found near the entered address'
+        . ' - falling back to "Shipping to closest pick-up point".';
+
+    expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
+        ->and(pickup_debug_notice_texts())->toContain($expected)
+        ->and(implode("\n", pickup_debug_logged($spy, 'debug')))->toContain($expected)
+        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->not->toContain('no postnord pick-up points');
+});
+
+it('adds no notice when shipping debug mode is off but still logs the error', function () {
+    with_option('woocommerce_shipping_debug_mode', 'no');
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return new WP_Error('http_request_failed', 'Failed to connect to app.smartsend.io port 443: Connection refused');
+    });
+
+    $output = pickup_debug_render();
+
+    // Same fallback text, no notices at all - checkout looks exactly as before.
+    expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
+        ->and(wc_notice_count())->toBe(0)
+        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain(
+            'Smart Send: pick-up point lookup for postnord failed with a transport error (transport-connection):'
+        );
+});
+
+it('adds no notice for an empty agent list when shipping debug mode is off', function () {
+    with_option('woocommerce_shipping_debug_mode', 'no');
+    spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => []]);
+    });
+
+    $output = pickup_debug_render();
+
+    expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
+        ->and(wc_notice_count())->toBe(0);
+});
+
+it('renders the agent dropdown and no failure notice when the lookup succeeds', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent()]]);
+    });
+
+    $output = pickup_debug_render();
+
+    expect($output)->toContain('ss_shipping_store_pickup')
+        ->and($output)->not->toContain('Shipping to closest pick-up point')
+        ->and(implode("\n", pickup_debug_notice_texts()))->not->toContain('pick-up point lookup');
+});

--- a/tests/Integration/PickupLookupDebugTest.php
+++ b/tests/Integration/PickupLookupDebugTest.php
@@ -6,7 +6,11 @@
  * pick-up point" fallback, while the classified reason (transport error,
  * API error response, empty result) is logged - error level for failures,
  * debug level for an empty result - and, with WooCommerce shipping debug
- * mode enabled, surfaced as a checkout debug notice.
+ * mode enabled, surfaced as a checkout debug notice via
+ * SS_Shipping_Checkout_Debug::add_notice(). add_notice() is a no-op when
+ * WC_DOING_AJAX is defined (matching core), so during checkout AJAX updates
+ * the log entry is the only trace; these tests exercise the non-AJAX render
+ * path.
  *
  * NOTE: like ShippingDebugModeTest, these tests assert on checkout notices
  * and therefore must run before the WC_DOING_AJAX-defining test in


### PR DESCRIPTION
Implements #47 — top of the v9 Phase 2 stack: #84 ← #85 ← #86 ← #87 ← this PR.

When the pick-up point lookup at checkout fails, the shopper still sees the byte-for-byte unchanged fallback (`Shipping to closest pick-up point`), but the reason is now classified in `SS_Shipping_Frontend::find_closest_agents_by_address()` (new `report_agent_lookup_failure()`), using the error taxonomy the HTTP client (#85) already produces — no re-parsing.

## Reason taxonomy and example texts

| Class | Detected via | Example notice/log text |
| --- | --- | --- |
| Transport failure | `Error->code` prefix `transport-` (`transport-timeout` / `transport-ssl` / `transport-connection` / `transport-*`) | `Smart Send: pick-up point lookup for postnord failed with a transport error (transport-timeout): The connection to the Smart Send API timed out. … Falling back to "Shipping to closest pick-up point".` |
| API error response | any other error with a code/message (API code such as `Unauthenticated` / `ValidationException`, or the HTTP status when the body carries no code; includes `api-empty-response` / `api-malformed-response`) | `Smart Send: pick-up point lookup for postnord failed with an API error (Unauthenticated): The API token is invalid. Falling back to "Shipping to closest pick-up point".` |
| Empty result | client's `NoResults` code (API answered, no agents near the address) | `Smart Send: no postnord pick-up points found near the entered address - falling back to "Shipping to closest pick-up point".` |

## Decoupled pattern (per the #92 rework of the stack base)

Logging and the checkout debug bar are separate concerns:

- **Logging** via `SS_Shipping_Logger`: transport and API failures at **error** level (always logs, regardless of the plugin debug setting; in addition to the client's request-cycle error entry). Empty result at **debug** level only — it is not an error.
- **Debug bar** via `SS_Shipping_Checkout_Debug::add_notice()` (from #87 as reworked in #92): all three reasons surface as a checkout notice only when WooCommerce shipping debug mode is on, with core's gating and exact-message dedupe. `add_notice()` never logs; each call site logs explicitly, once.

### AJAX nuance (by design)

`add_notice()` is a no-op whenever `WC_DOING_AJAX` is defined — and agent lookups often run during checkout AJAX shipping updates. In that path the log entry is the **only** trace of the failure reason. This matches WooCommerce core's own debug-notice behaviour (core suppresses its "Customer matched zone …" notices in the same situations); the notice appears on the non-AJAX checkout render.

## Not implemented (deliberately)

The issue's alternative placement — suffixing the select-option/fallback text with `(Debug: …)` — was **not** added. The debug-bar route keeps the customer-visible markup untouched even in debug mode; happy to add the option-text suffix if reviewers prefer it.

## Behaviour

No change to the fallback flow: same fallback text, same shipping behaviour, no new markup at checkout.

## Tests (`tests/Integration/PickupLookupDebugTest.php`, 7 tests)

Renders the real `display_ss_pickup_points()` path with the API mocked via `pre_http_request`, exercising the non-AJAX render path (`woocommerce_is_checkout` forced, `WC_DOING_AJAX` not defined in the test's run context — the file sorts before `ShippingDebugModeTest`, which defines it in its last test):

- transport error, API 401, code-less 422, empty agent list → debug notice content asserted with debug mode **on**
- no notices with debug mode **off** (transport + empty-result cases)
- error-level log entry asserted for failures; debug-level (and no error-level) for empty result
- fallback option text asserted byte-for-byte unchanged in both modes; success path still renders the dropdown with no failure notice

`composer test:integration`: 113 passed. `vendor/bin/phpcs` clean, `composer phpcs:compat` clean.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
