### PR TITLE
Refactor log levels and checkout debug content per logging policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,10 +58,10 @@ Two decoupled surfaces with distinct audiences — place every log/notice call d
 
 | Level | Use for | Example |
 |---|---|---|
-| `info` | Business events a merchant/support agent cares about after the fact (gated on the plugin "Debug Log" setting) | "Shipping label created", "Tracking number stored", "Pick-up point selected at checkout" |
-| `debug` | Developer trace only, non-polluting (gated on the plugin "Debug Log" setting) | "No Smart Send shipping method on order - skipping meta box content", rate evaluation detail, API request cycles (via `log_api_request`) |
+| `info` | Business events a merchant/support agent cares about after the fact; always logged (ungated audit trail) | "Shipping label created", "Tracking number stored", "Pick-up point selected at checkout" |
+| `debug` | Developer trace only, non-polluting — the ONLY level gated on the plugin "Debug Log" setting | "No Smart Send shipping method on order - skipping meta box content", rate evaluation detail, API request cycles (via `log_api_request`) |
 | `warning` | Failures the plugin recovers from; always logged | "Pick-up point not found - agent number rejected" |
-| `error` / `critical` | API and transport failures; always logged | "POST /shipments → 422 (312ms)" (via `log_api_request`) |
+| `error` / `critical` | API and transport failures, and recoverable-but-abnormal states; always logged | "POST /shipments → 422 (312ms)" (via `log_api_request`), "Failed to load WooCommerce order when deleting pick-up point meta" |
 
 Keep messages concise and greppable; put structured data (order id, agent no, shipment id, carrier) in the context array — the WooCommerce log viewer renders it natively.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,22 @@ Two class layers with different conventions:
 
 2. **PSR-style API client** in `includes/lib/Smartsend/` — namespace `Smartsend`, classes `Api` (endpoint methods, extends `Client`) and `Client` (HTTP via `wp_remote_*` against `https://app.smartsend.io/api/v1/`), plus `Models/` value objects (`Shipment`, `Agent`, and their sub-models). This layer is deliberately WordPress-light; keep API concerns here rather than in the `SS_Shipping_*` classes.
 
+## Logging policy
+
+Two decoupled surfaces with distinct audiences — place every log/notice call deliberately on one of them (see issue #92):
+
+1. **Checkout shipping debug bar** (`SS_Shipping_Checkout_Debug::add_notice()`) — for the merchant diagnosing checkout live (WooCommerce → Settings → Shipping → "Enable debug mode"). Carries the rate evaluation trace, which Smart Send rates ended up offered for the package, the overlapping-weight-row outcome, and pick-up point lookup results/failures. It never writes to the log — call `SS_Shipping_Logger` separately when a log entry is also wanted. Notices are a no-op during checkout AJAX (matching WooCommerce core), so the log entry is then the only trace.
+2. **The WooCommerce log** (`SS_Shipping_Logger`, source `smart-send-logistics`) — an audit trail of business events (`info`) plus developer trace (`debug`).
+
+| Level | Use for | Example |
+|---|---|---|
+| `info` | Business events a merchant/support agent cares about after the fact (gated on the plugin "Debug Log" setting) | "Shipping label created", "Tracking number stored", "Pick-up point selected at checkout" |
+| `debug` | Developer trace only, non-polluting (gated on the plugin "Debug Log" setting) | "No Smart Send shipping method on order - skipping meta box content", rate evaluation detail, API request cycles (via `log_api_request`) |
+| `warning` | Failures the plugin recovers from; always logged | "Pick-up point not found - agent number rejected" |
+| `error` / `critical` | API and transport failures; always logged | "POST /shipments → 422 (312ms)" (via `log_api_request`) |
+
+Keep messages concise and greppable; put structured data (order id, agent no, shipment id, carrier) in the context array — the WooCommerce log viewer renders it natively.
+
 Extension points are `smart_send_*` filters/actions (e.g. `smart_send_api_endpoint`, `smart_send_shipping_label_args`, `smart_send_shipping_label_created`, `smart_send_tracking_url`, `smart_send_order_note`). Preserve these when refactoring — merchants rely on them via code snippets.
 
 ## Releasing

--- a/smart-send-logistics/includes/class-ss-shipping-logger.php
+++ b/smart-send-logistics/includes/class-ss-shipping-logger.php
@@ -22,8 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * in the `$context` array, which the WooCommerce log viewer renders
  * natively.
  *
- * The `debug` and `info` levels are gated on the plugin's "Debug Log"
- * setting; `warning`, `error` and `critical` always log. The
+ * Only the `debug` level is gated on the plugin's "Debug Log" setting;
+ * `info`, `warning`, `error` and `critical` always log. The
  * `smart_send_logging` filter applies to all levels: it receives the
  * message and may rewrite it, or suppress the entry by returning null or
  * false.
@@ -70,13 +70,14 @@ class SS_Shipping_Logger {
 	}
 
 	/**
-	 * Log an informational message (gated on the plugin's debug setting).
+	 * Log an informational business event. Always logged, regardless of the
+	 * debug setting.
 	 *
 	 * @param string $message Message to log.
 	 * @param array  $context Optional structured context.
 	 */
 	public static function info( $message, $context = array() ) {
-		self::write( 'info', $message, $context, self::is_enabled() );
+		self::write( 'info', $message, $context, true );
 	}
 
 	/**

--- a/smart-send-logistics/includes/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-method.php
@@ -972,15 +972,16 @@ if (!class_exists('SS_Shipping_WC_Method')) :
                 'package'   => $package,
             );
 
-			$debug_message = 'Smart Send: evaluated method "' . $rate['label'] . '" (' . $rate['meta_data']['smart_send_shipping_method'] . ', rate id ' . $rate['id'] . ').';
+			// Log-file developer trace: the rate matched the zone, cost calculation starts.
 			SS_Shipping_Logger::debug(
-				$debug_message,
+				'Calculating shipping cost for shipping rate ' . $rate['id'],
 				array(
 					'rate_id' => $rate['id'],
+					'label'   => $rate['label'],
 					'method'  => $rate['meta_data']['smart_send_shipping_method'],
 				)
 			);
-			SS_Shipping_Checkout_Debug::add_notice( $debug_message );
+			SS_Shipping_Checkout_Debug::add_notice( 'Smart Send: evaluated method "' . $rate['label'] . '" (' . $rate['meta_data']['smart_send_shipping_method'] . ', rate id ' . $rate['id'] . ').' );
 
             // Set tax status based on selection otherwise always taxed
             $this->tax_status = $this->get_option('tax_status');
@@ -1055,6 +1056,22 @@ if (!class_exists('SS_Shipping_WC_Method')) :
 					SS_Shipping_Checkout_Debug::add_notice( $debug_message );
 				}
             }
+
+			// Log-file developer trace: the outcome of the cost calculation.
+			if ( isset( $this->rates[ $rate['id'] ] ) ) {
+				SS_Shipping_Logger::debug(
+					'Calculated shipping cost for shipping rate ' . $rate['id'] . ': ' . $this->rates[ $rate['id'] ]->get_cost(),
+					array(
+						'rate_id' => $rate['id'],
+						'cost'    => $this->rates[ $rate['id'] ]->get_cost(),
+					)
+				);
+			} else {
+				SS_Shipping_Logger::debug(
+					'Shipping rate ' . $rate['id'] . ' is not available for this package - no rate added',
+					array( 'rate_id' => $rate['id'] )
+				);
+			}
 
             /**
              * Developers can add additional rates based on this one via this action

--- a/smart-send-logistics/includes/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-method.php
@@ -972,11 +972,14 @@ if (!class_exists('SS_Shipping_WC_Method')) :
                 'package'   => $package,
             );
 
-			// write id of shipping method to log.
-			SS_Shipping_Logger::log( 'Handling shipping rate <' . $rate['id'] . '> with title: ' . $rate['label'] );
-			SS_Shipping_Logger::log( 'Rate details (json decode for details): ' . wp_json_encode( $rate ) );
 			$debug_message = 'Smart Send: evaluated method "' . $rate['label'] . '" (' . $rate['meta_data']['smart_send_shipping_method'] . ', rate id ' . $rate['id'] . ').';
-			SS_Shipping_Logger::debug( $debug_message );
+			SS_Shipping_Logger::debug(
+				$debug_message,
+				array(
+					'rate_id' => $rate['id'],
+					'method'  => $rate['meta_data']['smart_send_shipping_method'],
+				)
+			);
 			SS_Shipping_Checkout_Debug::add_notice( $debug_message );
 
             // Set tax status based on selection otherwise always taxed
@@ -987,18 +990,23 @@ if (!class_exists('SS_Shipping_WC_Method')) :
 
 				$rate['cost'] = $this->get_option( 'flatfee_cost' );
 				$this->add_rate( $rate );
-				// write to log, that shipping rate is added.
-				SS_Shipping_Logger::log( 'Free shipping rate added' );
 				$debug_message = 'Smart Send "' . $rate['label'] . '": free shipping applies - rate added with flat fee cost ' . $rate['cost'] . '.';
-				SS_Shipping_Logger::debug( $debug_message );
+				SS_Shipping_Logger::debug(
+					$debug_message,
+					array(
+						'rate_id' => $rate['id'],
+						'cost'    => $rate['cost'],
+					)
+				);
 				SS_Shipping_Checkout_Debug::add_notice( $debug_message );
 
             } else {
                 $cart_weight = WC()->cart->get_cart_contents_weight();
                 $weight_costs = $this->get_option('cost_weight', array());
 
-				$weight_unit = get_option( 'woocommerce_weight_unit' );
-				$rate_added  = false;
+				$weight_unit  = get_option( 'woocommerce_weight_unit' );
+				$rate_added   = false;
+				$matched_rows = array();
 
                 if ($weight_costs) {
                     foreach ($weight_costs as $weight_cost) {
@@ -1016,17 +1024,30 @@ if (!class_exists('SS_Shipping_WC_Method')) :
                                     ));
 
 									$this->add_rate( $rate );
-									$rate_added = true;
-									// write to log, that shipping rate is added.
-									SS_Shipping_Logger::log( 'Weight based shipping rate added (json decode for details): ' . wp_json_encode( $rate ) );
-									$debug_message = 'Smart Send "' . $rate['label'] . '": cart weight ' . $cart_weight . ' ' . $weight_unit . ' matched weight table row ' . $weight_cost['ss_min_weight'] . '-' . $weight_cost['ss_max_weight'] . ' ' . $weight_unit . ' - rate added with cost ' . $rate['cost'] . '.';
-									SS_Shipping_Logger::debug( $debug_message );
+									$rate_added     = true;
+									$matched_rows[] = $weight_cost['ss_min_weight'] . '-' . $weight_cost['ss_max_weight'] . ' ' . $weight_unit;
+									$debug_message  = 'Smart Send "' . $rate['label'] . '": cart weight ' . $cart_weight . ' ' . $weight_unit . ' matched weight table row ' . $weight_cost['ss_min_weight'] . '-' . $weight_cost['ss_max_weight'] . ' ' . $weight_unit . ' - rate added with cost ' . $rate['cost'] . '.';
+									SS_Shipping_Logger::debug(
+										$debug_message,
+										array(
+											'rate_id'     => $rate['id'],
+											'cost'        => $rate['cost'],
+											'cart_weight' => $cart_weight,
+										)
+									);
 									SS_Shipping_Checkout_Debug::add_notice( $debug_message );
 								}
                             }
                         }
                     }
                 }
+
+				if ( count( $matched_rows ) > 1 ) {
+					$last_row      = $matched_rows[ count( $matched_rows ) - 1 ];
+					$debug_message = 'Smart Send "' . $rate['label'] . '": ' . count( $matched_rows ) . ' overlapping weight table rows matched (' . implode( ', ', $matched_rows ) . ') - the rows share rate id ' . $rate['id'] . ', so only the LAST matching row (' . $last_row . ') is offered and the earlier matches were overwritten.';
+					SS_Shipping_Logger::debug( $debug_message );
+					SS_Shipping_Checkout_Debug::add_notice( $debug_message );
+				}
 
 				if ( ! $rate_added ) {
 					$debug_message = 'Smart Send "' . $rate['label'] . '": no rate added - cart weight ' . $cart_weight . ' ' . $weight_unit . ' did not match any weight table row.';

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -1046,7 +1046,7 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 			// There are situations where the order has been deleted and cannot be found.
 			// We should gracefully handle this situation of failing to load the order.
 			if ( ! $order ) {
-				SS_Shipping_Logger::debug( 'Order not found when deleting pick-up point meta - skipping', array( 'order_id' => $order_id ) );
+				SS_Shipping_Logger::error( 'Failed to load WooCommerce order when deleting pick-up point meta - skipping', array( 'order_id' => $order_id ) );
 
                 return;
             }

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -286,13 +286,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 
             $ss_shipping_method_id = $this->get_smart_send_method_id($order_id);
 
-            // Only display Smart Shipping (SS) meta box is SS selected as shipping method OR free shipping is set to SS method
-            if (! $ss_shipping_method_id) {
-                echo '<p>' . __('Order placed with a shipping method that is not from the Smart Send plugin',
-                        'smart-send-logistics') . '</p>';
+			// Only display Smart Shipping (SS) meta box is SS selected as shipping method OR free shipping is set to SS method.
+			if ( ! $ss_shipping_method_id ) {
+				SS_Shipping_Logger::debug( 'No Smart Send shipping method on order - skipping meta box content', array( 'order_id' => $order_id ) );
 
-                return;
-            }
+				echo '<p>' . esc_html__( 'Order placed with a shipping method that is not from the Smart Send plugin', 'smart-send-logistics' ) . '</p>';
+
+				return;
+			}
 
             $ss_shipping_method_name = SS_SHIPPING_WC()->get_shipping_method_name_from_all_shipping_method_instances($ss_shipping_method_id);
 
@@ -597,14 +598,28 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 					// API call to get agent info by agent no.
 					if ( SS_SHIPPING_WC()->get_api_handle()->getAgentByAgentNo( $shipping_method_carrier, $shipping_address['country'], $ss_shipping_agent_no ) ) {
 
-						SS_Shipping_Logger::log( 'Agent found and saved.' );
+						SS_Shipping_Logger::info(
+							'Pick-up point changed on order',
+							array(
+								'order_id' => $post_id,
+								'agent_no' => $ss_shipping_agent_no,
+								'carrier'  => $shipping_method_carrier,
+							)
+						);
 
                         $this->save_ss_shipping_order_agent($post_id,
                             SS_SHIPPING_WC()->get_api_handle()->getData());
                         return true;
                     } else {
 
-						SS_Shipping_Logger::log( 'Agent NOT found.' );
+						SS_Shipping_Logger::warning(
+							'Pick-up point not found - agent number rejected',
+							array(
+								'order_id' => $post_id,
+								'agent_no' => $ss_shipping_agent_no,
+								'carrier'  => $shipping_method_carrier,
+							)
+						);
 
                         $error_msg = sprintf(__('The agent number entered, %s, was not found.',
                             'smart-send-logistics'), $ss_shipping_agent_no);
@@ -733,6 +748,15 @@ if (!class_exists('SS_Shipping_WC_Order')) :
                 // save order meta data
                 $this->save_ss_shipment_id_in_order_meta($order_id, $response->shipment_id, $return);
 
+				SS_Shipping_Logger::info(
+					$return ? 'Return shipping label created' : 'Shipping label created',
+					array(
+						'order_id'    => $order_id,
+						'shipment_id' => $response->shipment_id,
+						'carrier'     => isset( $response->carrier_name ) ? $response->carrier_name : null,
+					)
+				);
+
                 // Get formatted order comment
                 $response->woocommerce['label_url'] = $labelUrl;
                 $response->woocommerce['order_note'] = $this->get_formatted_order_note_with_label_and_tracking($order_id,
@@ -741,27 +765,46 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 
                 // Save order note
                 if ($setting_save_order_note) {
-                    /*
-                     * Filter the order comment that is saved. The order comment can be seen in the WooCommerce backend
-                     *
-                     * @param string order note containing tracking link and link to pdf label
-                     * @param WC_Order object
-                     * @param boolean $return Whether or not the label is return (true) or normal (false)
-                     */
-                    $order_note = apply_filters('smart_send_shipping_label_comment',
-                        $response->woocommerce['order_note'], $order, $return);
-                    $order->add_order_note($order_note, 0, true);
-                }
+					/*
+					 * Filter the order comment that is saved. The order comment can be seen in the WooCommerce backend
+					 *
+					 * @param string order note containing tracking link and link to pdf label
+					 * @param WC_Order object
+					 * @param boolean $return Whether or not the label is return (true) or normal (false)
+					 */
+					$order_note = apply_filters(
+						'smart_send_shipping_label_comment',
+						$response->woocommerce['order_note'],
+						$order,
+						$return
+					);
+					$order->add_order_note( $order_note, 0, true );
 
-                // Add tracking info to "WooCommerce Shipment Tracking" plugin
-                foreach ($response->parcels as $parcel) {
-                    // Only add tracking info to "WooCommerce Shipment Tracking" plugin for non-return parcels
-                    if (!$return) {
-                        $this->save_tracking_in_shipment_tracking($order_id, $parcel->tracking_code,
-                            $parcel->tracking_link,
-                            $response->carrier_name, $date_shipped = null);
-                    }
-                }
+					SS_Shipping_Logger::info( 'Order note with label and tracking added', array( 'order_id' => $order_id ) );
+				}
+
+				// Add tracking info to "WooCommerce Shipment Tracking" plugin.
+				foreach ( $response->parcels as $parcel ) {
+					// Only add tracking info to "WooCommerce Shipment Tracking" plugin for non-return parcels.
+					if ( ! $return ) {
+						$this->save_tracking_in_shipment_tracking(
+							$order_id,
+							$parcel->tracking_code,
+							$parcel->tracking_link,
+							$response->carrier_name,
+							null
+						);
+
+						SS_Shipping_Logger::info(
+							'Tracking number stored',
+							array(
+								'order_id'      => $order_id,
+								'tracking_code' => $parcel->tracking_code,
+								'carrier'       => $response->carrier_name,
+							)
+						);
+					}
+				}
 
 	            // Set order status after label generation
                 // Important to update AFTER saving meta fields and tracking information (otherwise not included in email via Shipment Tracking)
@@ -1003,7 +1046,7 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 			// There are situations where the order has been deleted and cannot be found.
 			// We should gracefully handle this situation of failing to load the order.
 			if ( ! $order ) {
-				SS_Shipping_Logger::log( 'Failed to load WooCommerce order: ' . $order_id );
+				SS_Shipping_Logger::debug( 'Order not found when deleting pick-up point meta - skipping', array( 'order_id' => $order_id ) );
 
                 return;
             }

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -129,6 +129,16 @@ if (!class_exists('SS_Shipping_Frontend')) :
 
 				$ss_agents = SS_SHIPPING_WC()->get_api_handle()->getData();
 
+				$summary = 'Smart Send: found ' . count( $ss_agents ) . ' ' . $carrier . ' pick-up points near the entered address.';
+				SS_Shipping_Logger::debug(
+					$summary,
+					array(
+						'carrier'      => $carrier,
+						'result_count' => count( $ss_agents ),
+					)
+				);
+				SS_Shipping_Checkout_Debug::add_notice( $summary );
+
 				// Save all of the agents in sessions.
 				WC()->session->set( 'ss_shipping_agents', $ss_agents );
 
@@ -306,12 +316,22 @@ if (!class_exists('SS_Shipping_Frontend')) :
                 }
             }
 
-            // Saving posted agent information
-            if (!empty($selected_agent_no)) {
-                SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent_no($order_id,
-                    $selected_agent_no);
-                SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent($order_id, $selected_agent);
-            }
+			// Saving posted agent information.
+			if ( ! empty( $selected_agent_no ) ) {
+				SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent_no(
+					$order_id,
+					$selected_agent_no
+				);
+				SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent( $order_id, $selected_agent );
+
+				SS_Shipping_Logger::info(
+					'Pick-up point selected at checkout',
+					array(
+						'order_id' => $order_id,
+						'agent_no' => $selected_agent_no,
+					)
+				);
+			}
         }
 
         /**

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -569,7 +569,10 @@ if (!class_exists('SS_Shipping_WC')) :
                 $error = 1;
             }
 
-			SS_Shipping_Logger::log( $connection_msg );
+			SS_Shipping_Logger::debug(
+				'API token connection test ' . ( $error ? 'failed' : 'succeeded' ),
+				array( 'message' => $connection_msg )
+			);
 
             wp_send_json(array(
                 'message'    => $connection_msg,
@@ -621,16 +624,44 @@ if (!class_exists('SS_Shipping_WC')) :
                     $prices[] = floatval($shipping_method->cost) + array_sum($shipping_method->taxes);
                 }
 
-                // use the prices to sort the rates
-                array_multisort($prices, $available_shipping_methods);
-
-				// write to log.
-				SS_Shipping_Logger::log( 'Shipping methods sorted by cost' );
+				// Use the prices to sort the rates.
+				array_multisort( $prices, $available_shipping_methods );
 			}
 
-            // return the rates
-            return $available_shipping_methods;
-        }
+			$this->report_smart_send_rates_for_package( $available_shipping_methods );
+
+			// Return the rates.
+			return $available_shipping_methods;
+		}
+
+		/**
+		 * Surface which Smart Send rates ended up offered for the package.
+		 *
+		 * Runs on woocommerce_package_rates after every shipping method has
+		 * calculated its rates, so this is the final set the shopper is
+		 * offered. The summary goes to the checkout shipping debug bar and
+		 * to the log as a developer trace.
+		 *
+		 * @param array $available_shipping_methods WC_Shipping_Rate objects keyed by rate id.
+		 */
+		protected function report_smart_send_rates_for_package( $available_shipping_methods ) {
+			$offered = array();
+
+			foreach ( $available_shipping_methods as $shipping_rate ) {
+				if ( $shipping_rate instanceof WC_Shipping_Rate && SS_SHIPPING_METHOD_ID === $shipping_rate->get_method_id() ) {
+					$offered[] = '"' . $shipping_rate->get_label() . '" (' . $shipping_rate->get_id() . ', cost ' . $shipping_rate->get_cost() . ')';
+				}
+			}
+
+			if ( empty( $offered ) ) {
+				$message = 'Smart Send: no Smart Send rates offered for this package.';
+			} else {
+				$message = 'Smart Send: rates offered for this package: ' . implode( ', ', $offered ) . '.';
+			}
+
+			SS_Shipping_Logger::debug( $message );
+			SS_Shipping_Checkout_Debug::add_notice( $message );
+		}
     }
 
 endif;

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -569,10 +569,11 @@ if (!class_exists('SS_Shipping_WC')) :
                 $error = 1;
             }
 
-			SS_Shipping_Logger::debug(
-				'API token connection test ' . ( $error ? 'failed' : 'succeeded' ),
-				array( 'message' => $connection_msg )
-			);
+			if ( $error ) {
+				SS_Shipping_Logger::error( 'API token connection test failed', array( 'message' => $connection_msg ) );
+			} else {
+				SS_Shipping_Logger::info( 'API token connection test succeeded', array( 'message' => $connection_msg ) );
+			}
 
             wp_send_json(array(
                 'message'    => $connection_msg,

--- a/tests/Integration/LoggerTest.php
+++ b/tests/Integration/LoggerTest.php
@@ -2,8 +2,8 @@
 
 /*
  * Tests for the static SS_Shipping_Logger, a thin wrapper around
- * wc_get_logger(): the debug setting gates debug/info inside the class
- * while warning/error/critical always log, the smart_send_logging filter
+ * wc_get_logger(): the debug setting gates only the debug level inside the
+ * class while info/warning/error/critical always log, the smart_send_logging filter
  * can rewrite or suppress entries at all levels, structured data travels in the
  * context array (rendered natively by the WC log viewer), and API requests
  * made through Smartsend\Client produce one concise entry with method,
@@ -91,18 +91,18 @@ it('merges caller-provided context into the entry', function () {
     expect($spy->entries[0]['context']['source'])->toBe('smart-send-logistics');
 });
 
-it('gates debug and info on the debug setting but always logs warning, error and critical', function () {
+it('gates only debug on the debug setting; info, warning, error and critical always log', function () {
     with_ss_settings(['ss_debug' => 'no']);
     $spy = spy_on_logger();
 
     SS_Shipping_Logger::log('gated');
     SS_Shipping_Logger::debug('gated');
-    SS_Shipping_Logger::info('gated');
+    SS_Shipping_Logger::info('an info line');
     SS_Shipping_Logger::warning('a warning');
     SS_Shipping_Logger::error('an error');
     SS_Shipping_Logger::critical('a critical failure');
 
-    expect(array_column($spy->entries, 'level'))->toBe(['warning', 'error', 'critical']);
+    expect(array_column($spy->entries, 'level'))->toBe(['info', 'warning', 'error', 'critical']);
 });
 
 it('logs debug and info when the debug setting is on', function () {

--- a/tests/Integration/LoggingPolicyTest.php
+++ b/tests/Integration/LoggingPolicyTest.php
@@ -1,0 +1,345 @@
+<?php
+
+/*
+ * Logging policy (#92): the WooCommerce log is an audit trail of business
+ * events at the info level (label created, order note added, tracking number
+ * stored, pick-up point selected/changed) plus developer trace at the debug
+ * level, while the checkout shipping debug bar surfaces which Smart Send
+ * rates ended up offered for the package and the overlapping-weight-row
+ * outcome (the "uniqueness filtering": every matching weight row calls
+ * add_rate() with the same rate id, so the last matching row wins).
+ *
+ * NOTE: tests here assert on checkout notices and must run before the
+ * WC_DOING_AJAX-defining tests in ShippingDebugModeTest.php (alphabetical
+ * file order guarantees this). Reuses spy_on_logger() from LoggerTest.php
+ * and the label helpers from LabelGenerationTest.php, both of which load
+ * earlier alphabetically.
+ */
+
+/**
+ * Build a Smart Send shipping method instance with the given instance
+ * settings persisted in the options table (restored after the test).
+ */
+function ss_policy_method(array $instance_settings = [], int $instance_id = 99951): SS_Shipping_WC_Method
+{
+    $settings = array_merge([
+        'title'                      => 'SS Policy Method',
+        'method'                     => 'postnord_agent',
+        'return_method'              => 'postnord_returndropoff',
+        'auto_generate_return_label' => 'no',
+        'tax_status'                 => 'none',
+        'requires'                   => '',
+        'flatfee_cost'               => '0',
+        'min_amount'                 => '0',
+        'cost_weight'                => [],
+        'advanced_settings_enable'   => 'no',
+    ], $instance_settings);
+
+    with_option('woocommerce_smart_send_shipping_' . $instance_id . '_settings', $settings);
+
+    return new SS_Shipping_WC_Method($instance_id);
+}
+
+/**
+ * Put products in a fresh cart and return the shipping package the way
+ * WooCommerce hands it to calculate_shipping().
+ */
+function ss_policy_package(array $product_lines): array
+{
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+
+    WC()->cart->empty_cart();
+    remember_cleanup_callback(function (): void {
+        WC()->cart->empty_cart();
+    });
+
+    foreach ($product_lines as $line) {
+        [$product, $quantity] = is_array($line) ? $line : [$line, 1];
+        WC()->cart->add_to_cart($product->get_id(), $quantity);
+    }
+
+    WC()->cart->calculate_totals();
+
+    return current(WC()->cart->get_shipping_packages());
+}
+
+/**
+ * All queued WooCommerce notices of the default "success" type (the type
+ * wc_add_notice() uses when none is given, matching core's debug notices).
+ */
+function ss_policy_notices(): array
+{
+    return array_map(
+        fn (array $notice): string => (string) $notice['notice'],
+        wc_get_notices('success')
+    );
+}
+
+/**
+ * The logged messages of a given level recorded by the logger spy.
+ */
+function ss_policy_logged(object $spy, string $level): array
+{
+    $messages = [];
+    foreach ($spy->entries as $entry) {
+        if ($entry['level'] === $level) {
+            $messages[] = $entry['message'];
+        }
+    }
+
+    return $messages;
+}
+
+/**
+ * The first spy entry whose message matches exactly, or null.
+ */
+function ss_policy_entry(object $spy, string $message): ?array
+{
+    foreach ($spy->entries as $entry) {
+        if ($entry['message'] === $message) {
+            return $entry;
+        }
+    }
+
+    return null;
+}
+
+beforeEach(function (): void {
+    with_ss_settings(['ss_debug' => 'yes']);
+
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+    wc_clear_notices();
+    remember_cleanup_callback(function (): void {
+        wc_clear_notices();
+    });
+});
+
+it('logs the label, order note and tracking business events at info level on label creation', function () {
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => ss_api_shipment_data(['shipment_id' => 'policy-shipment'])]);
+    });
+    $order = create_labelable_order();
+
+    create_labels_for($order->get_id());
+
+    $infos = implode("\n", ss_policy_logged($spy, 'info'));
+    expect($infos)->toContain('Shipping label created')
+        ->toContain('Order note with label and tracking added')
+        ->toContain('Tracking number stored');
+
+    $created = ss_policy_entry($spy, 'Shipping label created');
+    expect($created)->not->toBeNull()
+        ->and($created['context']['order_id'])->toBe($order->get_id())
+        ->and($created['context']['shipment_id'])->toBe('policy-shipment')
+        ->and($created['context']['carrier'])->toBe('PostNord');
+
+    $tracking = ss_policy_entry($spy, 'Tracking number stored');
+    expect($tracking)->not->toBeNull()
+        ->and($tracking['context']['tracking_code'])->toBe('TRACK-1234');
+});
+
+it('logs "Return shipping label created" for return labels without a tracking event', function () {
+    $spy = spy_on_logger();
+    mock_smart_send_api();
+    $order = create_labelable_order();
+
+    create_labels_for($order->get_id(), true);
+
+    $infos = implode("\n", ss_policy_logged($spy, 'info'));
+    expect($infos)->toContain('Return shipping label created')
+        ->and($infos)->not->toContain('Tracking number stored');
+});
+
+it('logs an info event when the shopper selects a pick-up point at checkout', function () {
+    $spy     = spy_on_logger();
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_agent']);
+
+    WC()->session->set('ss_shipping_agents', [sample_agent()]);
+    $_POST['ss_shipping_store_pickup'] = '1234';
+    remember_cleanup_callback(function (): void {
+        unset($_POST['ss_shipping_store_pickup']);
+        WC()->session->set('ss_shipping_agents', null);
+    });
+
+    (new SS_Shipping_Frontend())->process_ss_pickup_points($order->get_id(), null);
+
+    $selected = ss_policy_entry($spy, 'Pick-up point selected at checkout');
+    expect($selected)->not->toBeNull()
+        ->and($selected['level'])->toBe('info')
+        ->and($selected['context']['order_id'])->toBe($order->get_id())
+        ->and($selected['context']['agent_no'])->toBe('1234');
+
+    expect(SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_ss_shipping_order_agent_no($order->get_id()))->toBe('1234');
+});
+
+it('logs an info event when the pick-up point is changed on an order', function () {
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => sample_agent(['agent_no' => '5678'])]);
+    });
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_agent']);
+
+    $method = new ReflectionMethod(SS_Shipping_WC_Order::class, 'save_shipping_agent');
+    $result = $method->invoke(SS_SHIPPING_WC()->get_ss_shipping_wc_order(), $order->get_id(), true, '5678');
+
+    expect($result)->toBeTrue();
+
+    $changed = ss_policy_entry($spy, 'Pick-up point changed on order');
+    expect($changed)->not->toBeNull()
+        ->and($changed['level'])->toBe('info')
+        ->and($changed['context']['order_id'])->toBe($order->get_id())
+        ->and($changed['context']['agent_no'])->toBe('5678')
+        ->and($changed['context']['carrier'])->toBe('postnord');
+});
+
+it('logs a warning when the agent number is rejected, even with the debug setting off', function () {
+    with_ss_settings(['ss_debug' => 'no']);
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(404, ['code' => 'NoResults', 'message' => 'The agent was not found.']);
+    });
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_agent']);
+
+    $method = new ReflectionMethod(SS_Shipping_WC_Order::class, 'save_shipping_agent');
+    $result = $method->invoke(SS_SHIPPING_WC()->get_ss_shipping_wc_order(), $order->get_id(), true, '9999');
+
+    expect($result)->toBeString();
+
+    $rejected = ss_policy_entry($spy, 'Pick-up point not found - agent number rejected');
+    expect($rejected)->not->toBeNull()
+        ->and($rejected['level'])->toBe('warning')
+        ->and($rejected['context']['agent_no'])->toBe('9999');
+});
+
+it('logs a debug trace when the meta box is rendered for a non Smart Send order', function () {
+    $spy     = spy_on_logger();
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order(['products' => [$product]]); // No Smart Send shipping item.
+
+    ob_start();
+    SS_SHIPPING_WC()->get_ss_shipping_wc_order()->render_smart_send_order_meta_box($order);
+    $output = ob_get_clean();
+
+    expect($output)->toContain('Order placed with a shipping method that is not from the Smart Send plugin')
+        ->and(implode("\n", ss_policy_logged($spy, 'debug')))->toContain('No Smart Send shipping method on order - skipping meta box content');
+});
+
+it('surfaces which Smart Send rates ended up offered for the package', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    $spy = spy_on_logger();
+
+    $ss_rate = new WC_Shipping_Rate('smart_send_shipping:7', 'SS Policy Rate', '49', [], 'smart_send_shipping', 7);
+    $other   = new WC_Shipping_Rate('flat_rate:3', 'Flat rate', '10', [], 'flat_rate', 3);
+
+    SS_SHIPPING_WC()->ss_sort_shipping_methods([
+        'smart_send_shipping:7' => $ss_rate,
+        'flat_rate:3'           => $other,
+    ]);
+
+    $expected = 'Smart Send: rates offered for this package: "SS Policy Rate" (smart_send_shipping:7, cost 49).';
+    $trace    = implode("\n", ss_policy_notices());
+
+    expect($trace)->toContain($expected)
+        ->and($trace)->not->toContain('Flat rate')
+        ->and(implode("\n", ss_policy_logged($spy, 'debug')))->toContain($expected);
+});
+
+it('reports when no Smart Send rates were offered for the package', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    spy_on_logger();
+
+    $other = new WC_Shipping_Rate('flat_rate:3', 'Flat rate', '10', [], 'flat_rate', 3);
+
+    SS_SHIPPING_WC()->ss_sort_shipping_methods(['flat_rate:3' => $other]);
+
+    expect(implode("\n", ss_policy_notices()))->toContain('Smart Send: no Smart Send rates offered for this package.');
+});
+
+it('explains that the last matching weight row wins when rows overlap', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    $spy = spy_on_logger();
+
+    $product = create_simple_product(['price' => 100, 'weight' => 2]);
+    $package = ss_policy_package([$product]);
+
+    $method = ss_policy_method([
+        'cost_weight' => [
+            ['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49'],
+            ['ss_min_weight' => '1', 'ss_max_weight' => '10', 'ss_cost_weight' => '99'],
+        ],
+    ]);
+    $method->calculate_shipping($package);
+
+    $unit     = get_option('woocommerce_weight_unit');
+    $expected = 'Smart Send "SS Policy Method": 2 overlapping weight table rows matched (1-5 ' . $unit . ', 1-10 ' . $unit
+        . ') - the rows share rate id smart_send_shipping:99951, so only the LAST matching row (1-10 ' . $unit
+        . ') is offered and the earlier matches were overwritten.';
+
+    // v8 oddity, unchanged: the last matching row silently wins.
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(99.0)
+        ->and(ss_policy_notices())->toContain($expected)
+        ->and(implode("\n", ss_policy_logged($spy, 'debug')))->toContain($expected);
+});
+
+it('adds no overlap notice when only one weight row matches', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    spy_on_logger();
+
+    $product = create_simple_product(['price' => 100, 'weight' => 2]);
+    $package = ss_policy_package([$product]);
+
+    $method = ss_policy_method([
+        'cost_weight' => [
+            ['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49'],
+            ['ss_min_weight' => '5', 'ss_max_weight' => '10', 'ss_cost_weight' => '99'],
+        ],
+    ], 99952);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and(implode("\n", ss_policy_notices()))->not->toContain('overlapping weight table rows');
+});
+
+it('no longer logs the removed noise entries', function () {
+    with_ss_settings(['ss_debug' => 'yes', 'sort_methods_by_cost' => 'yes']);
+    $spy = spy_on_logger();
+
+    $product = create_simple_product(['price' => 100, 'weight' => 2]);
+    $package = ss_policy_package([$product]);
+
+    // Free shipping path.
+    $free = ss_policy_method([
+        'requires'     => 'enabled',
+        'flatfee_cost' => '25',
+    ], 99953);
+    $free->calculate_shipping($package);
+
+    // Weight table path.
+    $weighted = ss_policy_method([
+        'cost_weight' => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ], 99954);
+    $weighted->calculate_shipping($package);
+
+    // Sorting path.
+    SS_SHIPPING_WC()->ss_sort_shipping_methods([
+        'smart_send_shipping:7' => new WC_Shipping_Rate('smart_send_shipping:7', 'SS Policy Rate', '49', [], 'smart_send_shipping', 7),
+        'flat_rate:3'           => new WC_Shipping_Rate('flat_rate:3', 'Flat rate', '10', [], 'flat_rate', 3),
+    ]);
+
+    $all = implode("\n", array_column($spy->entries, 'message'));
+
+    expect($all)->not->toContain('Handling shipping rate')
+        ->and($all)->not->toContain('Rate details (json decode for details)')
+        ->and($all)->not->toContain('Free shipping rate added')
+        ->and($all)->not->toContain('Weight based shipping rate added')
+        ->and($all)->not->toContain('Shipping methods sorted by cost');
+});

--- a/tests/Integration/LoggingPolicyTest.php
+++ b/tests/Integration/LoggingPolicyTest.php
@@ -309,6 +309,120 @@ it('adds no overlap notice when only one weight row matches', function () {
         ->and(implode("\n", ss_policy_notices()))->not->toContain('overlapping weight table rows');
 });
 
+it('logs the rate calculation start and cost outcome as a debug trace', function () {
+    $spy = spy_on_logger();
+
+    $product = create_simple_product(['price' => 100, 'weight' => 2]);
+    $package = ss_policy_package([$product]);
+
+    $method = ss_policy_method([
+        'cost_weight' => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ], 99955);
+    $method->calculate_shipping($package);
+
+    $debugs = implode("\n", ss_policy_logged($spy, 'debug'));
+    expect($debugs)->toContain('Calculating shipping cost for shipping rate smart_send_shipping:99955')
+        ->and($debugs)->toContain('Calculated shipping cost for shipping rate smart_send_shipping:99955: 49');
+
+    $outcome = ss_policy_entry($spy, 'Calculated shipping cost for shipping rate smart_send_shipping:99955: 49');
+    expect($outcome)->not->toBeNull()
+        ->and($outcome['context']['rate_id'])->toBe('smart_send_shipping:99955');
+});
+
+it('logs a not-available outcome when the cost calculation adds no rate', function () {
+    $spy = spy_on_logger();
+
+    $product = create_simple_product(['price' => 100, 'weight' => 10]);
+    $package = ss_policy_package([$product]);
+
+    $method = ss_policy_method([
+        'cost_weight' => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ], 99956);
+    $method->calculate_shipping($package);
+
+    $debugs = implode("\n", ss_policy_logged($spy, 'debug'));
+    expect($method->rates)->toHaveCount(0)
+        ->and($debugs)->toContain('Calculating shipping cost for shipping rate smart_send_shipping:99956')
+        ->and($debugs)->toContain('Shipping rate smart_send_shipping:99956 is not available for this package - no rate added');
+});
+
+it('logs an error when the order cannot be loaded while deleting pick-up point meta, even with debug off', function () {
+    with_ss_settings(['ss_debug' => 'no']);
+    $spy = spy_on_logger();
+
+    SS_SHIPPING_WC()->get_ss_shipping_wc_order()->delete_ss_shipping_order_agent(999999999);
+
+    $failed = ss_policy_entry($spy, 'Failed to load WooCommerce order when deleting pick-up point meta - skipping');
+    expect($failed)->not->toBeNull()
+        ->and($failed['level'])->toBe('error')
+        ->and($failed['context']['order_id'])->toBe(999999999);
+});
+
+/**
+ * Run the Validate API Token AJAX callback in-process: forge the nonce,
+ * make wp_doing_ajax() return true (outside AJAX wp_send_json() calls plain
+ * `die` and would kill the test process), and intercept the resulting
+ * wp_die() via the die handler filter.
+ */
+function ss_policy_run_connection_test(): void
+{
+    $_REQUEST['test_connection_nonce'] = wp_create_nonce('ss-test-connection');
+
+    $die_handler = function () {
+        return function (): void {
+            throw new RuntimeException('wp_die intercepted');
+        };
+    };
+    add_filter('wp_doing_ajax', '__return_true');
+    add_filter('wp_die_handler', $die_handler);
+    add_filter('wp_die_ajax_handler', $die_handler);
+
+    remember_cleanup_callback(function () use ($die_handler): void {
+        unset($_REQUEST['test_connection_nonce']);
+        remove_filter('wp_doing_ajax', '__return_true');
+        remove_filter('wp_die_handler', $die_handler);
+        remove_filter('wp_die_ajax_handler', $die_handler);
+    });
+
+    ob_start();
+    try {
+        SS_SHIPPING_WC()->ss_test_connection_callback();
+    } catch (RuntimeException $e) {
+        // Expected: wp_send_json() ends with wp_die().
+    }
+    ob_end_clean();
+}
+
+it('logs a successful connection test at info level even with the debug setting off', function () {
+    with_ss_settings(['ss_debug' => 'no', 'api_token' => 'policy-test-token']);
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => ['email' => 'merchant@example.test', 'website' => 'example.test']]);
+    });
+
+    ss_policy_run_connection_test();
+
+    $succeeded = ss_policy_entry($spy, 'API token connection test succeeded');
+    expect($succeeded)->not->toBeNull()
+        ->and($succeeded['level'])->toBe('info')
+        ->and($succeeded['context']['message'])->toContain('merchant@example.test');
+});
+
+it('logs a failed connection test at error level with the API response detail in context', function () {
+    with_ss_settings(['ss_debug' => 'no', 'api_token' => 'policy-test-token']);
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(401, ['code' => 'Unauthenticated', 'message' => 'The API token is invalid.']);
+    });
+
+    ss_policy_run_connection_test();
+
+    $failed = ss_policy_entry($spy, 'API token connection test failed');
+    expect($failed)->not->toBeNull()
+        ->and($failed['level'])->toBe('error')
+        ->and($failed['context']['message'])->toContain('The API token is invalid.');
+});
+
 it('no longer logs the removed noise entries', function () {
     with_ss_settings(['ss_debug' => 'yes', 'sort_methods_by_cost' => 'yes']);
     $spy = spy_on_logger();

--- a/tests/Integration/PickupLookupDebugTest.php
+++ b/tests/Integration/PickupLookupDebugTest.php
@@ -212,3 +212,33 @@ it('renders the agent dropdown and no failure notice when the lookup succeeds', 
         ->and($output)->not->toContain('Shipping to closest pick-up point')
         ->and(implode("\n", pickup_debug_notice_texts()))->not->toContain('pick-up point lookup');
 });
+
+it('surfaces a success summary with the carrier and result count (#92)', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    with_ss_settings(['ss_debug' => 'yes']); // Debug-level log entries require the plugin debug setting.
+    $spy = spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent(), sample_agent(['agent_no' => '5678'])]]);
+    });
+
+    $output = pickup_debug_render();
+
+    $expected = 'Smart Send: found 2 postnord pick-up points near the entered address.';
+
+    expect($output)->toContain('ss_shipping_store_pickup')
+        ->and(pickup_debug_notice_texts())->toContain($expected)
+        ->and(implode("\n", pickup_debug_logged($spy, 'debug')))->toContain($expected);
+});
+
+it('adds no success summary notice when shipping debug mode is off', function () {
+    with_option('woocommerce_shipping_debug_mode', 'no');
+    spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent()]]);
+    });
+
+    $output = pickup_debug_render();
+
+    expect($output)->toContain('ss_shipping_store_pickup')
+        ->and(wc_notice_count())->toBe(0);
+});


### PR DESCRIPTION
Implements the two-surface logging policy from #92: the checkout shipping debug bar for live checkout diagnosis, and the WooCommerce log as an info-level audit trail plus debug-level developer trace.

## Gating change (review decision)

**Only `debug` is gated on the plugin "Debug Log" (`ss_debug`) setting; `info`, `warning`, `error` and `critical` always log.** Previously `info` was gated together with `debug`. With debug off, the log now still carries the full business-event audit trail (labels, tracking, pick-up points, connection tests) and all warnings/errors; enabling debug adds the developer trace on top. The `smart_send_logging` filter continues to apply to all levels.

## Call site audit

### Reassigned to `info` (business events, always logged)

| Call site | Old | New |
|---|---|---|
| `class-ss-shipping-wc-order.php` `save_shipping_agent()` — agent found | `log()` "Agent found and saved." | `info` "Pick-up point changed on order" (context: order_id, agent_no, carrier) |
| `class-ss-shipping-wc-order.php` `create_label_for_single_order()` — label success | *(not logged)* | `info` "Shipping label created" / "Return shipping label created" (context: order_id, shipment_id, carrier) |
| `class-ss-shipping-wc-order.php` — order note saved | *(not logged)* | `info` "Order note with label and tracking added" (context: order_id) |
| `class-ss-shipping-wc-order.php` — tracking saved per parcel | *(not logged)* | `info` "Tracking number stored" (context: order_id, tracking_code, carrier) |
| `class-ss-shipping-frontend.php` `process_ss_pickup_points()` | *(not logged)* | `info` "Pick-up point selected at checkout" (context: order_id, agent_no) |
| `smart-send-logistics.php` connection test — success | `log( $connection_msg )` | `info` "API token connection test succeeded" (API response detail in context; visible regardless of the debug setting) |

### Reassigned to `warning` / `error` (recoverable-but-abnormal, always logged)

| Call site | Old | New |
|---|---|---|
| `save_shipping_agent()` — agent number rejected | `log()` "Agent NOT found." | `warning` "Pick-up point not found - agent number rejected" |
| `delete_ss_shipping_order_agent()` — order cannot be loaded | `log()` "Failed to load WooCommerce order: N" | `error` "Failed to load WooCommerce order when deleting pick-up point meta - skipping" (context: order_id) |
| connection test — failure | `log( $connection_msg )` | `error` "API token connection test failed" (API response detail in context) |

### Kept/clarified at `debug` (developer trace, gated on ss_debug)

| Call site | Old | New |
|---|---|---|
| `calculate_shipping()` — evaluation starts | `log()` "Handling shipping rate &lt;id&gt; with title: ..." | `debug` "Calculating shipping cost for shipping rate {id}" (context: rate_id, label, method) |
| `calculate_shipping()` — evaluation outcome | *(raw JSON dumps, see removed)* | `debug` "Calculated shipping cost for shipping rate {id}: {cost}" or "Shipping rate {id} is not available for this package - no rate added" |
| `render_smart_send_order_meta_box()` — non-SS order | *(not logged)* | `debug` "No Smart Send shipping method on order - skipping meta box content" (normal flow, stays debug) |
| rate trace lines from #5 (free shipping, weight rows, exclusions) | `debug` (message only) | `debug` unchanged messages, structured data moved to context arrays |
| API request cycles | `log_api_request` | unchanged |

### Removed (noise serving neither surface)

| Call site | Removed entry |
|---|---|
| `calculate_shipping()` | `log()` "Rate details (json decode for details): {...}" (raw JSON dump incl. the whole package) |
| `calculate_shipping()` | `log()` "Free shipping rate added" (redundant with the free-shipping debug trace) |
| `calculate_shipping()` | `log()` "Weight based shipping rate added (json decode for details): {...}" (raw JSON dump; detail now in the debug trace's context) |
| `ss_sort_shipping_methods()` | `log()` "Shipping methods sorted by cost" (no data; superseded by the per-package rates summary) |

## Uniqueness filtering findings

There is **no explicit uniqueness/dedup code in the plugin**. The mechanism is implicit: every matching weight table row calls `$this->add_rate( $rate )` with the **same rate id** (`smart_send_shipping:<instance>`), and WooCommerce core's `WC_Shipping_Method::add_rate()` stores rates keyed by id (`$this->rates[ $args['id'] ]`), so each later matching row silently overwrites the earlier one — the "overlapping weight brackets: last matching row silently wins" v8 oddity pinned by RateCalculationTest. The new debug output names this outcome explicitly instead of leaving it invisible. Behaviour is unchanged.

## New checkout debug bar lines (shipping debug mode on)

- Per-package summary, emitted from the `woocommerce_package_rates` filter after all methods have calculated:
  - `Smart Send: rates offered for this package: "PostNord pick-up" (smart_send_shipping:7, cost 49).`
  - `Smart Send: no Smart Send rates offered for this package.`
- Overlapping weight rows (the uniqueness outcome, per method):
  - `Smart Send "My method": 2 overlapping weight table rows matched (1-5 kg, 1-10 kg) - the rows share rate id smart_send_shipping:99951, so only the LAST matching row (1-10 kg) is offered and the earlier matches were overwritten.`
- Pick-up point lookup success summary (failure reasons already existed from #47/#88):
  - `Smart Send: found 2 postnord pick-up points near the entered address.`

All three also log at `debug`.

## CLAUDE.md

Added a "Logging policy" section documenting the two surfaces and the level table with one-line examples (updated for the ungated-info decision), so future code places calls correctly.

## Tests

- `tests/Integration/LoggingPolicyTest.php` (16 tests): info events on label creation (incl. return label, order note, tracking storage), pick-up point selected at checkout, pick-up point changed on an order, warning on rejected agent number (with debug off), meta-box skip debug trace, per-package rates summary (offered + none), overlap explanation (rate/cost behaviour unchanged), no overlap notice for a single match, rate-calc start/outcome debug trace (cost + not-available), error on unloadable order during pick-up point meta deletion, connection-test success (info, visible with debug off) and failure (error), and removed-noise assertions.
- `LoggerTest.php`: gating matrix updated — only debug is gated; info/warning/error/critical always log.
- `PickupLookupDebugTest.php`: success summary notice + gating when shipping debug mode is off.
- LoggingPolicyTest is named to sort before `ShippingDebugModeTest.php` (whose WC_DOING_AJAX tests poison later notice assertions).

Suite: 131 passed (488 assertions). `vendor/bin/phpcs` and `composer phpcs:compat` clean. No behaviour changes beyond log/notice output.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)
