### PR TITLE
Extract order-data utility and fix payload totals rules

### DIFF
--- a/smart-send-logistics/includes/class-ss-shipping-order-data.php
+++ b/smart-send-logistics/includes/class-ss-shipping-order-data.php
@@ -150,12 +150,13 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 
 				$quantity = $item->get_quantity();
 
-				// Total w/o tax and individual w/o tax.
-				$total_price_excluding_tax = (float) $item->get_subtotal();
+				// Total w/o tax and individual w/o tax. Clamped at >= 0 so a
+				// negative line never produces a negative item value (#54).
+				$total_price_excluding_tax = max( 0.0, (float) $item->get_subtotal() );
 				$unit_price_excluding_tax  = $total_price_excluding_tax / $quantity;
 
 				// Total tax.
-				$total_tax_amount = (float) $item->get_subtotal_tax();
+				$total_tax_amount = max( 0.0, (float) $item->get_subtotal_tax() );
 
 				// Total w/ tax and individual w/ tax.
 				$total_price_including_tax = $total_price_excluding_tax + $total_tax_amount;
@@ -186,47 +187,56 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 		/**
 		 * Get the order totals used on the shipment and parcel level.
 		 *
+		 * The rule (see issue #72): totals are derived from what WooCommerce
+		 * itself reports via CRUD getters and reconcile with
+		 * WC_Order::get_total(): subtotal + shipping = total, on both the
+		 * including-tax and excluding-tax basis. Every value is clamped at
+		 * >= 0, so a discount or gift card larger than the item value (which
+		 * can push the non-shipping subtotal negative) never produces a
+		 * negative amount in the booking request (#54). When a clamp kicks
+		 * in, the clamped value wins over strict reconciliation.
+		 *
 		 * @return array {
 		 *     Order totals.
 		 *
-		 *     @type float|string $subtotal_price_excluding_tax Order total excl. shipping, excl. tax.
-		 *     @type float|string $subtotal_price_including_tax Order total excl. shipping, incl. tax.
-		 *     @type float|string $subtotal_tax_amount          Tax on the order total excl. shipping.
-		 *     @type float|string $shipping_price_excluding_tax Shipping cost excl. tax.
-		 *     @type float|string $shipping_price_including_tax Shipping cost incl. tax.
-		 *     @type float|string $shipping_tax_amount          Tax on the shipping cost.
-		 *     @type float|string $total_price_excluding_tax    Order total excl. tax.
-		 *     @type float|string $total_price_including_tax    Order total incl. tax.
-		 *     @type float|string $total_tax_amount             Total tax on the order.
-		 *     @type string       $currency                     Order currency code.
+		 *     @type float  $subtotal_price_excluding_tax Order total excl. shipping, excl. tax.
+		 *     @type float  $subtotal_price_including_tax Order total excl. shipping, incl. tax.
+		 *     @type float  $subtotal_tax_amount          Tax on the order total excl. shipping.
+		 *     @type float  $shipping_price_excluding_tax Shipping cost excl. tax.
+		 *     @type float  $shipping_price_including_tax Shipping cost incl. tax.
+		 *     @type float  $shipping_tax_amount          Tax on the shipping cost.
+		 *     @type float  $total_price_excluding_tax    Order total excl. tax.
+		 *     @type float  $total_price_including_tax    Order total incl. tax.
+		 *     @type float  $total_tax_amount             Total tax on the order.
+		 *     @type string $currency                     Order currency code.
 		 * }
 		 */
 		public function get_totals() {
-			// Order totals.
-			$order_total      = $this->order->get_total();
-			$order_total_tax  = $this->order->get_total_tax();
-			$order_total_excl = $order_total - $order_total_tax;
+			// Order totals, as WooCommerce itself reports them.
+			$total_including_tax = (float) $this->order->get_total();
+			$total_tax           = (float) $this->order->get_total_tax();
+			$total_excluding_tax = $total_including_tax - $total_tax;
 
-			// Shipping totals.
-			$order_shipping      = $this->order->get_shipping_total();
-			$order_shipping_tax  = $this->order->get_shipping_tax();
-			$order_shipping_excl = $order_shipping - $order_shipping_tax;
+			// Shipping totals. WC_Order::get_shipping_total() is excluding tax.
+			$shipping_excluding_tax = (float) $this->order->get_shipping_total();
+			$shipping_tax           = (float) $this->order->get_shipping_tax();
+			$shipping_including_tax = $shipping_excluding_tax + $shipping_tax;
 
-			// Order totals without shipping.
-			$order_subtotal      = $order_total - $order_shipping;
-			$order_subtotal_tax  = $order_total_tax - $order_shipping_tax;
-			$order_subtotal_excl = $order_total_excl - $order_subtotal_tax;
+			// The non-shipping part of the order: items, fees and discounts.
+			$subtotal_including_tax = $total_including_tax - $shipping_including_tax;
+			$subtotal_tax           = $total_tax - $shipping_tax;
+			$subtotal_excluding_tax = $subtotal_including_tax - $subtotal_tax;
 
 			return array(
-				'subtotal_price_excluding_tax' => $order_subtotal_excl,
-				'subtotal_price_including_tax' => $order_subtotal,
-				'subtotal_tax_amount'          => $order_subtotal_tax,
-				'shipping_price_excluding_tax' => $order_shipping_excl,
-				'shipping_price_including_tax' => $order_shipping,
-				'shipping_tax_amount'          => $order_shipping_tax,
-				'total_price_excluding_tax'    => $order_total_excl,
-				'total_price_including_tax'    => $order_total,
-				'total_tax_amount'             => $order_total_tax,
+				'subtotal_price_excluding_tax' => max( 0.0, $subtotal_excluding_tax ),
+				'subtotal_price_including_tax' => max( 0.0, $subtotal_including_tax ),
+				'subtotal_tax_amount'          => max( 0.0, $subtotal_tax ),
+				'shipping_price_excluding_tax' => max( 0.0, $shipping_excluding_tax ),
+				'shipping_price_including_tax' => max( 0.0, $shipping_including_tax ),
+				'shipping_tax_amount'          => max( 0.0, $shipping_tax ),
+				'total_price_excluding_tax'    => max( 0.0, $total_excluding_tax ),
+				'total_price_including_tax'    => max( 0.0, $total_including_tax ),
+				'total_tax_amount'             => max( 0.0, $total_tax ),
 				'currency'                     => $this->order->get_currency(),
 			);
 		}

--- a/smart-send-logistics/includes/class-ss-shipping-order-data.php
+++ b/smart-send-logistics/includes/class-ss-shipping-order-data.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * WooCommerce Smart Send order data access.
+ *
+ * @package  SS_Shipping_Order_Data
+ * @category Shipping
+ * @author   Smart Send
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
+
+	/**
+	 * Answers every order-data question needed to build the booking request
+	 * (shipment payload) from a WC_Order, using WooCommerce CRUD getters only.
+	 *
+	 * This is the single place that knows how to read receiver address data,
+	 * item lines with weight/price/customs data and order totals. The class
+	 * returns plain arrays; assembling the Smart Send API models from them is
+	 * the job of SS_Shipping_Shipment.
+	 */
+	class SS_Shipping_Order_Data {
+
+		/**
+		 * The WooCommerce order.
+		 *
+		 * @var WC_Order
+		 */
+		protected $order;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Order $order The WooCommerce order.
+		 */
+		public function __construct( WC_Order $order ) {
+			$this->order = $order;
+		}
+
+		/**
+		 * Get the order id.
+		 *
+		 * @return int
+		 */
+		public function get_order_id() {
+			return $this->order->get_id();
+		}
+
+		/**
+		 * Get the order number (differs from the id when plugins customize it).
+		 *
+		 * @return string
+		 */
+		public function get_order_number() {
+			return $this->order->get_order_number();
+		}
+
+		/**
+		 * Get the receiver (shipping destination) data for the order.
+		 *
+		 * @return array {
+		 *     Receiver data.
+		 *
+		 *     @type string      $company       Company name.
+		 *     @type string      $name_line1    First name.
+		 *     @type string      $name_line2    Last name.
+		 *     @type string      $address_line1 Address line 1.
+		 *     @type string      $address_line2 Address line 2.
+		 *     @type string      $postal_code   Postal code.
+		 *     @type string      $city          City.
+		 *     @type string      $country       ISO country code.
+		 *     @type string|null $phone         Phone number, if usable for SMS notification.
+		 *     @type string|null $email         Email address.
+		 * }
+		 */
+		public function get_receiver_data() {
+			$billing_address = $this->order->get_address();
+
+			/*
+			 * Filter the receiver address used for the shipping label.
+			 *
+			 * @param array $shipping_address The order shipping address.
+			 * @param int   $order_id         Order ID.
+			 */
+			$shipping_address = apply_filters(
+				'smart_send_order_receiver',
+				$this->order->get_address( 'shipping' ),
+				$this->order->get_id()
+			);
+
+			// The shipping phone field was added in WooCommerce 5.6 but often added by hooks/plugins before that.
+			// Note that the field is not shown on checkout per default but can be enabled by filters/plugins.
+			// See: https://github.com/woocommerce/woocommerce/pull/30097#issuecomment-943114632
+			if ( isset( $shipping_address['phone'] ) && $shipping_address['phone'] ) {
+				$phone = $shipping_address['phone'];
+			} elseif ( $shipping_address['country'] === $billing_address['country'] ) { // Require as only local phone numbers is accepted.
+				$phone = $billing_address['phone'];
+			} else {
+				$phone = null;
+			}
+
+			// The shipping email field does not exist in default WP installations but can be added by filters/hooks.
+			if ( ! isset( $shipping_address['email'] ) && isset( $billing_address['email'] ) ) {
+				$shipping_address['email'] = $billing_address['email'];
+			}
+
+			return array(
+				'company'       => $shipping_address['company'],
+				'name_line1'    => $shipping_address['first_name'],
+				'name_line2'    => $shipping_address['last_name'],
+				'address_line1' => $shipping_address['address_1'],
+				'address_line2' => $shipping_address['address_2'],
+				'postal_code'   => $shipping_address['postcode'],
+				'city'          => $shipping_address['city'],
+				'country'       => $shipping_address['country'],
+				'phone'         => $phone,
+				'email'         => isset( $shipping_address['email'] ) ? $shipping_address['email'] : null,
+			);
+		}
+
+		/**
+		 * Get the item lines for the order: one row per order line with
+		 * weight, price and customs data.
+		 *
+		 * Prices are based on the pre-discount line subtotal, matching how
+		 * the plugin has always priced item lines (order-level discounts are
+		 * reflected in the order totals, not the individual lines).
+		 *
+		 * @return array[] List of item rows.
+		 */
+		public function get_items_data() {
+			$items = array();
+
+			foreach ( $this->order->get_items() as $item ) {
+				$product = wc_get_product( $item->get_product_id() );
+
+				if ( $item->get_variation_id() ) {
+					$product_variation = wc_get_product( $item->get_variation_id() );
+					$product_id        = $item->get_variation_id();
+					$product_sku       = $product_variation->get_sku() ? $product_variation->get_sku() : strval( $item->get_variation_id() );
+				} else {
+					$product_variation = $product;
+					$product_id        = $item->get_product_id();
+					// Ensure id is string and not int.
+					$product_sku = $product->get_sku() ? $product->get_sku() : strval( $item->get_product_id() );
+				}
+
+				$quantity = $item->get_quantity();
+
+				// Total w/o tax and individual w/o tax.
+				$total_price_excluding_tax = (float) $item->get_subtotal();
+				$unit_price_excluding_tax  = $total_price_excluding_tax / $quantity;
+
+				// Total tax.
+				$total_tax_amount = (float) $item->get_subtotal_tax();
+
+				// Total w/ tax and individual w/ tax.
+				$total_price_including_tax = $total_price_excluding_tax + $total_tax_amount;
+				$unit_price_including_tax  = $total_price_including_tax / $quantity;
+
+				$unit_weight = round( wc_get_weight( $product_variation->get_weight(), 'kg' ), 2 );
+
+				$items[] = array(
+					'id'                        => $product_id,
+					'sku'                       => $product_sku,
+					'name'                      => $product->get_title(),
+					'description'               => $this->get_product_meta( $product, '_ss_customs_desc' ),
+					'hs_code'                   => $this->get_product_meta( $product, '_ss_hs_code' ),
+					'country_of_origin'         => $this->get_product_meta( $product, '_ss_country_of_origin' ),
+					'quantity'                  => $quantity,
+					'unit_weight'               => $unit_weight,
+					'unit_price_excluding_tax'  => $unit_price_excluding_tax,
+					'unit_price_including_tax'  => $unit_price_including_tax,
+					'total_price_excluding_tax' => $total_price_excluding_tax,
+					'total_price_including_tax' => $total_price_including_tax,
+					'total_tax_amount'          => $total_tax_amount,
+				);
+			}
+
+			return $items;
+		}
+
+		/**
+		 * Get the order totals used on the shipment and parcel level.
+		 *
+		 * @return array {
+		 *     Order totals.
+		 *
+		 *     @type float|string $subtotal_price_excluding_tax Order total excl. shipping, excl. tax.
+		 *     @type float|string $subtotal_price_including_tax Order total excl. shipping, incl. tax.
+		 *     @type float|string $subtotal_tax_amount          Tax on the order total excl. shipping.
+		 *     @type float|string $shipping_price_excluding_tax Shipping cost excl. tax.
+		 *     @type float|string $shipping_price_including_tax Shipping cost incl. tax.
+		 *     @type float|string $shipping_tax_amount          Tax on the shipping cost.
+		 *     @type float|string $total_price_excluding_tax    Order total excl. tax.
+		 *     @type float|string $total_price_including_tax    Order total incl. tax.
+		 *     @type float|string $total_tax_amount             Total tax on the order.
+		 *     @type string       $currency                     Order currency code.
+		 * }
+		 */
+		public function get_totals() {
+			// Order totals.
+			$order_total      = $this->order->get_total();
+			$order_total_tax  = $this->order->get_total_tax();
+			$order_total_excl = $order_total - $order_total_tax;
+
+			// Shipping totals.
+			$order_shipping      = $this->order->get_shipping_total();
+			$order_shipping_tax  = $this->order->get_shipping_tax();
+			$order_shipping_excl = $order_shipping - $order_shipping_tax;
+
+			// Order totals without shipping.
+			$order_subtotal      = $order_total - $order_shipping;
+			$order_subtotal_tax  = $order_total_tax - $order_shipping_tax;
+			$order_subtotal_excl = $order_total_excl - $order_subtotal_tax;
+
+			return array(
+				'subtotal_price_excluding_tax' => $order_subtotal_excl,
+				'subtotal_price_including_tax' => $order_subtotal,
+				'subtotal_tax_amount'          => $order_subtotal_tax,
+				'shipping_price_excluding_tax' => $order_shipping_excl,
+				'shipping_price_including_tax' => $order_shipping,
+				'shipping_tax_amount'          => $order_shipping_tax,
+				'total_price_excluding_tax'    => $order_total_excl,
+				'total_price_including_tax'    => $order_total,
+				'total_tax_amount'             => $order_total_tax,
+				'currency'                     => $this->order->get_currency(),
+			);
+		}
+
+		/**
+		 * Get the order note to print as freetext on the shipping label, if
+		 * the "include order comment" setting is enabled.
+		 *
+		 * @return string|null
+		 */
+		public function get_order_note() {
+			$ss_settings = SS_SHIPPING_WC()->get_ss_shipping_settings();
+
+			$order_note = null;
+			if ( 'yes' === $ss_settings['include_order_comment'] ) {
+				$order_note = $this->order->get_customer_note();
+			}
+
+			/*
+			 * Filter the order note which can be printed as freetext on the shipping label.
+			 *
+			 * @param string   $order_note The customer note of the order.
+			 * @param WC_Order $order      The WooCommerce order.
+			 */
+			return apply_filters( 'smart_send_order_note', $order_note, $this->order );
+		}
+
+		/**
+		 * Read a Smart Send product meta value through the product CRUD layer.
+		 *
+		 * @param WC_Product $product  The (parent) product of the order line.
+		 * @param string     $meta_key Meta key to read.
+		 *
+		 * @return mixed The meta value, or an empty string when not set.
+		 */
+		protected function get_product_meta( $product, $meta_key ) {
+			return $product->get_meta( $meta_key, true );
+		}
+	}
+
+endif;

--- a/smart-send-logistics/includes/class-ss-shipping-order-data.php
+++ b/smart-send-logistics/includes/class-ss-shipping-order-data.php
@@ -118,7 +118,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 				$shipping_address['email'] = $billing_address['email'];
 			}
 
-			return array(
+			$receiver_data = array(
 				'company'       => $shipping_address['company'],
 				'name_line1'    => $shipping_address['first_name'],
 				'name_line2'    => $shipping_address['last_name'],
@@ -130,6 +130,14 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 				'phone'         => $phone,
 				'email'         => isset( $shipping_address['email'] ) ? $shipping_address['email'] : null,
 			);
+
+			/*
+			 * Filter the receiver section of the booking request.
+			 *
+			 * @param array    $receiver_data The receiver data (see the return doc above).
+			 * @param WC_Order $order         The WooCommerce order.
+			 */
+			return apply_filters( 'smart_send_payload_receiver', $receiver_data, $this->order );
 		}
 
 		/**
@@ -192,7 +200,13 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 				);
 			}
 
-			return $items;
+			/*
+			 * Filter the item lines of the booking request.
+			 *
+			 * @param array[]  $items One row per order line (see the return doc above).
+			 * @param WC_Order $order The WooCommerce order.
+			 */
+			return apply_filters( 'smart_send_payload_items', $items, $this->order );
 		}
 
 		/**
@@ -238,7 +252,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 			$subtotal_tax           = $total_tax - $shipping_tax;
 			$subtotal_excluding_tax = $subtotal_including_tax - $subtotal_tax;
 
-			return array(
+			$totals = array(
 				'subtotal_price_excluding_tax' => max( 0.0, $subtotal_excluding_tax ),
 				'subtotal_price_including_tax' => max( 0.0, $subtotal_including_tax ),
 				'subtotal_tax_amount'          => max( 0.0, $subtotal_tax ),
@@ -250,6 +264,16 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 				'total_tax_amount'             => max( 0.0, $total_tax ),
 				'currency'                     => $this->order->get_currency(),
 			);
+
+			/*
+			 * Filter the totals section of the booking request. The filter
+			 * runs after the clamping rule, so returned values are used
+			 * as-is.
+			 *
+			 * @param array    $totals The order totals (see the return doc above).
+			 * @param WC_Order $order  The WooCommerce order.
+			 */
+			return apply_filters( 'smart_send_payload_totals', $totals, $this->order );
 		}
 
 		/**

--- a/smart-send-logistics/includes/class-ss-shipping-order-data.php
+++ b/smart-send-logistics/includes/class-ss-shipping-order-data.php
@@ -102,6 +102,17 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 				$phone = null;
 			}
 
+			$phone = $this->normalize_phone( $phone );
+
+			/*
+			 * Filter the receiver phone number used for the shipping label
+			 * and the SMS notification service.
+			 *
+			 * @param string|null $phone The normalized receiver phone number.
+			 * @param WC_Order    $order The WooCommerce order.
+			 */
+			$phone = apply_filters( 'smart_send_receiver_phone', $phone, $this->order );
+
 			// The shipping email field does not exist in default WP installations but can be added by filters/hooks.
 			if ( ! isset( $shipping_address['email'] ) && isset( $billing_address['email'] ) ) {
 				$shipping_address['email'] = $billing_address['email'];
@@ -262,6 +273,33 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 			 * @param WC_Order $order      The WooCommerce order.
 			 */
 			return apply_filters( 'smart_send_order_note', $order_note, $this->order );
+		}
+
+		/**
+		 * Normalize a receiver phone number.
+		 *
+		 * Deliberately minimal for now: strips surrounding whitespace and
+		 * turns empty values into null. This is the seam where local phone
+		 * numbers will be converted to an international format (#56); use
+		 * the smart_send_receiver_phone filter to adjust the number until
+		 * then.
+		 *
+		 * @param string|null $phone The raw phone number.
+		 *
+		 * @return string|null
+		 */
+		protected function normalize_phone( $phone ) {
+			if ( ! $phone ) {
+				return null;
+			}
+
+			$phone = trim( $phone );
+
+			if ( '' === $phone ) {
+				return null;
+			}
+
+			return $phone;
 		}
 
 		/**

--- a/smart-send-logistics/includes/class-ss-shipping-order-data.php
+++ b/smart-send-logistics/includes/class-ss-shipping-order-data.php
@@ -168,9 +168,9 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 					'id'                        => $product_id,
 					'sku'                       => $product_sku,
 					'name'                      => $product->get_title(),
-					'description'               => $this->get_product_meta( $product, '_ss_customs_desc' ),
-					'hs_code'                   => $this->get_product_meta( $product, '_ss_hs_code' ),
-					'country_of_origin'         => $this->get_product_meta( $product, '_ss_country_of_origin' ),
+					'description'               => $this->get_product_meta( $product, $product_variation, '_ss_customs_desc' ),
+					'hs_code'                   => $this->get_product_meta( $product, $product_variation, '_ss_hs_code' ),
+					'country_of_origin'         => $this->get_product_meta( $product, $product_variation, '_ss_country_of_origin' ),
 					'quantity'                  => $quantity,
 					'unit_weight'               => $unit_weight,
 					'unit_price_excluding_tax'  => $unit_price_excluding_tax,
@@ -265,14 +265,25 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 		}
 
 		/**
-		 * Read a Smart Send product meta value through the product CRUD layer.
+		 * Read a Smart Send product meta value through the product CRUD
+		 * layer, variation-aware: the variation's own value wins, falling
+		 * back to the parent product when the variation has none.
 		 *
-		 * @param WC_Product $product  The (parent) product of the order line.
-		 * @param string     $meta_key Meta key to read.
+		 * @param WC_Product $product           The (parent) product of the order line.
+		 * @param WC_Product $product_variation The variation, or the product itself for simple products.
+		 * @param string     $meta_key          Meta key to read.
 		 *
 		 * @return mixed The meta value, or an empty string when not set.
 		 */
-		protected function get_product_meta( $product, $meta_key ) {
+		protected function get_product_meta( $product, $product_variation, $meta_key ) {
+			if ( $product_variation && $product_variation->get_id() !== $product->get_id() ) {
+				$value = $product_variation->get_meta( $meta_key, true );
+
+				if ( '' !== $value && null !== $value ) {
+					return $value;
+				}
+			}
+
 			return $product->get_meta( $meta_key, true );
 		}
 	}

--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -239,6 +239,14 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 				}
 			}
 
+			/*
+			 * Filter the parcels section of the booking request.
+			 *
+			 * @param \Smartsend\Models\Shipment\Parcel[] $parcels The assembled parcel models.
+			 * @param WC_Order                            $order   The WooCommerce order.
+			 */
+			$parcels = apply_filters( 'smart_send_payload_parcels', $parcels, $this->order );
+
 			// Create services.
 			$services = new \Smartsend\Models\Shipment\Services();
 			$services->setSmsNotification( $receiver->getSms() )// Always enable SMS notification.

--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -1,9 +1,4 @@
 <?php
-
-if (!defined('ABSPATH')) {
-    exit; // Exit if accessed directly
-}
-
 /**
  * WooCommerce Smart Send Shipping Order Payload.
  *
@@ -12,476 +7,409 @@ if (!defined('ABSPATH')) {
  * @author   Smart Send
  */
 
-if (!class_exists('SS_Shipping_Shipment')) :
-
-    class SS_Shipping_Shipment
-    {
-
-    	/*
-    	 * WC_Order object
-    	 */
-        protected $order = null;
-        
-        /*
-         * SS_Shipping_WC_Order object
-         */
-        protected $shipping_order = null;
-
-        /*
-         * \Smartsend\Models\Shipment object
-         */
-        protected $shipment = null;
-
-
-        /**
-         * Init and hook in the integration.
-         *
-         * @param WC_Order|integer $order
-         * @param array $shipping_order
-         */
-        public function __construct($order, $shipping_order)
-        {
-
-            if (is_numeric($order) && $order > 0) {
-                $this->order = wc_get_order($order);
-
-                if (!$this->order) {
-                    return;
-                }
-
-            } elseif ($order instanceof WC_Order) {
-                $this->order = $order;
-            } else {
-                return;
-            }
-
-            $this->shipping_order = $shipping_order;
-
-            //New shipment model
-            $this->shipment = new \Smartsend\Models\Shipment();
-        }
-
-        /**
-         * Create single order
-         *
-         * @param boolean $return
-         * @return boolean
-         */
-        public function make_single_shipment_api_call( $return )
-        {
-            $this->make_single_shipment_api_payload( $return );
-            $this->make_single_shipment_api_request();
-
-            if (SS_SHIPPING_WC()->get_api_handle()->isSuccessful()) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-
-        /**
-         * Get API call data
-         *
-         * @return object
-         */
-        public function get_shipping_data()
-        {
-            return SS_SHIPPING_WC()->get_api_handle()->getData();
-        }
-
-        /**
-         * Get error message
-         *
-         * @return string
-         */
-        public function get_error_msg()
-        {
-            return SS_SHIPPING_WC()->get_api_handle()->getErrorString();
-        }
-
-        /**
-         * Get shipment object
-         *
-         * @return \Smartsend\Models\Shipment
-         */
-        public function get_shipment()
-        {
-            return $this->shipment;
-        }
-
-        /**
-         * Create Payload for API request
-         *
-         * @param boolean $return
-         * @return void
-         */
-        protected function make_single_shipment_api_payload( $return )
-        {
-            $order_id = $this->getOrderId($this->order);
-            
-            $ss_args = array();
-
-            // Get shipping method
-            $ss_shipping_method_id = $this->shipping_order->get_smart_send_method_id($order_id, $return);
-
-            if ($return && isset($ss_shipping_method_id['smart_send_return_method'])) {
-                // If no return method set return error
-                if (empty($ss_shipping_method_id['smart_send_return_method'])) {
-                    return array('error' => __('No return method set', 'smart-send-logistics'));
-                } else {
-                    $ss_shipping_method_id = $ss_shipping_method_id['smart_send_return_method'];
-                }
-
-            } else {
-                $ss_args['ss_agent'] = $this->shipping_order->get_ss_shipping_order_agent($order_id);
-            }
-
-            // Determine shipping method and carrier from return settings
-            $shipping_method_carrier = SS_SHIPPING_WC()->get_shipping_method_carrier($ss_shipping_method_id);
-            $shipping_method_type = SS_SHIPPING_WC()->get_shipping_method_type($ss_shipping_method_id);
-
-            $ss_args['ss_carrier'] = $shipping_method_carrier;
-            $ss_args['ss_type'] = $shipping_method_type;
-            $ss_args['ss_parcels'] = $this->shipping_order->get_ss_shipping_order_parcels($order_id);
-
-            /*
-             * Filter the arguments used when creating a shipping label
-             *
-             * @param array $ss_args contains info about shipping carrier, shipping method, agent and parcels
-             * @param int  $order_id  Order ID
-             * @param boolean $return Whether or not the label is return (true) or normal (false)
-             */
-            $ss_args = apply_filters('smart_send_shipping_label_args', $ss_args, $order_id, $return);
-
-            $ss_settings = SS_SHIPPING_WC()->get_ss_shipping_settings();
-
-            // Get address related information
-            $billing_address = $this->order->get_address();
-            $shipping_address = apply_filters(
-            	'smart_send_order_receiver',
-	            $this->order->get_address('shipping'),
-                $this->getOrderId($this->order)
-            );
-
-            // The shipping phone field was added in WooCommerce 5.6 but often added by hooks/plugins before that.
-            // Note that the field is not shown on checkout per default but can be enabled by filters/plugins.
-            // See: https://github.com/woocommerce/woocommerce/pull/30097#issuecomment-943114632
-            if (isset($shipping_address['phone']) && $shipping_address['phone']) { // Field did not exist prior to WooCommerce 5.6
-                $phone = $shipping_address['phone'];
-            } elseif ($shipping_address['country'] == $billing_address['country']) { // Require as only local phone numbers is accepted
-                $phone = $billing_address['phone'];
-            } else {
-                $phone = null;
-            }
-
-            // The shipping email field does not exist in default WP installations but can be added by filters/hooks.
-            if (!isset($shipping_address['email']) && isset($billing_address['email'])) {
-                $shipping_address['email'] = $billing_address['email'];
-            }
-
-            // Make receiver object.
-            $receiver = new \Smartsend\Models\Shipment\Receiver();
-            $receiver->setInternalId($this->getOrderId($this->order))
-                ->setInternalReference($this->order->get_order_number() ? $this->order->get_order_number() : null)
-                ->setCompany($shipping_address['company'] ?: null)
-                ->setNameLine1($shipping_address['first_name'] ?: null)
-                ->setNameLine2($shipping_address['last_name'] ?: null)
-                ->setAddressLine1($shipping_address['address_1'] ?: null)
-                ->setAddressLine2($shipping_address['address_2'] ?: null)
-                ->setPostalCode($shipping_address['postcode'] ?: null)
-                ->setCity($shipping_address['city'] ?: null)
-                ->setCountry($shipping_address['country'] ?: null)
-                ->setSms($phone ?: null)
-                ->setEmail($shipping_address['email'] ?: null);
-
-            // Add the receiver to the shipment
-            $this->shipment->setReceiver($receiver);
-
-            // Add the sender to the shipment (we use the system default for now)
-            //$this->shipment->setSender(Sender $sender);
-
-            $ss_agent = apply_filters(
-              'smart_send_order_agent',
-              empty($ss_args['ss_agent']) ? null : $ss_args['ss_agent'],
-              $this->getOrderId($this->order)
-            );
-
-            if (!empty($ss_agent)) {
-                // Add an agent (pick-up point) to the shipment
-                $agent = new Smartsend\Models\Shipment\Agent();
-                $agent->setInternalId(isset($ss_agent->id) ? $ss_agent->id : $ss_agent->agent_no)
-                    ->setInternalReference(isset($ss_agent->id) ? $ss_agent->id : $ss_agent->agent_no)
-                    ->setAgentNo($ss_agent->agent_no ?: null)
-                    ->setCompany($ss_agent->company ?: null)
-                    // ->setNameLine1(null)
-                    // ->setNameLine2(null)
-                    ->setAddressLine1($ss_agent->address_line1 ?: null)
-                    ->setAddressLine2($ss_agent->address_line2 ?: null)
-                    ->setPostalCode($ss_agent->postal_code ?: null)
-                    ->setCity($ss_agent->city ?: null)
-                    ->setCountry($ss_agent->country ?: null);
-                // ->setSms(null)
-                // ->setEmail(null);
-
-                // Add the agent to the shipment
-                $this->shipment->setAgent($agent);
-            }
-
-            // Get order item specific data
-            $ordered_items = $this->order->get_items();
-
-            // Get product info from the same routine so that we won't have
-            // to iterate through the ordered items once again.
-            $item_data = array();
-
-            if (!empty($ordered_items)) {
-                $items = array();
-                $index = 0;
-                $weight_total = 0;
-                foreach ($ordered_items as $key => $item) {
-                    $product = wc_get_product($item['product_id']);
-
-                    if (!empty($item['variation_id'])) {
-                        $product_variation = wc_get_product($item['variation_id']);
-                        // Ensure id is string and not int
-                        $product_id = $item['variation_id'];
-                        $product_sku = $product_variation->get_sku() ? $product_variation->get_sku() : strval($item['variation_id']);
-
-                        // $product_attribute = wc_get_product_variation_attributes($item['variation_id']);
-                        // $product_description .= ' : ' . current( $product_attribute );
-
-                    } else {
-                        $product_variation = $product;
-                        $product_id = $item['product_id'];
-                        // Ensure id is string and not int
-                        $product_sku = $product->get_sku() ? $product->get_sku() : strval($item['product_id']);
-                    }
-
-                    $product_description = $product->get_title();
-
-                    // WC 3.0 code!
-                    if (defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '3.0', '>=')) {
-                        // $product_val_tax = wc_get_price_including_tax( $product_variation );
-                        // $args['qty'] = $item['qty'];
-                        // $product_val_tax_total = wc_get_price_including_tax( $product_variation, $args );
-
-                        // Total w/o tax and individual w/o tax
-                        $product_val_total = (float)$item->get_subtotal();
-                        $product_val = $product_val_total / $item['qty'];
-
-                        // Total tax
-                        $product_tax_total = (float)$item->get_subtotal_tax();
-
-                        // Total w/ tax and indivdual w/ tax
-                        $product_val_tax_total = $product_val_total + $product_tax_total;
-                        $product_val_tax = $product_val_tax_total / $item['qty'];
-
-
-                        if (!empty($product->get_short_description())) {
-                            $product_description = $product->get_short_description();
-                        } elseif (!empty($product->get_description())) {
-                            $product_description = $product->get_description();
-                        }
-
-                    } else {
-                        // Total w/o tax and individual w/o tax
-                        $product_val_total = (float)$item['line_subtotal'];
-                        $product_val = $product_val_total / $item['qty'];
-
-                        // Total tax
-                        $product_tax_total = (float)$item['line_tax'];
-
-                        // Total w/ tax and indivdual w/ tax
-                        $product_val_tax_total = $product_val_total + $product_tax_total;
-                        $product_val_tax = $product_val_tax_total / $item['qty'];
-
-                        if (!empty($product->post->post_excerpt)) {
-                            $product_description = $product->post->post_excerpt;
-                        } elseif (!empty($product->post->post_content)) {
-                            $product_description = $product->post->post_content;
-                        }
-
-                    }
-
-                    $product_weight = round(wc_get_weight($product_variation->get_weight(), 'kg'), 2);
-                    if ($product_weight) {
-                        $weight_total += ($item['qty'] * $product_weight);
-                    }
-
-                    // Update product/item data array
-                    $item_data[$product_id] = array(
-                        'product_val'     => $product_val,
-                        'product_val_tax' => $product_val_tax,
-                        'product_weight'  => $product_weight,
-                    );
-
-                    $product_img_id = $product->get_image_id();
-                    $product_img_url = wp_get_attachment_url($product_img_id);
-
-                    $hs_code = get_post_meta($item['product_id'], '_ss_hs_code', true);
-                    $custom_desc = get_post_meta($item['product_id'], '_ss_customs_desc', true);
-	                $country_of_origin = get_post_meta($item['product_id'], '_ss_country_of_origin', true);
-
-                    $items[$index] = new \Smartsend\Models\Shipment\Item();
-                    $items[$index]->setInternalId($product_id ?: null)
-                        ->setInternalReference($product_id ?: null)
-                        ->setSku($product_sku ?: null)
-                        ->setName($product->get_title() ?: null)
-                        ->setDescription($custom_desc ?: null)//$product_description can be used, but is often to long (255)
-                        ->setHsCode($hs_code ?: null)
-	                    ->setCountryOfOrigin($country_of_origin ?: null)
-                        ->setImageUrl(null)//$product_img_url can be used, but sometimes include spaces (bug) which causes validation error
-                        ->setUnitWeight($product_weight > 0 ? $product_weight : null)
-                        ->setUnitPriceExcludingTax($product_val ?: null)
-                        ->setUnitPriceIncludingTax($product_val_tax ?: null)
-                        ->setQuantity($item['qty'] ?: null)
-                        ->setTotalPriceExcludingTax($product_val_total ?: null)
-                        ->setTotalPriceIncludingTax($product_val_tax_total ?: null)
-                        ->setTotalTaxAmount($product_tax_total ?: null);
-
-                    // Store product item in data item array for later reference
-                    $item_data[$product_id]['product_item'] = $items[$index];
-
-                    $index++;
-                }
-
-                $order_note = null;
-                // Create the parcels array
-                if (defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '3.0', '>=')) {
-                    if ($ss_settings['include_order_comment'] == 'yes') {
-                        $order_note = $this->order->get_customer_note();
-                    }
-                    $order_currency = $this->order->get_currency();
-                } else {
-                    if ($ss_settings['include_order_comment'] == 'yes') {
-                        $order_note = $this->order->customer_note;
-                    }
-                    $order_currency = $this->order->get_currency();
-                }
-
-                /*
-                 * Filter the order note which can be printed as freetext on the shipping label
-                 *
-                 * @param string $order_note is the customer note of the order
-                 * @param WC_Order object
-                 */
-                $order_note = apply_filters('smart_send_order_note', $order_note, $this->order);
-
-                // Order totals
-                $order_total = $this->order->get_total();
-                $order_total_tax = $this->order->get_total_tax();
-                $order_total_excl = $order_total - $order_total_tax;
-
-                // Shipping totals
-                $order_shipping = $this->order->get_shipping_total();
-                $order_shipping_tax = $this->order->get_shipping_tax();
-                $order_shipping_excl = $order_shipping - $order_shipping_tax;
-
-                // Order totals without shipping
-                $order_subtotal = $order_total - $order_shipping;
-                $order_subtotal_tax = $order_total_tax - $order_shipping_tax;
-                $order_subtotal_excl = $order_total_excl - $order_subtotal_tax;
-
-                $parcels = array();
-                if (!empty($ss_args['ss_parcels'])) {
-                    if (is_array($ss_args['ss_parcels'])) {
-
-                        $boxes = array();
-                        foreach ($ss_args['ss_parcels'] as $parcel) {
-                            $boxes[$parcel['value']][] = array(
-                                'id'   => $parcel['id'],
-                                'name' => $parcel['name'],
-                            );
-                        }
-
-                        foreach ($boxes as $box_number => $items) {
-                            $item_total_wo_tax = 0;
-                            $item_total_tax = 0;
-                            $item_total_incl_tax = 0;
-                            $item_weight_total = 0;
-                            $product_items = array();
-
-                            foreach ($items as $item) {
-                                $data = $item_data[$item['id']];
-
-                                $item_total_wo_tax += floatval($data['product_val']);
-                                $item_total_incl_tax += floatval($data['product_val_tax']);
-                                $item_weight_total += floatval($data['product_weight']);
-
-                                // Compute for the total tax per individual
-                                $item_total_tax += $item_total_incl_tax - $item_total_wo_tax;
-
-                                array_push($product_items, $data['product_item']);
-                            }
-
-							$parcel_total_weight = apply_filters(
-								'smart_send_parcel_weight',
-								$item_weight_total ? $item_weight_total : null,
-								$this->getOrderId($this->order)
-							);
-
-                            $parcel = new \Smartsend\Models\Shipment\Parcel();
-                            $parcel->setInternalId($this->getOrderId($this->order) ?: null)
-                                ->setInternalReference($this->order->get_order_number() ?: null)
-                                ->setWeight($parcel_total_weight)
-                                ->setHeight(null)
-                                ->setWidth(null)
-                                ->setLength(null)
-                                ->setFreetext($order_note ?: null)
-                                ->setItems($product_items)// Alternatively add each item using $parcel->addItem(Item $item)
-                                ->setTotalPriceExcludingTax($item_total_wo_tax ?: null)
-                                ->setTotalPriceIncludingTax($item_total_incl_tax ?: null)
-                                ->setTotalTaxAmount($item_total_tax ?: null);
-
-                            array_push($parcels, $parcel);
-                        }
-                    }
-                } else {
-                    // Create a parcel containing the items just defined
-                    $parcels[0] = new \Smartsend\Models\Shipment\Parcel();
-                    $parcels[0]->setInternalId($this->getOrderId($this->order) ?: null)
-                        ->setInternalReference($this->order->get_order_number() ?: null)
-                        ->setWeight($weight_total ?: null)
-                        ->setHeight(null)
-                        ->setWidth(null)
-                        ->setLength(null)
-                        ->setFreetext($order_note ?: null)
-                        ->setItems($items)// Alternatively add each item using $parcel->addItem(Item $item)
-                        ->setTotalPriceExcludingTax($order_subtotal_excl ?: null)
-                        ->setTotalPriceIncludingTax($order_subtotal ?: null)
-                        ->setTotalTaxAmount($order_subtotal_tax ?: null);
-                }
-            }
-
-            // Create services
-            $services = new \Smartsend\Models\Shipment\Services();
-            $services->setSmsNotification($receiver->getSms())//Always enable SMS notification
-            ->setEmailNotification($receiver->getEmail()); //Always enable Email notification
-
-            // Determine shipping method and carrier from return settings
-            $shipping_method_carrier = $ss_args['ss_carrier'];
-            $shipping_method_type = $ss_args['ss_type'];
-
-            // Add final parameters to shipment
-            $this->shipment->setInternalId($this->getOrderId($this->order) ?: null)
-                ->setInternalReference($this->order->get_order_number() ?: null)
-                ->setShippingCarrier($shipping_method_carrier ?: null)
-                ->setShippingMethod($shipping_method_type ?: null)
-                ->setShippingDate(date('Y-m-d'))
-                ->setParcels($parcels)// Alternatively add each parcel using $this->shipment->addParcel(Parcel $parcel);
-                ->setServices($services)
-                ->setSubtotalPriceExcludingTax($order_subtotal_excl ?: null)
-                ->setSubtotalPriceIncludingTax($order_subtotal ?: null)
-                ->setTotalPriceExcludingTax($order_total_excl ?: null)
-                ->setTotalPriceIncludingTax($order_total ?: null)
-                ->setShippingPriceExcludingTax($order_shipping_excl ?: null)
-                ->setShippingPriceIncludingTax($order_shipping ?: null)
-                ->setTotalTaxAmount($order_total_tax ?: null)
-                ->setCurrency($order_currency ?: null);
-        }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
+
+	/**
+	 * Assembles the Smart Send API shipment model for a WooCommerce order and
+	 * sends it to the API. All WooCommerce data access goes through
+	 * SS_Shipping_Order_Data; this class only builds the API models.
+	 */
+	class SS_Shipping_Shipment {
 
 		/**
-		 * Call Smart Send Shipment API, log response
+		 * The WooCommerce order.
+		 *
+		 * @var WC_Order|null
+		 */
+		protected $order = null;
+
+		/**
+		 * Order data access utility.
+		 *
+		 * @var SS_Shipping_Order_Data|null
+		 */
+		protected $order_data = null;
+
+		/**
+		 * The admin order integration.
+		 *
+		 * @var SS_Shipping_WC_Order|null
+		 */
+		protected $shipping_order = null;
+
+		/**
+		 * The shipment model being assembled.
+		 *
+		 * @var \Smartsend\Models\Shipment|null
+		 */
+		protected $shipment = null;
+
+		/**
+		 * Init and hook in the integration.
+		 *
+		 * @param WC_Order|integer     $order          The order (object or id) to build a shipment for.
+		 * @param SS_Shipping_WC_Order $shipping_order The admin order integration.
+		 */
+		public function __construct( $order, $shipping_order ) {
+			if ( is_numeric( $order ) && $order > 0 ) {
+				$this->order = wc_get_order( $order );
+
+				if ( ! $this->order ) {
+					return;
+				}
+			} elseif ( $order instanceof WC_Order ) {
+				$this->order = $order;
+			} else {
+				return;
+			}
+
+			$this->order_data     = new SS_Shipping_Order_Data( $this->order );
+			$this->shipping_order = $shipping_order;
+
+			// New shipment model.
+			$this->shipment = new \Smartsend\Models\Shipment();
+		}
+
+		/**
+		 * Create single order.
+		 *
+		 * @param boolean $is_return Whether the label is a return label.
+		 *
+		 * @return boolean
+		 */
+		public function make_single_shipment_api_call( $is_return ) {
+			$this->make_single_shipment_api_payload( $is_return );
+			$this->make_single_shipment_api_request();
+
+			if ( SS_SHIPPING_WC()->get_api_handle()->isSuccessful() ) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		/**
+		 * Get API call data.
+		 *
+		 * @return object
+		 */
+		public function get_shipping_data() {
+			return SS_SHIPPING_WC()->get_api_handle()->getData();
+		}
+
+		/**
+		 * Get error message.
+		 *
+		 * @return string
+		 */
+		public function get_error_msg() {
+			return SS_SHIPPING_WC()->get_api_handle()->getErrorString();
+		}
+
+		/**
+		 * Get shipment object.
+		 *
+		 * @return \Smartsend\Models\Shipment
+		 */
+		public function get_shipment() {
+			return $this->shipment;
+		}
+
+		/**
+		 * Create Payload for API request.
+		 *
+		 * @param boolean $is_return Whether the label is a return label.
+		 *
+		 * @return array|void
+		 */
+		protected function make_single_shipment_api_payload( $is_return ) {
+			$order_id = $this->order_data->get_order_id();
+
+			$ss_args = array();
+
+			// Get shipping method.
+			$ss_shipping_method_id = $this->shipping_order->get_smart_send_method_id( $order_id, $is_return );
+
+			if ( $is_return && isset( $ss_shipping_method_id['smart_send_return_method'] ) ) {
+				// If no return method set return error.
+				if ( empty( $ss_shipping_method_id['smart_send_return_method'] ) ) {
+					return array( 'error' => __( 'No return method set', 'smart-send-logistics' ) );
+				} else {
+					$ss_shipping_method_id = $ss_shipping_method_id['smart_send_return_method'];
+				}
+			} else {
+				$ss_args['ss_agent'] = $this->shipping_order->get_ss_shipping_order_agent( $order_id );
+			}
+
+			// Determine shipping method and carrier from return settings.
+			$ss_args['ss_carrier'] = SS_SHIPPING_WC()->get_shipping_method_carrier( $ss_shipping_method_id );
+			$ss_args['ss_type']    = SS_SHIPPING_WC()->get_shipping_method_type( $ss_shipping_method_id );
+			$ss_args['ss_parcels'] = $this->shipping_order->get_ss_shipping_order_parcels( $order_id );
+
+			/*
+			 * Filter the arguments used when creating a shipping label
+			 *
+			 * @param array   $ss_args  contains info about shipping carrier, shipping method, agent and parcels
+			 * @param int     $order_id Order ID
+			 * @param boolean $is_return Whether or not the label is return (true) or normal (false)
+			 */
+			$ss_args = apply_filters( 'smart_send_shipping_label_args', $ss_args, $order_id, $is_return );
+
+			// Add the receiver to the shipment.
+			$receiver = $this->build_receiver();
+			$this->shipment->setReceiver( $receiver );
+
+			// Add the agent (pick-up point) to the shipment, if any.
+			$ss_agent = apply_filters(
+				'smart_send_order_agent',
+				empty( $ss_args['ss_agent'] ) ? null : $ss_args['ss_agent'],
+				$order_id
+			);
+
+			if ( ! empty( $ss_agent ) ) {
+				$this->shipment->setAgent( $this->build_agent( $ss_agent ) );
+			}
+
+			// Item lines and totals.
+			$items_data = $this->order_data->get_items_data();
+
+			$parcels = array();
+			$totals  = array(
+				'subtotal_price_excluding_tax' => null,
+				'subtotal_price_including_tax' => null,
+				'subtotal_tax_amount'          => null,
+				'shipping_price_excluding_tax' => null,
+				'shipping_price_including_tax' => null,
+				'shipping_tax_amount'          => null,
+				'total_price_excluding_tax'    => null,
+				'total_price_including_tax'    => null,
+				'total_tax_amount'             => null,
+				'currency'                     => null,
+			);
+
+			if ( ! empty( $items_data ) ) {
+				$totals     = $this->order_data->get_totals();
+				$order_note = $this->order_data->get_order_note();
+
+				// Build the item models, keyed by product/variation id so a
+				// parcel split can reference them.
+				$items        = array();
+				$item_lookup  = array();
+				$weight_total = 0;
+
+				foreach ( $items_data as $item_row ) {
+					$item_model = $this->build_item( $item_row );
+
+					$items[] = $item_model;
+
+					$item_lookup[ $item_row['id'] ] = array(
+						'row'   => $item_row,
+						'model' => $item_model,
+					);
+
+					if ( $item_row['unit_weight'] ) {
+						$weight_total += ( $item_row['quantity'] * $item_row['unit_weight'] );
+					}
+				}
+
+				if ( ! empty( $ss_args['ss_parcels'] ) ) {
+					if ( is_array( $ss_args['ss_parcels'] ) ) {
+						$parcels = $this->build_split_parcels( $ss_args['ss_parcels'], $item_lookup, $order_note );
+					}
+				} else {
+					// Create a single parcel containing the items just defined.
+					$parcel = new \Smartsend\Models\Shipment\Parcel();
+					$parcel->setInternalId( $this->value_or_null( $order_id ) )
+						->setInternalReference( $this->value_or_null( $this->order_data->get_order_number() ) )
+						->setWeight( $this->value_or_null( $weight_total ) )
+						->setHeight( null )
+						->setWidth( null )
+						->setLength( null )
+						->setFreetext( $this->value_or_null( $order_note ) )
+						->setItems( $items )// Alternatively add each item using $parcel->addItem(Item $item).
+						->setTotalPriceExcludingTax( $this->value_or_null( $totals['subtotal_price_excluding_tax'] ) )
+						->setTotalPriceIncludingTax( $this->value_or_null( $totals['subtotal_price_including_tax'] ) )
+						->setTotalTaxAmount( $this->value_or_null( $totals['subtotal_tax_amount'] ) );
+
+					$parcels[] = $parcel;
+				}
+			}
+
+			// Create services.
+			$services = new \Smartsend\Models\Shipment\Services();
+			$services->setSmsNotification( $receiver->getSms() )// Always enable SMS notification.
+				->setEmailNotification( $receiver->getEmail() ); // Always enable Email notification.
+
+			// Add final parameters to shipment.
+			$this->shipment->setInternalId( $this->value_or_null( $order_id ) )
+				->setInternalReference( $this->value_or_null( $this->order_data->get_order_number() ) )
+				->setShippingCarrier( $this->value_or_null( $ss_args['ss_carrier'] ) )
+				->setShippingMethod( $this->value_or_null( $ss_args['ss_type'] ) )
+				->setShippingDate( gmdate( 'Y-m-d' ) )
+				->setParcels( $parcels )// Alternatively add each parcel using $this->shipment->addParcel(Parcel $parcel).
+				->setServices( $services )
+				->setSubtotalPriceExcludingTax( $this->value_or_null( $totals['subtotal_price_excluding_tax'] ) )
+				->setSubtotalPriceIncludingTax( $this->value_or_null( $totals['subtotal_price_including_tax'] ) )
+				->setTotalPriceExcludingTax( $this->value_or_null( $totals['total_price_excluding_tax'] ) )
+				->setTotalPriceIncludingTax( $this->value_or_null( $totals['total_price_including_tax'] ) )
+				->setShippingPriceExcludingTax( $this->value_or_null( $totals['shipping_price_excluding_tax'] ) )
+				->setShippingPriceIncludingTax( $this->value_or_null( $totals['shipping_price_including_tax'] ) )
+				->setTotalTaxAmount( $this->value_or_null( $totals['total_tax_amount'] ) )
+				->setCurrency( $this->value_or_null( $totals['currency'] ) );
+		}
+
+		/**
+		 * Build the receiver model from the order data.
+		 *
+		 * @return \Smartsend\Models\Shipment\Receiver
+		 */
+		protected function build_receiver() {
+			$receiver_data = $this->order_data->get_receiver_data();
+
+			$receiver = new \Smartsend\Models\Shipment\Receiver();
+			$receiver->setInternalId( $this->order_data->get_order_id() )
+				->setInternalReference( $this->value_or_null( $this->order_data->get_order_number() ) )
+				->setCompany( $this->value_or_null( $receiver_data['company'] ) )
+				->setNameLine1( $this->value_or_null( $receiver_data['name_line1'] ) )
+				->setNameLine2( $this->value_or_null( $receiver_data['name_line2'] ) )
+				->setAddressLine1( $this->value_or_null( $receiver_data['address_line1'] ) )
+				->setAddressLine2( $this->value_or_null( $receiver_data['address_line2'] ) )
+				->setPostalCode( $this->value_or_null( $receiver_data['postal_code'] ) )
+				->setCity( $this->value_or_null( $receiver_data['city'] ) )
+				->setCountry( $this->value_or_null( $receiver_data['country'] ) )
+				->setSms( $this->value_or_null( $receiver_data['phone'] ) )
+				->setEmail( $this->value_or_null( $receiver_data['email'] ) );
+
+			return $receiver;
+		}
+
+		/**
+		 * Build the agent (pick-up point) model from the stored agent object.
+		 *
+		 * @param object $ss_agent The agent object stored on the order.
+		 *
+		 * @return \Smartsend\Models\Shipment\Agent
+		 */
+		protected function build_agent( $ss_agent ) {
+			$agent = new \Smartsend\Models\Shipment\Agent();
+			$agent->setInternalId( isset( $ss_agent->id ) ? $ss_agent->id : $ss_agent->agent_no )
+				->setInternalReference( isset( $ss_agent->id ) ? $ss_agent->id : $ss_agent->agent_no )
+				->setAgentNo( $this->value_or_null( $ss_agent->agent_no ) )
+				->setCompany( $this->value_or_null( $ss_agent->company ) )
+				->setAddressLine1( $this->value_or_null( $ss_agent->address_line1 ) )
+				->setAddressLine2( $this->value_or_null( $ss_agent->address_line2 ) )
+				->setPostalCode( $this->value_or_null( $ss_agent->postal_code ) )
+				->setCity( $this->value_or_null( $ss_agent->city ) )
+				->setCountry( $this->value_or_null( $ss_agent->country ) );
+
+			return $agent;
+		}
+
+		/**
+		 * Build an item model from an item data row.
+		 *
+		 * @param array $item_row Item row from SS_Shipping_Order_Data::get_items_data().
+		 *
+		 * @return \Smartsend\Models\Shipment\Item
+		 */
+		protected function build_item( $item_row ) {
+			$item = new \Smartsend\Models\Shipment\Item();
+			$item->setInternalId( $this->value_or_null( $item_row['id'] ) )
+				->setInternalReference( $this->value_or_null( $item_row['id'] ) )
+				->setSku( $this->value_or_null( $item_row['sku'] ) )
+				->setName( $this->value_or_null( $item_row['name'] ) )
+				->setDescription( $this->value_or_null( $item_row['description'] ) )// The product description can be used, but is often too long (255).
+				->setHsCode( $this->value_or_null( $item_row['hs_code'] ) )
+				->setCountryOfOrigin( $this->value_or_null( $item_row['country_of_origin'] ) )
+				->setImageUrl( null )// The product image url can be used, but sometimes includes spaces (bug) which causes validation error.
+				->setUnitWeight( $item_row['unit_weight'] > 0 ? $item_row['unit_weight'] : null )
+				->setUnitPriceExcludingTax( $this->value_or_null( $item_row['unit_price_excluding_tax'] ) )
+				->setUnitPriceIncludingTax( $this->value_or_null( $item_row['unit_price_including_tax'] ) )
+				->setQuantity( $this->value_or_null( $item_row['quantity'] ) )
+				->setTotalPriceExcludingTax( $this->value_or_null( $item_row['total_price_excluding_tax'] ) )
+				->setTotalPriceIncludingTax( $this->value_or_null( $item_row['total_price_including_tax'] ) )
+				->setTotalTaxAmount( $this->value_or_null( $item_row['total_tax_amount'] ) );
+
+			return $item;
+		}
+
+		/**
+		 * Build one parcel per box from the parcel-split meta stored on the order.
+		 *
+		 * @param array       $ss_parcels  Parcel split meta rows (id, name, value).
+		 * @param array       $item_lookup Item rows and models keyed by product/variation id.
+		 * @param string|null $order_note  Freetext for the parcels.
+		 *
+		 * @return \Smartsend\Models\Shipment\Parcel[]
+		 */
+		protected function build_split_parcels( $ss_parcels, $item_lookup, $order_note ) {
+			$parcels = array();
+
+			$boxes = array();
+			foreach ( $ss_parcels as $parcel_meta ) {
+				$boxes[ $parcel_meta['value'] ][] = array(
+					'id'   => $parcel_meta['id'],
+					'name' => $parcel_meta['name'],
+				);
+			}
+
+			foreach ( $boxes as $box_items ) {
+				$item_total_wo_tax   = 0;
+				$item_total_tax      = 0;
+				$item_total_incl_tax = 0;
+				$item_weight_total   = 0;
+				$product_items       = array();
+
+				foreach ( $box_items as $box_item ) {
+					$item_row = $item_lookup[ $box_item['id'] ]['row'];
+
+					$item_total_wo_tax   += floatval( $item_row['unit_price_excluding_tax'] );
+					$item_total_incl_tax += floatval( $item_row['unit_price_including_tax'] );
+					$item_weight_total   += floatval( $item_row['unit_weight'] );
+
+					// Compute for the total tax per individual.
+					$item_total_tax += $item_total_incl_tax - $item_total_wo_tax;
+
+					$product_items[] = $item_lookup[ $box_item['id'] ]['model'];
+				}
+
+				/*
+				 * Filter the weight of a parcel.
+				 *
+				 * @param float|null $parcel_weight Total weight of the items in the parcel.
+				 * @param int        $order_id      Order ID.
+				 */
+				$parcel_total_weight = apply_filters(
+					'smart_send_parcel_weight',
+					$this->value_or_null( $item_weight_total ),
+					$this->order_data->get_order_id()
+				);
+
+				$parcel = new \Smartsend\Models\Shipment\Parcel();
+				$parcel->setInternalId( $this->value_or_null( $this->order_data->get_order_id() ) )
+					->setInternalReference( $this->value_or_null( $this->order_data->get_order_number() ) )
+					->setWeight( $parcel_total_weight )
+					->setHeight( null )
+					->setWidth( null )
+					->setLength( null )
+					->setFreetext( $this->value_or_null( $order_note ) )
+					->setItems( $product_items )// Alternatively add each item using $parcel->addItem(Item $item).
+					->setTotalPriceExcludingTax( $this->value_or_null( $item_total_wo_tax ) )
+					->setTotalPriceIncludingTax( $this->value_or_null( $item_total_incl_tax ) )
+					->setTotalTaxAmount( $this->value_or_null( $item_total_tax ) );
+
+				$parcels[] = $parcel;
+			}
+
+			return $parcels;
+		}
+
+		/**
+		 * Call Smart Send Shipment API, log response.
 		 *
 		 * @return void
 		 */
@@ -491,21 +419,21 @@ if (!class_exists('SS_Shipping_Shipment')) :
 			SS_SHIPPING_WC()->get_api_handle()->createShipmentAndLabels( $this->shipment );
 		}
 
-        /**
-         * Get the order id
-         *
-         * @param WC_Order
-         * @return string
-         */
-        protected function getOrderId($order)
-        {
-            // WC 3.0 code!
-            if (defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '3.0', '>=')) {
-                return $order->get_id();
-            } else {
-                return $order->id;
-            }
-        }
-    }
+		/**
+		 * Return the value when truthy, null otherwise (the API models expect
+		 * null instead of empty/zero values).
+		 *
+		 * @param mixed $value The value to check.
+		 *
+		 * @return mixed|null
+		 */
+		protected function value_or_null( $value ) {
+			if ( $value ) {
+				return $value;
+			}
+
+			return null;
+		}
+	}
 
 endif;

--- a/tests/Integration/ShipmentPayloadTest.php
+++ b/tests/Integration/ShipmentPayloadTest.php
@@ -154,16 +154,12 @@ it('books a simple domestic agent order with the full expected payload', functio
                         'total_price_including_tax' => 200,
                     ]),
                 ],
-                // v8 oddity: with zero tax, the parcel "excluding tax" total
-                // includes shipping (order_total - subtotal_tax) while the
-                // "including tax" total does not.
-                'total_price_excluding_tax' => 239,
+                'total_price_excluding_tax' => 200,
                 'total_price_including_tax' => 200,
                 'total_tax_amount'          => null,
             ],
         ],
-        // v8 oddity: same asymmetry on the shipment-level subtotal.
-        'subtotal_price_excluding_tax' => 239,
+        'subtotal_price_excluding_tax' => 200,
         'subtotal_price_including_tax' => 200,
         'shipping_price_excluding_tax' => 39,
         'shipping_price_including_tax' => 39,
@@ -205,12 +201,13 @@ it('prices item lines pre-discount when a percentage coupon is applied', functio
                         'total_price_including_tax' => 200,
                     ]),
                 ],
-                'total_price_excluding_tax' => 219,
+                // The coupon discount is reflected in the parcel totals.
+                'total_price_excluding_tax' => 180,
                 'total_price_including_tax' => 180,
                 'total_tax_amount'          => null,
             ],
         ],
-        'subtotal_price_excluding_tax' => 219,
+        'subtotal_price_excluding_tax' => 180,
         'subtotal_price_including_tax' => 180,
         'shipping_price_excluding_tax' => 39,
         'shipping_price_including_tax' => 39,
@@ -245,12 +242,12 @@ it('folds an order fee into the parcel totals but not into any item line', funct
                 'items'              => [expected_item($product)],
                 // Fee is part of the order subtotal, so the parcel totals
                 // exceed the sum of the item lines.
-                'total_price_excluding_tax' => 164,
+                'total_price_excluding_tax' => 125,
                 'total_price_including_tax' => 125,
                 'total_tax_amount'          => null,
             ],
         ],
-        'subtotal_price_excluding_tax' => 164,
+        'subtotal_price_excluding_tax' => 125,
         'subtotal_price_including_tax' => 125,
         'shipping_price_excluding_tax' => 39,
         'shipping_price_including_tax' => 39,
@@ -291,18 +288,16 @@ it('books a taxed order with the v8 tax semantics', function () {
                         'total_tax_amount'          => 25,
                     ]),
                 ],
-                'total_price_excluding_tax' => 114,
-                'total_price_including_tax' => 134.75,
+                'total_price_excluding_tax' => 100,
+                'total_price_including_tax' => 125,
                 'total_tax_amount'          => 25,
             ],
         ],
-        // v8 oddity: WC_Order::get_shipping_total() is already excluding
-        // tax, but the plugin treats it as including tax; the resulting
-        // "excluding tax" shipping price subtracts the shipping tax twice.
-        'subtotal_price_excluding_tax' => 114,
-        'subtotal_price_including_tax' => 134.75,
-        'shipping_price_excluding_tax' => 29.25,
-        'shipping_price_including_tax' => 39,
+        // Totals reconcile: subtotal + shipping = total on both bases.
+        'subtotal_price_excluding_tax' => 100,
+        'subtotal_price_including_tax' => 125,
+        'shipping_price_excluding_tax' => 39,
+        'shipping_price_including_tax' => 48.75,
         'total_price_excluding_tax'    => 139,
         'total_price_including_tax'    => 173.75,
         'total_tax_amount'             => 34.75,
@@ -357,12 +352,12 @@ it('includes customs data on the item lines for an international order', functio
                         'country_of_origin' => 'DK',
                     ]),
                 ],
-                'total_price_excluding_tax' => 250,
+                'total_price_excluding_tax' => 100,
                 'total_price_including_tax' => 100,
                 'total_tax_amount'          => null,
             ],
         ],
-        'subtotal_price_excluding_tax' => 250,
+        'subtotal_price_excluding_tax' => 100,
         'subtotal_price_including_tax' => 100,
         'shipping_price_excluding_tax' => 150,
         'shipping_price_including_tax' => 150,
@@ -512,6 +507,53 @@ it('includes the customer note as parcel freetext when enabled in settings', fun
     $payload = capture_shipment_payload($order);
 
     expect($payload['parcels'][0]['freetext'])->toBe('Please leave at the back door');
+});
+
+it('reconciles totals with the order total when a gift card partially covers the items', function () {
+    $product = create_simple_product(['name' => 'Partially Gifted Product', 'price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'fees'            => [['Gift card', -50]],
+        'shipping_method' => 'postnord_homedelivery',
+        'shipping_total'  => '39',
+    ]);
+
+    $payload = capture_shipment_payload($order);
+
+    // total = 100 - 50 + 39 = 89; subtotal + shipping = total on both bases.
+    expect($payload['parcels'][0]['total_price_excluding_tax'])->toEqual(50)
+        ->and($payload['parcels'][0]['total_price_including_tax'])->toEqual(50)
+        ->and($payload['subtotal_price_excluding_tax'])->toEqual(50)
+        ->and($payload['subtotal_price_including_tax'])->toEqual(50)
+        ->and($payload['shipping_price_excluding_tax'])->toEqual(39)
+        ->and($payload['shipping_price_including_tax'])->toEqual(39)
+        ->and($payload['total_price_excluding_tax'])->toEqual(89)
+        ->and($payload['total_price_including_tax'])->toEqual(89);
+});
+
+it('clamps negative values to zero when a gift card exceeds the item value', function () {
+    $product = create_simple_product(['name' => 'Gifted Product', 'price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'fees'            => [['Gift card', -120]],
+        'shipping_method' => 'postnord_homedelivery',
+        'shipping_total'  => '39',
+    ]);
+
+    $payload = capture_shipment_payload($order);
+
+    // total = 100 - 120 + 39 = 19. The non-shipping subtotal would be
+    // 19 - 39 = -20 (the #54 failure mode); it is clamped to zero and a
+    // zero amount is sent as null. No negative value appears anywhere.
+    expect($payload['parcels'][0]['total_price_excluding_tax'])->toBeNull()
+        ->and($payload['parcels'][0]['total_price_including_tax'])->toBeNull()
+        ->and($payload['parcels'][0]['items'][0]['total_price_excluding_tax'])->toEqual(100)
+        ->and($payload['subtotal_price_excluding_tax'])->toBeNull()
+        ->and($payload['subtotal_price_including_tax'])->toBeNull()
+        ->and($payload['shipping_price_excluding_tax'])->toEqual(39)
+        ->and($payload['shipping_price_including_tax'])->toEqual(39)
+        ->and($payload['total_price_excluding_tax'])->toEqual(19)
+        ->and($payload['total_price_including_tax'])->toEqual(19);
 });
 
 it('lets the smart_send_shipping_label_args filter override carrier and method', function () {

--- a/tests/Integration/ShipmentPayloadTest.php
+++ b/tests/Integration/ShipmentPayloadTest.php
@@ -622,6 +622,57 @@ it('lets the smart_send_receiver_phone filter adjust the receiver phone', functi
         ->and($payload['services']['sms_notification'])->toBe('+4587654321');
 });
 
+it('lets the per-section payload filters adjust receiver, items, parcels and totals', function () {
+    $product = create_simple_product(['name' => 'Filtered Product', 'price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_homedelivery',
+        'shipping_total'  => '39',
+    ]);
+
+    $receiver_filter = function (array $receiver_data, WC_Order $filtered_order) {
+        $receiver_data['company'] = 'Filtered Company';
+
+        return $receiver_data;
+    };
+    $items_filter = function (array $items, WC_Order $filtered_order) {
+        $items[0]['name'] = 'Filtered Item Name';
+
+        return $items;
+    };
+    $totals_filter = function (array $totals, WC_Order $filtered_order) {
+        $totals['total_price_including_tax'] = 999;
+
+        return $totals;
+    };
+    $parcels_filter = function (array $parcels, WC_Order $filtered_order) {
+        foreach ($parcels as $parcel) {
+            expect($parcel)->toBeInstanceOf(\Smartsend\Models\Shipment\Parcel::class);
+            $parcel->setWeight(42);
+        }
+
+        return $parcels;
+    };
+
+    add_filter('smart_send_payload_receiver', $receiver_filter, 10, 2);
+    add_filter('smart_send_payload_items', $items_filter, 10, 2);
+    add_filter('smart_send_payload_totals', $totals_filter, 10, 2);
+    add_filter('smart_send_payload_parcels', $parcels_filter, 10, 2);
+    remember_cleanup_callback(function () use ($receiver_filter, $items_filter, $totals_filter, $parcels_filter): void {
+        remove_filter('smart_send_payload_receiver', $receiver_filter, 10);
+        remove_filter('smart_send_payload_items', $items_filter, 10);
+        remove_filter('smart_send_payload_totals', $totals_filter, 10);
+        remove_filter('smart_send_payload_parcels', $parcels_filter, 10);
+    });
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload['receiver']['company'])->toBe('Filtered Company')
+        ->and($payload['parcels'][0]['items'][0]['name'])->toBe('Filtered Item Name')
+        ->and($payload['parcels'][0]['weight'])->toEqual(42)
+        ->and($payload['total_price_including_tax'])->toEqual(999);
+});
+
 it('lets the smart_send_shipping_label_args filter override carrier and method', function () {
     $product = create_simple_product(['price' => 100, 'weight' => 1]);
     $order   = create_order([

--- a/tests/Integration/ShipmentPayloadTest.php
+++ b/tests/Integration/ShipmentPayloadTest.php
@@ -583,6 +583,45 @@ it('clamps negative values to zero when a gift card exceeds the item value', fun
         ->and($payload['total_price_including_tax'])->toEqual(19);
 });
 
+it('normalizes the receiver phone by trimming surrounding whitespace', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'billing_address' => ['phone' => '  +4512345678  '],
+        'shipping_method' => 'postnord_homedelivery',
+    ]);
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload['receiver']['sms'])->toBe('+4512345678')
+        ->and($payload['services']['sms_notification'])->toBe('+4512345678');
+});
+
+it('lets the smart_send_receiver_phone filter adjust the receiver phone', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_homedelivery',
+    ]);
+
+    $filter = function ($phone, $filtered_order) use ($order) {
+        expect($phone)->toBe('+4512345678')
+            ->and($filtered_order)->toBeInstanceOf(WC_Order::class)
+            ->and($filtered_order->get_id())->toBe($order->get_id());
+
+        return '+4587654321';
+    };
+    add_filter('smart_send_receiver_phone', $filter, 10, 2);
+    remember_cleanup_callback(function () use ($filter): void {
+        remove_filter('smart_send_receiver_phone', $filter, 10);
+    });
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload['receiver']['sms'])->toBe('+4587654321')
+        ->and($payload['services']['sms_notification'])->toBe('+4587654321');
+});
+
 it('lets the smart_send_shipping_label_args filter override carrier and method', function () {
     $product = create_simple_product(['price' => 100, 'weight' => 1]);
     $order   = create_order([

--- a/tests/Integration/ShipmentPayloadTest.php
+++ b/tests/Integration/ShipmentPayloadTest.php
@@ -452,6 +452,33 @@ it('uses the variation id, sku and weight for variable products', function () {
     ]));
 });
 
+it('reads customs meta from the variation, falling back to the parent product', function () {
+    [$parent, $variation] = create_variable_product([
+        'name'   => 'Variable Customs Product',
+        'price'  => 100,
+        'weight' => 1,
+    ]);
+    $parent->update_meta_data('_ss_hs_code', '61091000');
+    $parent->update_meta_data('_ss_customs_desc', 'Cotton t-shirt');
+    $parent->update_meta_data('_ss_country_of_origin', 'DK');
+    $parent->save();
+
+    // The variation overrides only the HS code.
+    $variation->update_meta_data('_ss_hs_code', '62052000');
+    $variation->save();
+
+    $order = create_order([
+        'products'        => [$variation],
+        'shipping_method' => 'postnord_agent',
+    ]);
+
+    $payload = capture_shipment_payload($order);
+
+    expect($payload['parcels'][0]['items'][0]['hs_code'])->toBe('62052000')
+        ->and($payload['parcels'][0]['items'][0]['description'])->toBe('Cotton t-shirt')
+        ->and($payload['parcels'][0]['items'][0]['country_of_origin'])->toBe('DK');
+});
+
 it('sends a null parcel weight when products have no weight', function () {
     $product = create_simple_product(['name' => 'Weightless Product', 'price' => 50, 'weight' => null]);
     $order   = create_order([


### PR DESCRIPTION
Closes #72. First PR of the v9 Phase 3 stack, based on `develop`.

## Class design

New `SS_Shipping_Order_Data` (`includes/class-ss-shipping-order-data.php`) — named to fit the `SS_Shipping_*` / `class-ss-shipping-*.php` autoloader convention rather than the issue's `SS_Order_Util` suggestion, which the autoloader could not load. It is the single place that answers order-data questions from a `WC_Order` using CRUD getters only, returning plain arrays:

- `get_receiver_data()` — shipping/billing address resolution incl. the phone/email fallbacks and the frozen `smart_send_order_receiver` filter, plus the new phone normalization step
- `get_items_data()` — one row per order line with weight/price/customs data (variation-aware product meta)
- `get_totals()` — subtotal/shipping/total on both tax bases, reconciling with `WC_Order::get_total()`
- `get_order_note()` — the freetext gate + frozen `smart_send_order_note` filter

`SS_Shipping_Shipment` is now pure API-model assembly (`build_receiver` / `build_agent` / `build_item` / `build_split_parcels`). No `get_post_meta`/`update_post_meta` remains in the booking path (HPOS-safe); product customs meta is read via `$product->get_meta()`. Both files were brought fully up to WPCS (they were previously baseline-carried; the baseline file is untouched).

## Commit split

1. **Mechanical** — `4ab5d1c` extracts the utility with a byte-identical payload; every golden characterization test passed untouched. Also drops dead pre-WC-3.0 branches (floor is WC 4.7, per the #90 guard policy) and the unused product description/image lookups.
2. **Behaviour: totals rule** — `f93436d`
3. **Behaviour: variation-aware customs meta** — `0b90196`
4. **Behaviour: phone normalization seam** — `71efba8`
5. **Feature: per-section payload filters** — `ed97f43`

## Behaviour changes (golden tests updated knowingly)

### 1. Totals reconcile with the order total and are clamped ≥ 0 (fixes the #54 failure mode; supersedes #26)

The rule: `subtotal + shipping = total` on both the including- and excluding-tax basis, all derived from CRUD getters, every amount clamped at ≥ 0 (item lines included). When a clamp kicks in, the clamp wins over strict reconciliation.

**Shipping-tax inversion** (200 DKK items, 39 DKK shipping, 25% tax):

| field | before | after |
|---|---|---|
| `shipping_price_excluding_tax` | 29.25 | 39 |
| `shipping_price_including_tax` | 39 | 48.75 |
| `subtotal_price_excluding_tax` | 114 | 100 |
| `subtotal_price_including_tax` | 134.75 | 125 |

v8 treated `get_shipping_total()` (which is excl. tax) as including tax, subtracting the shipping tax twice.

**Excl-tax subtotal included shipping** (200 DKK items + 39 DKK shipping, no tax):

| field | before | after |
|---|---|---|
| parcel/`subtotal_price_excluding_tax` | 239 | 200 |
| parcel/`subtotal_price_including_tax` | 200 | 200 |

**Negative values clamped** (100 DKK product, −120 DKK gift-card fee, 39 DKK shipping → order total 19): v8 sent `subtotal_price_excluding_tax: -20`, which the API rejects with a ValidationException and the customer gets stuck (#54). Now the negative subtotal is clamped to 0 (serialized as `null`), shipping 39/39, total 19/19.

### 2. Variation-aware customs meta

`_ss_hs_code`, `_ss_customs_desc`, `_ss_country_of_origin` are now read from the ordered variation first, falling back to the parent product. v8 always read the parent, silently ignoring variation-level customs data.

### 3. Receiver phone normalization + filter (groundwork for #56)

The receiver phone passes through a normalization step (minimal for now: trim, empty → null — the seam where local→international conversion will land) and then the new `smart_send_receiver_phone` filter.

## New filters

- `smart_send_receiver_phone( string|null $phone, WC_Order $order )`
- `smart_send_payload_receiver( array $receiver_data, WC_Order $order )`
- `smart_send_payload_items( array $items, WC_Order $order )`
- `smart_send_payload_totals( array $totals, WC_Order $order )` — runs after the clamp; returned values are used as-is
- `smart_send_payload_parcels( \Smartsend\Models\Shipment\Parcel[] $parcels, WC_Order $order )`

Naming follows the convention for #73 (`smart_send_` prefix, filters for values); the receiver/items/totals filters operate on plain data arrays in the utility, the parcels filter on the assembled models in `SS_Shipping_Shipment`. All existing `smart_send_*` hooks keep their names and signatures.

## v8 oddities: fixed vs deliberately kept

Fixed (covered by the issue's totals rule): shipping-tax inversion; excl-tax subtotal/parcel totals including shipping; negative subtotals.

Deliberately kept: **coupon-blind item lines** — item lines are still priced from the pre-discount line subtotal, so order-level discounts show only in the totals (item lines keep their customs value; per-line attribution of order-level gift cards is ambiguous, and changing it would alter customs declarations — left for #51/#54 follow-ups if desired); **zero amounts serialized as `null`** (the API models' long-standing `?: null` convention).

## Tests

- Mechanical commit: all 131 existing integration tests green with the golden payload tests untouched.
- Final: 137 passed (532 assertions); `vendor/bin/phpcs` clean, `composer phpcs:compat` clean.
- New cases: gift card partially/fully exceeding item value, variation customs meta with parent fallback, phone trim + `smart_send_receiver_phone`, all four per-section filters fire and are respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
