### PR TITLE
Add PHP version to API request User-Agent

### DIFF
--- a/smart-send-logistics/includes/lib/Smartsend/Client.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Client.php
@@ -111,6 +111,7 @@ class Client
             "WordPress"     => get_bloginfo('version'),
             "WooCommerce"   => $wooCommerceVersion,
             "SmartSend"     => $this->getModuleVersion(),
+            "PHP"           => phpversion(),
         );
         $userAgentString = str_replace('=', '/', http_build_query($userAgent, '', ' '));
 


### PR DESCRIPTION
## What changed

Added the shop's PHP version to the User-Agent header sent with all Smart Send API requests, via `Client::getUserAgent()` in `smart-send-logistics/includes/lib/Smartsend/Client.php`. The header now reports WordPress, WooCommerce, plugin, and PHP versions:

```
WordPress/6.7 WooCommerce/11.0 SmartSend/8.2.0 PHP/8.2.1
```

## Why

Knowing the shop's PHP version server-side helps diagnose customer issues and track the installed-base PHP distribution.

## Notes for reviewers

- `phpversion()` exists on the plugin's PHP 5.6 floor, and the existing `http_build_query` + `str_replace` construction handles version strings with dots/hyphens cleanly (verified locally).
- All requests go through this shared header setup, so every API call gets the new component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)