### PR TITLE
Apply existence-guard policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,16 @@ Two decoupled surfaces with distinct audiences — place every log/notice call d
 
 Keep messages concise and greppable; put structured data (order id, agent no, shipment id, carrier) in the context array — the WooCommerce log viewer renders it natively.
 
+## Existence-guard policy
+
+`function_exists`/`class_exists` guards appear **only** where existence genuinely varies across the supported range (see issue #90). The three legitimate categories:
+
+1. **Optional third-party plugins** — e.g. `wc_st_add_tracking_number` (Shipment Tracking), `WC_Subscriptions`.
+2. **WP/WC APIs newer than our floors** (PHP 7.4 / WC 4.7) — e.g. `FeaturesUtil` (WC 6.5+), the HPOS `CustomOrdersTableController`.
+3. **Load-context differences** — e.g. `get_plugins()` outside admin (prefer `require_once` of the include over a silent guard).
+
+Everything else — any WP or WC core API our floors guarantee — is called directly, with **no** guard: a guard on an impossible state silently swallows real bugs. Every kept guard carries a one-line comment naming why existence varies. Exactly one bootstrap-level WooCommerce-active check lives in `smart-send-logistics.php` (`init()`'s `WOOCOMMERCE_VERSION` gate — belt-and-braces for WP < 6.5, where `Requires Plugins: woocommerce` is not enforced); everything downstream assumes WooCommerce is present.
+
 Extension points are `smart_send_*` filters/actions (e.g. `smart_send_api_endpoint`, `smart_send_shipping_label_args`, `smart_send_shipping_label_created`, `smart_send_tracking_url`, `smart_send_order_note`). Preserve these when refactoring — merchants rely on them via code snippets.
 
 ## Releasing

--- a/smart-send-logistics/includes/class-ss-shipping-checkout-debug.php
+++ b/smart-send-logistics/includes/class-ss-shipping-checkout-debug.php
@@ -41,10 +41,6 @@ class SS_Shipping_Checkout_Debug {
 			return;
 		}
 
-		if ( ! function_exists( 'wc_add_notice' ) || ! function_exists( 'wc_has_notice' ) ) {
-			return;
-		}
-
 		if ( wc_has_notice( $message ) ) {
 			return;
 		}

--- a/smart-send-logistics/includes/class-ss-shipping-logger.php
+++ b/smart-send-logistics/includes/class-ss-shipping-logger.php
@@ -134,10 +134,6 @@ class SS_Shipping_Logger {
 			return;
 		}
 
-		if ( ! function_exists( 'wc_add_notice' ) || ! function_exists( 'wc_has_notice' ) ) {
-			return;
-		}
-
 		if ( wc_has_notice( $message ) ) {
 			return;
 		}
@@ -243,10 +239,6 @@ class SS_Shipping_Logger {
 	 * @param bool   $enabled Whether logging is enabled for this entry (before the filter).
 	 */
 	private static function write( $level, $message, $context, $enabled ) {
-		if ( ! function_exists( 'wc_get_logger' ) ) {
-			return;
-		}
-
 		if ( ! $enabled || ! in_array( $level, self::LEVELS, true ) ) {
 			return;
 		}

--- a/smart-send-logistics/includes/class-ss-shipping-order-data.php
+++ b/smart-send-logistics/includes/class-ss-shipping-order-data.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+// A second copy of the plugin may already have defined the class.
 if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 
 	/**

--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+// A second copy of the plugin may already have defined the class.
 if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 
 	/**

--- a/smart-send-logistics/includes/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-method.php
@@ -4,7 +4,8 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
-if (!class_exists('SS_Shipping_WC_Method')) :
+// A second copy of the plugin may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 
     class SS_Shipping_WC_Method extends WC_Shipping_Flat_Rate
     {

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -15,7 +15,8 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableControlle
  * @author   Smart Send
  */
 
-if (!class_exists('SS_Shipping_WC_Order')) :
+// A second copy of the plugin may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
 
 	class SS_Shipping_WC_Order {
 
@@ -70,15 +71,14 @@ if (!class_exists('SS_Shipping_WC_Order')) :
             add_filter('update_post_metadata_by_mid', array($this, 'filter_update_agent_meta'), 10, 4);//For Wordpress 5.0.0+
             add_action('deleted_post_meta', array($this, 'action_deleted_agent_meta'), 10, 4);
 
-            $subs_version = class_exists('WC_Subscriptions') && !empty(WC_Subscriptions::$version) ? WC_Subscriptions::$version : null;
-            // Prevent data being copied to subscriptions
-            if (null !== $subs_version && version_compare($subs_version, '2.0.0', '>=')) {
-                add_filter('wcs_renewal_order_meta_query',
-                    array($this, 'woocommerce_subscriptions_renewal_order_meta_query'), 10);
-            } else {
-                add_filter('woocommerce_subscriptions_renewal_order_meta_query',
-                    array($this, 'woocommerce_subscriptions_renewal_order_meta_query'), 10);
-            }
+			// The WooCommerce Subscriptions plugin is optional.
+			$subs_version = class_exists( 'WC_Subscriptions' ) && ! empty( WC_Subscriptions::$version ) ? WC_Subscriptions::$version : null;
+			// Prevent data being copied to subscriptions.
+			if ( null !== $subs_version && version_compare( $subs_version, '2.0.0', '>=' ) ) {
+				add_filter( 'wcs_renewal_order_meta_query', array( $this, 'woocommerce_subscriptions_renewal_order_meta_query' ), 10 );
+			} else {
+				add_filter( 'woocommerce_subscriptions_renewal_order_meta_query', array( $this, 'woocommerce_subscriptions_renewal_order_meta_query' ), 10 );
+			}
 
 			// Add bulk actions to the Orders screen table bulk action drop-downs.
 			$this->register_bulk_order_actions();
@@ -87,18 +87,19 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 			$this->admin_notices->init_hooks();
 		}
 
-        /**
-         * Register bulk order actions.
-         * @see https://make.wordpress.org/core/2016/10/04/custom-bulk-actions/
-         * @since WordPress 4.7.0
-         * @return void
-         */
-        private function register_bulk_order_actions()
-        {
-            $screen = class_exists( '\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' )
-                && wc_get_container()->get(CustomOrdersTableController::class)->custom_orders_table_usage_is_enabled()
-                ? 'woocommerce_page_wc-orders' // function not available wc_get_page_screen_id( 'shop-order' )
-                : 'edit-shop_order'; // Index page is called 'edit-shop_order' and not just 'shop_order' as stated in the url
+		/**
+		 * Register bulk order actions.
+		 *
+		 * @see https://make.wordpress.org/core/2016/10/04/custom-bulk-actions/
+		 * @since WordPress 4.7.0
+		 * @return void
+		 */
+		private function register_bulk_order_actions() {
+			// The HPOS CustomOrdersTableController exists since WC 6.4; the plugin's WC floor is 4.7.
+			$screen = class_exists( '\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' )
+				&& wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+				? 'woocommerce_page_wc-orders' // function not available wc_get_page_screen_id( 'shop-order' )
+				: 'edit-shop_order'; // Index page is called 'edit-shop_order' and not just 'shop_order' as stated in the url
 
             // An actions in the dropdown
             add_filter("bulk_actions-{$screen}", array($this, 'add_bulk_order_actions'));
@@ -243,15 +244,15 @@ if (!class_exists('SS_Shipping_WC_Order')) :
 			return $sendback;
 		}
 
-        /**
-         * Add the meta box for shipment info on the order page
-         */
-        public function add_smart_send_order_meta_box()
-        {
-            // @see https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#audit-for-order-administration-screen-functions
-            $screen = class_exists( '\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) && wc_get_container()->get(CustomOrdersTableController::class)->custom_orders_table_usage_is_enabled()
-                ? wc_get_page_screen_id( 'shop-order' )
-                : 'shop_order';
+		/**
+		 * Add the meta box for shipment info on the order page
+		 */
+		public function add_smart_send_order_meta_box() {
+			// @see https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#audit-for-order-administration-screen-functions
+			// The HPOS CustomOrdersTableController exists since WC 6.4; the plugin's WC floor is 4.7.
+			$screen = class_exists( '\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) && wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+				? wc_get_page_screen_id( 'shop-order' )
+				: 'shop_order';
 
             add_meta_box(
                 'woocommerce-ss-shipping-label',
@@ -1176,10 +1177,11 @@ if (!class_exists('SS_Shipping_WC_Order')) :
             $date_shipped = null
         ) {
 
-            if (function_exists('wc_st_add_tracking_number')) {
-                wc_st_add_tracking_number($order_id, $tracking_number, $provider, $date_shipped, $tracking_url);
-            }
-        }
+			// The WooCommerce Shipment Tracking plugin is optional.
+			if ( function_exists( 'wc_st_add_tracking_number' ) ) {
+				wc_st_add_tracking_number( $order_id, $tracking_number, $provider, $date_shipped, $tracking_url );
+			}
+		}
 
         /**
          * Prevents data being copied to subscription renewals

--- a/smart-send-logistics/includes/class-ss-shipping-wc-product.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-product.php
@@ -12,7 +12,8 @@ if (!defined('ABSPATH')) {
  * @author   Smart Send
  */
 
-if (!class_exists('SS_Shipping_WC_Product')) :
+// A second copy of the plugin may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_WC_Product' ) ) :
 
     class SS_Shipping_WC_Product
     {

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -12,7 +12,8 @@ if (!defined('ABSPATH')) {
  * @author   Smart Send
  */
 
-if (!class_exists('SS_Shipping_Frontend')) :
+// A second copy of the plugin may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 
     class SS_Shipping_Frontend
     {

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -31,7 +31,8 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly.
 }
 
-if (!class_exists('SS_Shipping_WC')) :
+// A second copy of the plugin (e.g. bundled elsewhere) may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 
     class SS_Shipping_WC
     {
@@ -98,12 +99,12 @@ if (!class_exists('SS_Shipping_WC')) :
 			$this->init_hooks();
 		}
 
-        public function declaring_hpos_compatibility()
-        {
-            if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
-                \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
-            }
-        }
+		public function declaring_hpos_compatibility() {
+			// FeaturesUtil exists since WC 6.5; the plugin's WC floor is 4.7.
+			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+			}
+		}
 
         /**
          * Main Smart Send Shipping Instance.
@@ -178,16 +179,18 @@ if (!class_exists('SS_Shipping_WC')) :
 			// "called incorrectly" notice.
 			$this->define( 'SS_BUTTON_TEST_CONNECTION', __( 'Validate API Token', 'smart-send-logistics' ) );
 
-            // Checks if WooCommerce 2.6 is installed.
-            if (defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '2.6', '>=')) {
-                $this->ss_shipping_frontend = new SS_Shipping_Frontend();
-                $this->ss_shipping_wc_order = new SS_Shipping_WC_Order();
-                $this->ss_shipping_wc_product = new SS_Shipping_WC_Product();
-                $this->ss_plugin_screen_updates = new SS_Plugins_Screen_Updates();
-            } else {
-                // Throw an admin error informing the user this plugin needs WooCommerce to function
-                add_action('admin_notices', array($this, 'notice_wc_required'));
-            }
+			// The single bootstrap-level WooCommerce-active gate: `Requires Plugins: woocommerce`
+			// already guarantees WooCommerce on WP >= 6.5, so this check is belt-and-braces for
+			// older WordPress. Everything downstream of it assumes WooCommerce is present.
+			if ( defined( 'WOOCOMMERCE_VERSION' ) && version_compare( WOOCOMMERCE_VERSION, '2.6', '>=' ) ) {
+				$this->ss_shipping_frontend     = new SS_Shipping_Frontend();
+				$this->ss_shipping_wc_order     = new SS_Shipping_WC_Order();
+				$this->ss_shipping_wc_product   = new SS_Shipping_WC_Product();
+				$this->ss_plugin_screen_updates = new SS_Plugins_Screen_Updates();
+			} else {
+				// Throw an admin error informing the user this plugin needs WooCommerce to function.
+				add_action( 'admin_notices', array( $this, 'notice_wc_required' ) );
+			}
 
         }
 


### PR DESCRIPTION
Applies the existence-guard policy from #90: guards remain only where existence genuinely varies across the supported range (PHP 7.4 / WC 4.7 floors, `Requires Plugins: woocommerce`). Guards on floor-guaranteed WP/WC core APIs are removed; every kept guard now carries a one-line comment stating why existence varies.

**Stacked on #97** (`feature/issue-72-order-data-utility`) — merge that first.

## Classification table

| Guard | Location | Category | Outcome |
|---|---|---|---|
| `function_exists( 'wc_get_logger' )` | `includes/class-ss-shipping-logger.php` (`write()`) | Floor-guaranteed (WC core, any version) | **Removed** |
| `function_exists( 'wc_add_notice' ) \|\| function_exists( 'wc_has_notice' )` | `includes/class-ss-shipping-logger.php` (`debug_notice()`) | Floor-guaranteed in checkout contexts | **Removed** |
| `function_exists( 'wc_add_notice' ) \|\| function_exists( 'wc_has_notice' )` | `includes/class-ss-shipping-checkout-debug.php` (`add_notice()`) | Floor-guaranteed in checkout contexts | **Removed** |
| `class_exists( FeaturesUtil::class )` | `smart-send-logistics.php:104` | WC API newer than floor (WC 6.5+) | Kept + comment |
| `class_exists( '\Automattic\...\CustomOrdersTableController' )` | `includes/class-ss-shipping-wc-order.php:99` | WC API newer than floor (HPOS, WC 6.4+) | Kept + comment |
| `class_exists( '\Automattic\...\CustomOrdersTableController' )` | `includes/class-ss-shipping-wc-order.php:253` | WC API newer than floor (HPOS, WC 6.4+) | Kept + comment |
| `class_exists( 'WC_Subscriptions' )` | `includes/class-ss-shipping-wc-order.php:75` | Optional third-party plugin | Kept + comment |
| `function_exists( 'wc_st_add_tracking_number' )` | `includes/class-ss-shipping-wc-order.php:1181` | Optional third-party plugin (Shipment Tracking) | Kept + comment |
| `function_exists( 'get_plugins' )` | `includes/lib/Smartsend/Client.php:98` | Load context (admin include on frontend); guard + `require_once`, the pattern the policy prefers | Kept (pre-existing comment) |
| `class_exists( 'SS_Shipping_WC' )` | `smart-send-logistics.php:35` | Duplicate plugin copy may already define the class | Kept + comment |
| `class_exists( 'SS_Shipping_Order_Data' )` | `includes/class-ss-shipping-order-data.php:15` | Duplicate plugin copy | Kept + comment |
| `class_exists( 'SS_Shipping_Shipment' )` | `includes/class-ss-shipping-shipment.php:15` | Duplicate plugin copy | Kept + comment |
| `class_exists( 'SS_Shipping_WC_Method' )` | `includes/class-ss-shipping-wc-method.php:8` | Duplicate plugin copy | Kept + comment |
| `class_exists( 'SS_Shipping_WC_Product' )` | `includes/class-ss-shipping-wc-product.php:16` | Duplicate plugin copy | Kept + comment |
| `class_exists( 'SS_Shipping_Frontend' )` | `includes/frontend/class-ss-shipping-frontend.php:16` | Duplicate plugin copy | Kept + comment |
| `class_exists( 'SS_Shipping_WC_Order' )` | `includes/class-ss-shipping-wc-order.php:19` | Duplicate plugin copy | Kept + comment |

No `method_exists`/`interface_exists` calls exist in the plugin.

## Single bootstrap gate

The `WOOCOMMERCE_VERSION` check in `SS_Shipping_WC::init()` is confirmed as the one bootstrap-level WooCommerce-active gate (belt-and-braces for WP < 6.5, where `Requires Plugins` is not enforced) and is now commented as such. Everything downstream assumes WooCommerce is present.

## CLAUDE.md

Added an "Existence-guard policy" section (placed after the Logging policy) documenting the three legitimate guard categories, the call-directly rule, the one-line-comment requirement, and the single bootstrap gate.

## Notes

- Lines adjacent to the edits lost their phpcs-baseline cover and were brought fully to WPCS (tabs, spacing, single quotes) per project rules; `phpcs.baseline.xml` itself is untouched.
- No test exercised the removed guards' absence branches, so no test changes were needed.
- `composer test:integration`: 137 passed. `vendor/bin/phpcs`: clean. `composer phpcs:compat`: clean.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
