### PR TITLE
Declare class properties explicitly (typed where safe)

### DIFF
--- a/smart-send-logistics/includes/class-ss-plugins-screen-updates.php
+++ b/smart-send-logistics/includes/class-ss-plugins-screen-updates.php
@@ -17,9 +17,19 @@ class SS_Plugins_Screen_Updates {
 	/**
 	 * The upgrade notice shown inline.
 	 *
-	 * @var string
+	 * Deliberately untyped: get_upgrade_notice() returns false when the
+	 * transient is empty and the readme fetch fails.
+	 *
+	 * @var string|false
 	 */
 	protected $upgrade_notice = '';
+
+	/**
+	 * The new plugin version offered by the update response.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $new_version = null;
 
 	/**
 	 * Constructor.

--- a/smart-send-logistics/includes/class-ss-shipping-autoloader.php
+++ b/smart-send-logistics/includes/class-ss-shipping-autoloader.php
@@ -8,12 +8,12 @@ if (!defined('ABSPATH')) {
 class SS_Shipping_Autoloader
 {
 
-    /**
-     * Path to the includes directory.
-     *
-     * @var string
-     */
-    private $include_path = '';
+	/**
+	 * Path to the includes directory.
+	 *
+	 * @var string
+	 */
+	private string $include_path = '';
 
     /**
      * The Constructor.

--- a/smart-send-logistics/includes/class-ss-shipping-logger.php
+++ b/smart-send-logistics/includes/class-ss-shipping-logger.php
@@ -33,7 +33,10 @@ class SS_Shipping_Logger {
 	/**
 	 * The shared WC_Logger instance.
 	 *
-	 * @var WC_Logger_Interface
+	 * Public and deliberately untyped: tests (and potentially merchant code)
+	 * inject logger doubles that do not implement WC_Logger_Interface.
+	 *
+	 * @var WC_Logger_Interface|null
 	 */
 	public static $logger;
 

--- a/smart-send-logistics/includes/class-ss-shipping-order-data.php
+++ b/smart-send-logistics/includes/class-ss-shipping-order-data.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 		 *
 		 * @var WC_Order
 		 */
-		protected $order;
+		protected WC_Order $order;
 
 		/**
 		 * Constructor.

--- a/smart-send-logistics/includes/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/includes/class-ss-shipping-shipment.php
@@ -24,7 +24,10 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 		/**
 		 * The WooCommerce order.
 		 *
-		 * @var WC_Order|null
+		 * Deliberately untyped: wc_get_order() can return false (or a
+		 * WC_Order_Refund), and the constructor relies on that falsy value.
+		 *
+		 * @var WC_Order|false|null
 		 */
 		protected $order = null;
 
@@ -33,21 +36,21 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 		 *
 		 * @var SS_Shipping_Order_Data|null
 		 */
-		protected $order_data = null;
+		protected ?SS_Shipping_Order_Data $order_data = null;
 
 		/**
 		 * The admin order integration.
 		 *
 		 * @var SS_Shipping_WC_Order|null
 		 */
-		protected $shipping_order = null;
+		protected ?SS_Shipping_WC_Order $shipping_order = null;
 
 		/**
 		 * The shipment model being assembled.
 		 *
 		 * @var \Smartsend\Models\Shipment|null
 		 */
-		protected $shipment = null;
+		protected ?\Smartsend\Models\Shipment $shipment = null;
 
 		/**
 		 * Init and hook in the integration.

--- a/smart-send-logistics/includes/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-method.php
@@ -10,9 +10,9 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
     class SS_Shipping_WC_Method extends WC_Shipping_Flat_Rate
     {
 
-        private $shipping_method = array();
+		private array $shipping_method = array();
 
-		private $return_shipping_method = array();
+		private array $return_shipping_method = array();
 
         /**
          * Init and hook in the integration.

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
 
 	class SS_Shipping_WC_Order {
 
-		protected $label_prefix = 'smart-send-label-';
+		protected string $label_prefix = 'smart-send-label-';
 
 		/**
 		 * Admin notices component used to flash one-time notices after
@@ -28,7 +28,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
 		 *
 		 * @var SS_Shipping_Admin_Notices
 		 */
-		protected $admin_notices;
+		protected SS_Shipping_Admin_Notices $admin_notices;
 
 		/**
 		 * Init and hook in the integration.

--- a/smart-send-logistics/includes/lib/Smartsend/Client.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Client.php
@@ -13,12 +13,13 @@ class Client
 
     /** @var string Untyped: the value passes through the smart_send_api_endpoint filter, whose return value is not under our control. */
     private $api_host = 'https://app.smartsend.io/api/v1/';
-    /** @var string|null Untyped: assigned via the public setWebsite() setter without casting. */
-    private $website;
-    /** @var string|null Untyped: assigned via the public setApiToken() setter without casting. */
-    private $api_token;
-    /** @var bool Untyped: assigned via the public setDemo() setter without casting. */
-    private $demo;
+    // ?string: setWebsite() can receive null when get_website_url()'s
+    // parse_url() call fails to resolve a host (returns null on a malformed
+    // site URL); setApiToken() can receive null when no token is configured
+    // yet (SS_Shipping_WC::get_api_token_setting() returns null).
+    private ?string $website = null;
+    private ?string $api_token = null;
+    private bool $demo = false;
     protected ?string $request_endpoint = null;
     protected ?array $request_headers = null;
     /** @var string|null Untyped: json_encode() can return false on encoding failure. */
@@ -34,7 +35,7 @@ class Client
     protected $content_type;
     /** @var array|\WP_Error|null Untyped: holds the raw wp_remote_request() result. */
     protected $debug;
-    /** @var mixed */
+    /** @var mixed Untyped: assigned only null (clearAll()); no accessor reads it, so its real API contract is unconfirmed. */
     protected $meta;
     protected ?bool $success = null;
     /** @var mixed API response data. */
@@ -42,7 +43,7 @@ class Client
     /** @var mixed API response links. */
     protected $links;
     protected ?Error $error = null;
-    /** @var callable|null Untyped: PHP does not support callable property types. */
+    /** @var callable|null Untyped: PHP does not support callable property types (the setter parameter below is still hinted `callable`). */
     private $request_logger;
     private ?float $request_started_at = null;
 
@@ -55,47 +56,47 @@ class Client
         $this->api_host = apply_filters( 'smart_send_api_endpoint', $this->api_host);
     }
 
-    public function setApiToken($api_token)
+    public function setApiToken(?string $api_token): void
     {
         $this->api_token = $api_token;
     }
 
-    public function setWebsite($website)
+    public function setWebsite(?string $website): void
     {
         // Remove www. from the start of the website
-        if (substr($website, 0, strlen('www.')) == 'www.') {
+        if ($website !== null && substr($website, 0, strlen('www.')) == 'www.') {
             $website = substr($website, strlen('www.'));
         }
 
         $this->website = $website;
     }
 
-    public function setDemo($demo)
+    public function setDemo(bool $demo): void
     {
         $this->demo = $demo;
     }
 
-    public function getApiEndpoint() 
+    public function getApiEndpoint()
     {
         return $this->getApiHost().($this->getDemo() ? 'demo/' : '')."website/".$this->getWebsite()."/";
     }
 
-    private function getApiHost() 
+    private function getApiHost()
     {
         return $this->api_host;
     }
 
-    private function getWebsite() 
+    private function getWebsite(): ?string
     {
         return $this->website;
     }
 
-    private function getApiToken() 
+    private function getApiToken(): ?string
     {
         return $this->api_token;
     }
 
-    public function getDemo() 
+    public function getDemo(): bool
     {
         return $this->demo;
     }
@@ -151,9 +152,9 @@ class Client
     }
 
     /**
-     * @return mixed
+     * @return Error|null
      */
-    public function getError()
+    public function getError(): ?Error
     {
         return $this->error;
     }
@@ -218,9 +219,9 @@ class Client
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getRequestEndpoint()
+    public function getRequestEndpoint(): ?string
     {
         return $this->request_endpoint;
     }
@@ -234,17 +235,17 @@ class Client
     }
 
     /**
-     * @return mixed
+     * @return array|null
      */
-    public function getRequestHeaders()
+    public function getRequestHeaders(): ?array
     {
         return $this->request_headers;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getResponseBody()
+    public function getResponseBody(): ?string
     {
         return $this->response_body;
     }
@@ -269,7 +270,7 @@ class Client
      * @param   callable|null $request_logger
      * @return  void
      */
-    public function setRequestLogger($request_logger)
+    public function setRequestLogger(?callable $request_logger): void
     {
         $this->request_logger = $request_logger;
     }
@@ -304,7 +305,7 @@ class Client
      * Was the API response contain link to next page of results
      * @return  boolean
      */
-    public function isSuccessful()
+    public function isSuccessful(): ?bool
     {
         return $this->success;
     }

--- a/smart-send-logistics/includes/lib/Smartsend/Client.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Client.php
@@ -11,26 +11,40 @@ class Client
 {
     const TIMEOUT = 30;
 
+    /** @var string Untyped: the value passes through the smart_send_api_endpoint filter, whose return value is not under our control. */
     private $api_host = 'https://app.smartsend.io/api/v1/';
+    /** @var string|null Untyped: assigned via the public setWebsite() setter without casting. */
     private $website;
+    /** @var string|null Untyped: assigned via the public setApiToken() setter without casting. */
     private $api_token;
+    /** @var bool Untyped: assigned via the public setDemo() setter without casting. */
     private $demo;
-    protected $request_endpoint;
-    protected $request_headers;
+    protected ?string $request_endpoint = null;
+    protected ?array $request_headers = null;
+    /** @var string|null Untyped: json_encode() can return false on encoding failure. */
     protected $request_body;
+    /** @var array|\WpOrg\Requests\Utility\CaseInsensitiveDictionary|null Untyped: wp_remote_retrieve_headers() returns either shape. */
     protected $response_headers;
-    protected $response_body;
+    protected ?string $response_body = null;
+    /** @var mixed Decoded JSON response body. */
     protected $response;
+    /** @var int|string|null Untyped: wp_remote_retrieve_response_code() returns '' on transport failure. */
     protected $http_status_code;
+    /** @var string|array|null Untyped: wp_remote_retrieve_header() returns an array for duplicate headers. */
     protected $content_type;
+    /** @var array|\WP_Error|null Untyped: holds the raw wp_remote_request() result. */
     protected $debug;
+    /** @var mixed */
     protected $meta;
-    protected $success;
+    protected ?bool $success = null;
+    /** @var mixed API response data. */
     protected $data;
+    /** @var mixed API response links. */
     protected $links;
-    protected $error;
+    protected ?Error $error = null;
+    /** @var callable|null Untyped: PHP does not support callable property types. */
     private $request_logger;
-    private $request_started_at;
+    private ?float $request_started_at = null;
 
     public function __construct($api_token, $website, $demo=false)
     {

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Agent.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Agent.php
@@ -12,232 +12,231 @@ class Agent implements \JsonSerializable
 {
     //private $id; Only returned by API
     //private $type='agent'; Only returned by API
-    private $agent_no;
-    private $carrier;
-    private $company;
-    private $name_line1;
-    private $name_line2;
-    private $address_line1;
-    private $address_line2;
-    private $postal_code;
-    private $city;
-    private $country;
-    // Typed with "= null" so get_object_vars() serialization is unchanged;
-    // the uncast public setters above stay untyped (see Models/Shipment.php).
+    // Typed with "= null" so get_object_vars() serialization is unchanged.
+    private ?string $agent_no = null;
+    private ?string $carrier = null;
+    private ?string $company = null;
+    private ?string $name_line1 = null;
+    private ?string $name_line2 = null;
+    private ?string $address_line1 = null;
+    private ?string $address_line2 = null;
+    private ?string $postal_code = null;
+    private ?string $city = null;
+    private ?string $country = null;
     private ?Coordinates $coordinates = null;
-    private $opening_hours;
+    private ?array $opening_hours = null;
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAgentNo()
+    public function getAgentNo(): ?string
     {
         return $this->agent_no;
     }
 
     /**
-     * @param mixed $agent_no
-     * @return Agent
+     * @param string|null $agent_no
+     * @return self
      */
-    public function setAgentNo($agent_no)
+    public function setAgentNo(?string $agent_no): self
     {
         $this->agent_no = $agent_no;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCarrier()
+    public function getCarrier(): ?string
     {
         return $this->carrier;
     }
 
     /**
-     * @param mixed $carrier
-     * @return Agent
+     * @param string|null $carrier
+     * @return self
      */
-    public function setCarrier($carrier)
+    public function setCarrier(?string $carrier): self
     {
         $this->carrier = $carrier;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCompany()
+    public function getCompany(): ?string
     {
         return $this->company;
     }
 
     /**
-     * @param mixed $company
-     * @return Agent
+     * @param string|null $company
+     * @return self
      */
-    public function setCompany($company)
+    public function setCompany(?string $company): self
     {
         $this->company = $company;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getNameLine1()
+    public function getNameLine1(): ?string
     {
         return $this->name_line1;
     }
 
     /**
-     * @param mixed $name_line1
-     * @return Agent
+     * @param string|null $name_line1
+     * @return self
      */
-    public function setNameLine1($name_line1)
+    public function setNameLine1(?string $name_line1): self
     {
         $this->name_line1 = $name_line1;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getNameLine2()
+    public function getNameLine2(): ?string
     {
         return $this->name_line2;
     }
 
     /**
-     * @param mixed $name_line2
-     * @return Agent
+     * @param string|null $name_line2
+     * @return self
      */
-    public function setNameLine2($name_line2)
+    public function setNameLine2(?string $name_line2): self
     {
         $this->name_line2 = $name_line2;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAddressLine1()
+    public function getAddressLine1(): ?string
     {
         return $this->address_line1;
     }
 
     /**
-     * @param mixed $address_line1
-     * @return Agent
+     * @param string|null $address_line1
+     * @return self
      */
-    public function setAddressLine1($address_line1)
+    public function setAddressLine1(?string $address_line1): self
     {
         $this->address_line1 = $address_line1;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAddressLine2()
+    public function getAddressLine2(): ?string
     {
         return $this->address_line2;
     }
 
     /**
-     * @param mixed $address_line2
-     * @return Agent
+     * @param string|null $address_line2
+     * @return self
      */
-    public function setAddressLine2($address_line2)
+    public function setAddressLine2(?string $address_line2): self
     {
         $this->address_line2 = $address_line2;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getPostalCode()
+    public function getPostalCode(): ?string
     {
         return $this->postal_code;
     }
 
     /**
-     * @param mixed $postal_code
-     * @return Agent
+     * @param string|null $postal_code
+     * @return self
      */
-    public function setPostalCode($postal_code)
+    public function setPostalCode(?string $postal_code): self
     {
         $this->postal_code = $postal_code;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCity()
+    public function getCity(): ?string
     {
         return $this->city;
     }
 
     /**
-     * @param mixed $city
-     * @return Agent
+     * @param string|null $city
+     * @return self
      */
-    public function setCity($city)
+    public function setCity(?string $city): self
     {
         $this->city = $city;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCountry()
+    public function getCountry(): ?string
     {
         return $this->country;
     }
 
     /**
-     * @param mixed $country
-     * @return Agent
+     * @param string|null $country
+     * @return self
      */
-    public function setCountry($country)
+    public function setCountry(?string $country): self
     {
         $this->country = $country;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return Coordinates|null
      */
-    public function getCoordinates()
+    public function getCoordinates(): ?Coordinates
     {
         return $this->coordinates;
     }
 
     /**
      * @param Coordinates $coordinates
-     * @return Agent
+     * @return self
      */
-    public function setCoordinates(Coordinates $coordinates)
+    public function setCoordinates(Coordinates $coordinates): self
     {
         $this->coordinates = $coordinates;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return OpeningHour[]|null
      */
-    public function getOpeningHours()
+    public function getOpeningHours(): ?array
     {
         return $this->opening_hours;
     }
 
     /**
-     * @param mixed $opening_hours
-     * @return Agent
+     * @param OpeningHour[]|null $opening_hours
+     * @return self
      */
-    public function setOpeningHours($opening_hours)
+    public function setOpeningHours(?array $opening_hours): self
     {
         $this->opening_hours = $opening_hours;
         return $this;
@@ -245,9 +244,9 @@ class Agent implements \JsonSerializable
 
     /**
      * @param OpeningHour $opening_hour
-     * @return Agent
+     * @return self
      */
-    public function addOpeningHours(OpeningHour $opening_hour)
+    public function addOpeningHours(OpeningHour $opening_hour): self
     {
         if (is_array($this->opening_hours)) {
             $this->opening_hours[] = $opening_hour;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Agent.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Agent.php
@@ -22,7 +22,9 @@ class Agent implements \JsonSerializable
     private $postal_code;
     private $city;
     private $country;
-    private $coordinates;
+    // Typed with "= null" so get_object_vars() serialization is unchanged;
+    // the uncast public setters above stay untyped (see Models/Shipment.php).
+    private ?Coordinates $coordinates = null;
     private $opening_hours;
 
     /**

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Agent/Coordinates.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Agent/Coordinates.php
@@ -5,42 +5,42 @@ namespace Smartsend\Models\Agent;
 class Coordinates implements \JsonSerializable
 {
 
-    private $latitude;
-    private $longitude;
+    private ?float $latitude = null;
+    private ?float $longitude = null;
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getLatitude()
+    public function getLatitude(): ?float
     {
         return $this->latitude;
     }
 
     /**
      * @param mixed $latitude
-     * @return Coordinates
+     * @return self
      */
-    public function setLatitude($latitude)
+    public function setLatitude($latitude): self
     {
-        $this->latitude = $latitude;
+        $this->latitude = is_null($latitude) ? null : ((float) $latitude);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getLongitude()
+    public function getLongitude(): ?float
     {
         return $this->longitude;
     }
 
     /**
      * @param mixed $longitude
-     * @return Coordinates
+     * @return self
      */
-    public function setLongitude($longitude)
+    public function setLongitude($longitude): self
     {
-        $this->longitude = $longitude;
+        $this->longitude = is_null($longitude) ? null : ((float) $longitude);
         return $this;
     }
 

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Agent/OpeningHour.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Agent/OpeningHour.php
@@ -4,59 +4,59 @@ namespace Smartsend\Models\Agent;
 
 class OpeningHour implements \JsonSerializable
 {
-    private $day;
-    private $opens;
-    private $closes;
+    private ?string $day = null;
+    private ?string $opens = null;
+    private ?string $closes = null;
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getDay()
+    public function getDay(): ?string
     {
         return $this->day;
     }
 
     /**
-     * @param mixed $day
-     * @return OpeningHour
+     * @param string|null $day
+     * @return self
      */
-    public function setDay($day)
+    public function setDay(?string $day): self
     {
         $this->day = $day;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getOpens()
+    public function getOpens(): ?string
     {
         return $this->opens;
     }
 
     /**
-     * @param mixed $opens
-     * @return OpeningHour
+     * @param string|null $opens
+     * @return self
      */
-    public function setOpens($opens)
+    public function setOpens(?string $opens): self
     {
         $this->opens = $opens;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCloses()
+    public function getCloses(): ?string
     {
         return $this->closes;
     }
 
     /**
-     * @param mixed $closes
-     * @return OpeningHour
+     * @param string|null $closes
+     * @return self
      */
-    public function setCloses($closes)
+    public function setCloses(?string $closes): self
     {
         $this->closes = $closes;
         return $this;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Error.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Error.php
@@ -6,10 +6,21 @@ namespace Smartsend\Models;
 
 class Error
 {
+    // $links: decoded JSON, observed as an object (getErrorString() reads
+    // $error->links->about) but could be an array depending on what the API
+    // sends; PHP 7.4 has no union types to express "object|array|null".
     public $links;
+    // $id: the API's error id can be a string or an int; no union types in
+    // PHP 7.4 to express that.
     public $id;
+    // $code: proven to vary in shape by the defensive is_scalar() guards in
+    // SS_Shipping_Logger and SS_Shipping_Frontend before casting it to
+    // string, so it is not safely typeable without union types.
     public $code;
-    public $message;
+    public ?string $message = null;
+    // $errors: either the internal array() default or a decoded-JSON value
+    // straight from the API (object or array depending on the response
+    // shape) - iterated with foreach either way. No union types in PHP 7.4.
     public $errors;
 
     /**
@@ -22,9 +33,9 @@ class Error
 
     /**
      * @param mixed $links
-     * @return Error
+     * @return self
      */
-    public function setLinks($links)
+    public function setLinks($links): self
     {
         $this->links = $links;
         return $this;
@@ -40,9 +51,9 @@ class Error
 
     /**
      * @param mixed $id
-     * @return Error
+     * @return self
      */
-    public function setId($id)
+    public function setId($id): self
     {
         $this->id = $id;
         return $this;
@@ -58,27 +69,27 @@ class Error
 
     /**
      * @param mixed $code
-     * @return Error
+     * @return self
      */
-    public function setCode($code)
+    public function setCode($code): self
     {
         $this->code = $code;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getMessage()
+    public function getMessage(): ?string
     {
         return $this->message;
     }
 
     /**
-     * @param mixed $message
-     * @return Error
+     * @param string|null $message
+     * @return self
      */
-    public function setMessage($message)
+    public function setMessage(?string $message): self
     {
         $this->message = $message;
         return $this;
@@ -94,9 +105,9 @@ class Error
 
     /**
      * @param mixed $errors
-     * @return Error
+     * @return self
      */
-    public function setErrors($errors)
+    public function setErrors($errors): self
     {
         $this->errors = $errors;
         return $this;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment.php
@@ -16,23 +16,28 @@ require_once 'Shipment/Services.php';
 
 class Shipment implements \JsonSerializable
 {
-    private $internal_id;
-    private $internal_reference;
+    // Typed properties keep the "= null" default so jsonSerialize()'s
+    // get_object_vars() output (and therefore the API payload) is identical
+    // to the previous untyped declarations. Properties whose setters do not
+    // cast are left untyped: adding a scalar type would silently coerce
+    // loosely-typed input and change the JSON payload.
+    private ?string $internal_id = null;
+    private ?string $internal_reference = null;
     private $shipping_carrier;
     private $shipping_method;
     private $shipping_date;
-    private $sender;
-    private $receiver;
-    private $agent;
-    private $parcels;
-    private $services;
-    private $subtotal_price_excluding_tax;
-    private $subtotal_price_including_tax;
-    private $shipping_price_excluding_tax;
-    private $shipping_price_including_tax;
-    private $total_price_excluding_tax;
-    private $total_price_including_tax;
-    private $total_tax_amount;
+    private ?Sender $sender = null;
+    private ?Receiver $receiver = null;
+    private ?ShipmentAgent $agent = null;
+    private ?array $parcels = null;
+    private ?Services $services = null;
+    private ?float $subtotal_price_excluding_tax = null;
+    private ?float $subtotal_price_including_tax = null;
+    private ?float $shipping_price_excluding_tax = null;
+    private ?float $shipping_price_including_tax = null;
+    private ?float $total_price_excluding_tax = null;
+    private ?float $total_price_including_tax = null;
+    private ?float $total_tax_amount = null;
     private $currency;
 
     public function __construct(Array $shipment=null)

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment.php
@@ -18,14 +18,12 @@ class Shipment implements \JsonSerializable
 {
     // Typed properties keep the "= null" default so jsonSerialize()'s
     // get_object_vars() output (and therefore the API payload) is identical
-    // to the previous untyped declarations. Properties whose setters do not
-    // cast are left untyped: adding a scalar type would silently coerce
-    // loosely-typed input and change the JSON payload.
+    // to the previous untyped declarations.
     private ?string $internal_id = null;
     private ?string $internal_reference = null;
-    private $shipping_carrier;
-    private $shipping_method;
-    private $shipping_date;
+    private ?string $shipping_carrier = null;
+    private ?string $shipping_method = null;
+    private ?string $shipping_date = null;
     private ?Sender $sender = null;
     private ?Receiver $receiver = null;
     private ?ShipmentAgent $agent = null;
@@ -38,7 +36,7 @@ class Shipment implements \JsonSerializable
     private ?float $total_price_excluding_tax = null;
     private ?float $total_price_including_tax = null;
     private ?float $total_tax_amount = null;
-    private $currency;
+    private ?string $currency = null;
 
     public function __construct(Array $shipment=null)
     {
@@ -117,162 +115,162 @@ class Shipment implements \JsonSerializable
     }
 
     /**
-     * @return null
+     * @return string|null
      */
-    public function getInternalId()
+    public function getInternalId(): ?string
     {
         return $this->internal_id;
     }
 
     /**
      * @param string $internal_id
-     * @return Shipment
+     * @return self
      */
-    public function setInternalId($internal_id)
+    public function setInternalId($internal_id): self
     {
         $this->internal_id = (string) $internal_id;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalReference()
+    public function getInternalReference(): ?string
     {
         return $this->internal_reference;
     }
 
     /**
      * @param string $internal_reference
-     * @return Shipment
+     * @return self
      */
-    public function setInternalReference($internal_reference)
+    public function setInternalReference($internal_reference): self
     {
         $this->internal_reference = (string) $internal_reference;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getShippingCarrier()
+    public function getShippingCarrier(): ?string
     {
         return $this->shipping_carrier;
     }
 
     /**
-     * @param mixed $shipping_carrier
-     * @return Shipment
+     * @param string|null $shipping_carrier
+     * @return self
      */
-    public function setShippingCarrier($shipping_carrier)
+    public function setShippingCarrier(?string $shipping_carrier): self
     {
         $this->shipping_carrier = $shipping_carrier;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getShippingMethod()
+    public function getShippingMethod(): ?string
     {
         return $this->shipping_method;
     }
 
     /**
-     * @param mixed $shipping_method
-     * @return Shipment
+     * @param string|null $shipping_method
+     * @return self
      */
-    public function setShippingMethod($shipping_method)
+    public function setShippingMethod(?string $shipping_method): self
     {
         $this->shipping_method = $shipping_method;
         return $this;
     }
-    
+
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getShippingDate()
+    public function getShippingDate(): ?string
     {
         return $this->shipping_date;
     }
 
     /**
-     * @param mixed $shipping_date
-     * @return Shipment
+     * @param string|null $shipping_date
+     * @return self
      */
-    public function setShippingDate($shipping_date)
+    public function setShippingDate(?string $shipping_date): self
     {
         $this->shipping_date = $shipping_date;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return Sender|null
      */
-    public function getSender()
+    public function getSender(): ?Sender
     {
         return $this->sender;
     }
 
     /**
      * @param Sender $sender
-     * @return Shipment
+     * @return self
      */
-    public function setSender(Sender $sender)
+    public function setSender(Sender $sender): self
     {
         $this->sender = $sender;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return Receiver|null
      */
-    public function getReceiver()
+    public function getReceiver(): ?Receiver
     {
         return $this->receiver;
     }
 
     /**
-     * @param mixed $receiver
-     * @return Shipment
+     * @param Receiver $receiver
+     * @return self
      */
-    public function setReceiver(Receiver $receiver)
+    public function setReceiver(Receiver $receiver): self
     {
         $this->receiver = $receiver;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return ShipmentAgent|null
      */
-    public function getAgent()
+    public function getAgent(): ?ShipmentAgent
     {
         return $this->agent;
     }
 
     /**
      * @param ShipmentAgent $agent
-     * @return Shipment
+     * @return self
      */
-    public function setAgent(ShipmentAgent $agent)
+    public function setAgent(ShipmentAgent $agent): self
     {
         $this->agent = $agent;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return Parcel[]|null
      */
-    public function getParcels()
+    public function getParcels(): ?array
     {
         return $this->parcels;
     }
 
     /**
-     * @param mixed $parcels
-     * @return Shipment
+     * @param Parcel[] $parcels
+     * @return self
      */
-    public function setParcels(array $parcels)
+    public function setParcels(array $parcels): self
     {
         $this->parcels = $parcels;
         return $this;
@@ -280,9 +278,9 @@ class Shipment implements \JsonSerializable
 
     /**
      * @param Parcel $parcel
-     * @return Shipment
+     * @return self
      */
-    public function addParcel(Parcel $parcel)
+    public function addParcel(Parcel $parcel): self
     {
         if (is_array($this->parcels)) {
             $this->parcels[] = $parcel;
@@ -294,162 +292,162 @@ class Shipment implements \JsonSerializable
     }
 
     /**
-     * @return mixed
+     * @return Services|null
      */
-    public function getServices()
+    public function getServices(): ?Services
     {
         return $this->services;
     }
 
     /**
      * @param Services $services
-     * @return Shipment
+     * @return self
      */
-    public function setServices(Services $services)
+    public function setServices(Services $services): self
     {
         $this->services = $services;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getSubtotalPriceExcludingTax()
+    public function getSubtotalPriceExcludingTax(): ?float
     {
         return $this->subtotal_price_excluding_tax;
     }
 
     /**
      * @param mixed $subtotal_price_excluding_tax
-     * @return Shipment
+     * @return self
      */
-    public function setSubtotalPriceExcludingTax($subtotal_price_excluding_tax)
+    public function setSubtotalPriceExcludingTax($subtotal_price_excluding_tax): self
     {
         $this->subtotal_price_excluding_tax = is_null($subtotal_price_excluding_tax) ? null : ((float) $subtotal_price_excluding_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getSubtotalPriceIncludingTax()
+    public function getSubtotalPriceIncludingTax(): ?float
     {
         return $this->subtotal_price_including_tax;
     }
 
     /**
      * @param mixed $subtotal_price_including_tax
-     * @return Shipment
+     * @return self
      */
-    public function setSubtotalPriceIncludingTax($subtotal_price_including_tax)
+    public function setSubtotalPriceIncludingTax($subtotal_price_including_tax): self
     {
         $this->subtotal_price_including_tax = is_null($subtotal_price_including_tax) ? null : ((float) $subtotal_price_including_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getShippingPriceExcludingTax()
+    public function getShippingPriceExcludingTax(): ?float
     {
         return $this->shipping_price_excluding_tax;
     }
 
     /**
      * @param mixed $shipping_price_excluding_tax
-     * @return Shipment
+     * @return self
      */
-    public function setShippingPriceExcludingTax($shipping_price_excluding_tax)
+    public function setShippingPriceExcludingTax($shipping_price_excluding_tax): self
     {
         $this->shipping_price_excluding_tax = is_null($shipping_price_excluding_tax) ? null : ((float) $shipping_price_excluding_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getShippingPriceIncludingTax()
+    public function getShippingPriceIncludingTax(): ?float
     {
         return $this->shipping_price_including_tax;
     }
 
     /**
      * @param mixed $shipping_price_including_tax
-     * @return Shipment
+     * @return self
      */
-    public function setShippingPriceIncludingTax($shipping_price_including_tax)
+    public function setShippingPriceIncludingTax($shipping_price_including_tax): self
     {
         $this->shipping_price_including_tax = is_null($shipping_price_including_tax) ? null : ((float) $shipping_price_including_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getTotalPriceExcludingTax()
+    public function getTotalPriceExcludingTax(): ?float
     {
         return $this->total_price_excluding_tax;
     }
 
     /**
      * @param mixed $total_price_excluding_tax
-     * @return Shipment
+     * @return self
      */
-    public function setTotalPriceExcludingTax($total_price_excluding_tax)
+    public function setTotalPriceExcludingTax($total_price_excluding_tax): self
     {
         $this->total_price_excluding_tax = is_null($total_price_excluding_tax) ? null : ((float) $total_price_excluding_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getTotalPriceIncludingTax()
+    public function getTotalPriceIncludingTax(): ?float
     {
         return $this->total_price_including_tax;
     }
 
     /**
      * @param mixed $total_price_including_tax
-     * @return Shipment
+     * @return self
      */
-    public function setTotalPriceIncludingTax($total_price_including_tax)
+    public function setTotalPriceIncludingTax($total_price_including_tax): self
     {
         $this->total_price_including_tax = is_null($total_price_including_tax) ? null : ((float) $total_price_including_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getTotalTaxAmount()
+    public function getTotalTaxAmount(): ?float
     {
         return $this->total_tax_amount;
     }
 
     /**
      * @param mixed $total_tax_amount
-     * @return Shipment
+     * @return self
      */
-    public function setTotalTaxAmount($total_tax_amount)
+    public function setTotalTaxAmount($total_tax_amount): self
     {
         $this->total_tax_amount = is_null($total_tax_amount) ? null : ((float) $total_tax_amount);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCurrency()
+    public function getCurrency(): ?string
     {
         return $this->currency;
     }
 
     /**
-     * @param mixed $currency
-     * @return Shipment
+     * @param string|null $currency
+     * @return self
      */
-    public function setCurrency($currency)
+    public function setCurrency(?string $currency): self
     {
         $this->currency = $currency;
         return $this;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Agent.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Agent.php
@@ -4,8 +4,10 @@ namespace Smartsend\Models\Shipment;
 
 class Agent implements \JsonSerializable
 {
-    private $internal_id;
-    private $internal_reference;
+    // Typed properties keep "= null" so get_object_vars() serialization is
+    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    private ?string $internal_id = null;
+    private ?string $internal_reference = null;
     private $agent_no;
     private $company;
     private $name_line1;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Agent.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Agent.php
@@ -5,20 +5,20 @@ namespace Smartsend\Models\Shipment;
 class Agent implements \JsonSerializable
 {
     // Typed properties keep "= null" so get_object_vars() serialization is
-    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    // unchanged.
     private ?string $internal_id = null;
     private ?string $internal_reference = null;
-    private $agent_no;
-    private $company;
-    private $name_line1;
-    private $name_line2;
-    private $address_line1;
-    private $address_line2;
-    private $postal_code;
-    private $city;
-    private $country;
-    private $sms;
-    private $email;
+    private ?string $agent_no = null;
+    private ?string $company = null;
+    private ?string $name_line1 = null;
+    private ?string $name_line2 = null;
+    private ?string $address_line1 = null;
+    private ?string $address_line2 = null;
+    private ?string $postal_code = null;
+    private ?string $city = null;
+    private ?string $country = null;
+    private ?string $sms = null;
+    private ?string $email = null;
 
     public function __construct($receiver=array())
     {
@@ -76,234 +76,234 @@ class Agent implements \JsonSerializable
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalId()
+    public function getInternalId(): ?string
     {
         return $this->internal_id;
     }
 
     /**
      * @param string $internal_id
-     * @return Agent
+     * @return self
      */
-    public function setInternalId($internal_id)
+    public function setInternalId($internal_id): self
     {
         $this->internal_id = (string) $internal_id;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalReference()
+    public function getInternalReference(): ?string
     {
         return $this->internal_reference;
     }
 
     /**
      * @param string $internal_reference
-     * @return Agent
+     * @return self
      */
-    public function setInternalReference($internal_reference)
+    public function setInternalReference($internal_reference): self
     {
         $this->internal_reference = (string) $internal_reference;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAgentNo()
+    public function getAgentNo(): ?string
     {
         return $this->agent_no;
     }
 
     /**
-     * @param mixed $agent_no
-     * @return Agent
+     * @param string|null $agent_no
+     * @return self
      */
-    public function setAgentNo($agent_no)
+    public function setAgentNo(?string $agent_no): self
     {
         $this->agent_no = $agent_no;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCompany()
+    public function getCompany(): ?string
     {
         return $this->company;
     }
 
     /**
-     * @param mixed $company
-     * @return Agent
+     * @param string|null $company
+     * @return self
      */
-    public function setCompany($company)
+    public function setCompany(?string $company): self
     {
         $this->company = $company;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getNameLine1()
+    public function getNameLine1(): ?string
     {
         return $this->name_line1;
     }
 
     /**
-     * @param mixed $name_line1
-     * @return Agent
+     * @param string|null $name_line1
+     * @return self
      */
-    public function setNameLine1($name_line1)
+    public function setNameLine1(?string $name_line1): self
     {
         $this->name_line1 = $name_line1;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getNameLine2()
+    public function getNameLine2(): ?string
     {
         return $this->name_line2;
     }
 
     /**
-     * @param mixed $name_line2
-     * @return Agent
+     * @param string|null $name_line2
+     * @return self
      */
-    public function setNameLine2($name_line2)
+    public function setNameLine2(?string $name_line2): self
     {
         $this->name_line2 = $name_line2;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAddressLine1()
+    public function getAddressLine1(): ?string
     {
         return $this->address_line1;
     }
 
     /**
-     * @param mixed $address_line1
-     * @return Agent
+     * @param string|null $address_line1
+     * @return self
      */
-    public function setAddressLine1($address_line1)
+    public function setAddressLine1(?string $address_line1): self
     {
         $this->address_line1 = $address_line1;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAddressLine2()
+    public function getAddressLine2(): ?string
     {
         return $this->address_line2;
     }
 
     /**
-     * @param mixed $address_line2
-     * @return Agent
+     * @param string|null $address_line2
+     * @return self
      */
-    public function setAddressLine2($address_line2)
+    public function setAddressLine2(?string $address_line2): self
     {
         $this->address_line2 = $address_line2;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getPostalCode()
+    public function getPostalCode(): ?string
     {
         return $this->postal_code;
     }
 
     /**
-     * @param mixed $postal_code
-     * @return Agent
+     * @param string|null $postal_code
+     * @return self
      */
-    public function setPostalCode($postal_code)
+    public function setPostalCode(?string $postal_code): self
     {
         $this->postal_code = $postal_code;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCity()
+    public function getCity(): ?string
     {
         return $this->city;
     }
 
     /**
-     * @param mixed $city
-     * @return Agent
+     * @param string|null $city
+     * @return self
      */
-    public function setCity($city)
+    public function setCity(?string $city): self
     {
         $this->city = $city;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCountry()
+    public function getCountry(): ?string
     {
         return $this->country;
     }
 
     /**
-     * @param mixed $country
-     * @return Agent
+     * @param string|null $country
+     * @return self
      */
-    public function setCountry($country)
+    public function setCountry(?string $country): self
     {
         $this->country = $country;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getSms()
+    public function getSms(): ?string
     {
         return $this->sms;
     }
 
     /**
-     * @param mixed $sms
-     * @return Agent
+     * @param string|null $sms
+     * @return self
      */
-    public function setSms($sms)
+    public function setSms(?string $sms): self
     {
         $this->sms = $sms;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
     /**
-     * @param mixed $email
-     * @return Agent
+     * @param string|null $email
+     * @return self
      */
-    public function setEmail($email)
+    public function setEmail(?string $email): self
     {
         $this->email = $email;
         return $this;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Item.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Item.php
@@ -6,15 +6,15 @@ namespace Smartsend\Models\Shipment;
 class Item implements \JsonSerializable
 {
     // Typed properties keep "= null" so get_object_vars() serialization is
-    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    // unchanged.
     private ?string $internal_id = null;
     private ?string $internal_reference = null;
-    private $sku;
-    private $name;
-    private $description;
-    private $hs_code;
-    private $country_of_origin;
-    private $image_url;
+    private ?string $sku = null;
+    private ?string $name = null;
+    private ?string $description = null;
+    private ?string $hs_code = null;
+    private ?string $country_of_origin = null;
+    private ?string $image_url = null;
     private ?float $unit_weight = null;
     private ?float $unit_price_excluding_tax = null;
     private ?float $unit_price_including_tax = null;
@@ -87,162 +87,162 @@ class Item implements \JsonSerializable
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalId()
+    public function getInternalId(): ?string
     {
         return $this->internal_id;
     }
 
     /**
      * @param string $internal_id
-     * @return Item
+     * @return self
      */
-    public function setInternalId($internal_id)
+    public function setInternalId($internal_id): self
     {
         $this->internal_id = (string) $internal_id;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalReference()
+    public function getInternalReference(): ?string
     {
         return $this->internal_reference;
     }
 
     /**
      * @param string $internal_reference
-     * @return Item
+     * @return self
      */
-    public function setInternalReference($internal_reference)
+    public function setInternalReference($internal_reference): self
     {
         $this->internal_reference = (string) $internal_reference;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getSku()
+    public function getSku(): ?string
     {
         return $this->sku;
     }
 
     /**
-     * @param mixed $sku
-     * @return Item
+     * @param string|null $sku
+     * @return self
      */
-    public function setSku($sku)
+    public function setSku(?string $sku): self
     {
         $this->sku = $sku;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
     /**
-     * @param mixed $name
-     * @return Item
+     * @param string|null $name
+     * @return self
      */
-    public function setName($name)
+    public function setName(?string $name): self
     {
         $this->name = $name;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
 
     /**
-     * @param mixed $description
-     * @return Item
+     * @param string|null $description
+     * @return self
      */
-    public function setDescription($description)
+    public function setDescription(?string $description): self
     {
         $this->description = $description;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getHsCode()
+    public function getHsCode(): ?string
     {
         return $this->hs_code;
     }
 
     /**
-     * @param mixed $hs_code
-     * @return Item
+     * @param string|null $hs_code
+     * @return self
      */
-    public function setHsCode($hs_code)
+    public function setHsCode(?string $hs_code): self
     {
         $this->hs_code = $hs_code;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCountryOfOrigin()
+    public function getCountryOfOrigin(): ?string
     {
         return $this->country_of_origin;
     }
 
     /**
-     * @param mixed $country_of_origin
-     * @return Item
+     * @param string|null $country_of_origin
+     * @return self
      */
-    public function setCountryOfOrigin($country_of_origin)
+    public function setCountryOfOrigin(?string $country_of_origin): self
     {
         $this->country_of_origin = $country_of_origin;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getImageUrl()
+    public function getImageUrl(): ?string
     {
         return $this->image_url;
     }
 
     /**
-     * @param mixed $image_url
-     * @return Item
+     * @param string|null $image_url
+     * @return self
      */
-    public function setImageUrl($image_url)
+    public function setImageUrl(?string $image_url): self
     {
         $this->image_url = $image_url;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getUnitWeight()
+    public function getUnitWeight(): ?float
     {
         return $this->unit_weight;
     }
 
     /**
      * @param mixed $unit_weight
-     * @return Item
+     * @return self
      */
-    public function setUnitWeight($unit_weight)
+    public function setUnitWeight($unit_weight): self
     {
 
         $this->unit_weight = is_null($unit_weight) ? null : ((float) $unit_weight);
@@ -250,108 +250,108 @@ class Item implements \JsonSerializable
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getUnitPriceExcludingTax()
+    public function getUnitPriceExcludingTax(): ?float
     {
         return $this->unit_price_excluding_tax;
     }
 
     /**
      * @param mixed $unit_price_excluding_tax
-     * @return Item
+     * @return self
      */
-    public function setUnitPriceExcludingTax($unit_price_excluding_tax)
+    public function setUnitPriceExcludingTax($unit_price_excluding_tax): self
     {
         $this->unit_price_excluding_tax = is_null($unit_price_excluding_tax) ? null : ((float) $unit_price_excluding_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getUnitPriceIncludingTax()
+    public function getUnitPriceIncludingTax(): ?float
     {
         return $this->unit_price_including_tax;
     }
 
     /**
      * @param mixed $unit_price_including_tax
-     * @return Item
+     * @return self
      */
-    public function setUnitPriceIncludingTax($unit_price_including_tax)
+    public function setUnitPriceIncludingTax($unit_price_including_tax): self
     {
         $this->unit_price_including_tax = is_null($unit_price_including_tax) ? null : ((float) $unit_price_including_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getQuantity()
+    public function getQuantity(): ?float
     {
         return $this->quantity;
     }
 
     /**
      * @param mixed $quantity
-     * @return Item
+     * @return self
      */
-    public function setQuantity($quantity)
+    public function setQuantity($quantity): self
     {
         $this->quantity = is_null($quantity) ? null : ((float) $quantity);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getTotalPriceExcludingTax()
+    public function getTotalPriceExcludingTax(): ?float
     {
         return $this->total_price_excluding_tax;
     }
 
     /**
      * @param mixed $total_price_excluding_tax
-     * @return Item
+     * @return self
      */
-    public function setTotalPriceExcludingTax($total_price_excluding_tax)
+    public function setTotalPriceExcludingTax($total_price_excluding_tax): self
     {
         $this->total_price_excluding_tax = is_null($total_price_excluding_tax) ? null : ((float) $total_price_excluding_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getTotalPriceIncludingTax()
+    public function getTotalPriceIncludingTax(): ?float
     {
         return $this->total_price_including_tax;
     }
 
     /**
      * @param mixed $total_price_including_tax;
-     * @return Item
+     * @return self
      */
-    public function setTotalPriceIncludingTax($total_price_including_tax)
+    public function setTotalPriceIncludingTax($total_price_including_tax): self
     {
         $this->total_price_including_tax = is_null($total_price_including_tax) ? null : ((float) $total_price_including_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getTotalTaxAmount()
+    public function getTotalTaxAmount(): ?float
     {
         return $this->total_tax_amount;
     }
 
     /**
      * @param mixed $total_tax_amount
-     * @return Item
+     * @return self
      */
-    public function setTotalTaxAmount($total_tax_amount)
+    public function setTotalTaxAmount($total_tax_amount): self
     {
         $this->total_tax_amount = is_null($total_tax_amount) ? null : ((float) $total_tax_amount);
         return $this;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Item.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Item.php
@@ -5,21 +5,23 @@ namespace Smartsend\Models\Shipment;
 
 class Item implements \JsonSerializable
 {
-    private $internal_id;
-    private $internal_reference;
+    // Typed properties keep "= null" so get_object_vars() serialization is
+    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    private ?string $internal_id = null;
+    private ?string $internal_reference = null;
     private $sku;
     private $name;
     private $description;
     private $hs_code;
     private $country_of_origin;
     private $image_url;
-    private $unit_weight;
-    private $unit_price_excluding_tax;
-    private $unit_price_including_tax;
-    private $quantity;
-    private $total_price_excluding_tax;
-    private $total_price_including_tax;
-    private $total_tax_amount;
+    private ?float $unit_weight = null;
+    private ?float $unit_price_excluding_tax = null;
+    private ?float $unit_price_including_tax = null;
+    private ?float $quantity = null;
+    private ?float $total_price_excluding_tax = null;
+    private ?float $total_price_including_tax = null;
+    private ?float $total_tax_amount = null;
 
     public function __construct($item=array())
     {

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Parcel.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Parcel.php
@@ -8,17 +8,19 @@ require_once 'Item.php';
 
 class Parcel implements \JsonSerializable
 {
-    private $internal_id;
-    private $internal_reference;
-    private $weight;
-    private $height;
-    private $width;
-    private $length;
+    // Typed properties keep "= null" so get_object_vars() serialization is
+    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    private ?string $internal_id = null;
+    private ?string $internal_reference = null;
+    private ?float $weight = null;
+    private ?float $height = null;
+    private ?float $width = null;
+    private ?float $length = null;
     private $freetext;
-    private $items;
-    private $total_price_excluding_tax;
-    private $total_price_including_tax;
-    private $total_tax_amount;
+    private ?array $items = null;
+    private ?float $total_price_excluding_tax = null;
+    private ?float $total_price_including_tax = null;
+    private ?float $total_tax_amount = null;
 
     public function __construct($parcel=array())
     {

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Parcel.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Parcel.php
@@ -9,14 +9,14 @@ require_once 'Item.php';
 class Parcel implements \JsonSerializable
 {
     // Typed properties keep "= null" so get_object_vars() serialization is
-    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    // unchanged.
     private ?string $internal_id = null;
     private ?string $internal_reference = null;
     private ?float $weight = null;
     private ?float $height = null;
     private ?float $width = null;
     private ?float $length = null;
-    private $freetext;
+    private ?string $freetext = null;
     private ?array $items = null;
     private ?float $total_price_excluding_tax = null;
     private ?float $total_price_including_tax = null;
@@ -74,144 +74,144 @@ class Parcel implements \JsonSerializable
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalId()
+    public function getInternalId(): ?string
     {
         return $this->internal_id;
     }
 
     /**
      * @param string $internal_id
-     * @return Parcel
+     * @return self
      */
-    public function setInternalId($internal_id)
+    public function setInternalId($internal_id): self
     {
         $this->internal_id = (string) $internal_id;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalReference()
+    public function getInternalReference(): ?string
     {
         return $this->internal_reference;
     }
 
     /**
      * @param string $internal_reference
-     * @return Parcel
+     * @return self
      */
-    public function setInternalReference($internal_reference)
+    public function setInternalReference($internal_reference): self
     {
         $this->internal_reference = (string) $internal_reference;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getWeight()
+    public function getWeight(): ?float
     {
         return $this->weight;
     }
 
     /**
      * @param mixed $weight
-     * @return Parcel
+     * @return self
      */
-    public function setWeight($weight)
+    public function setWeight($weight): self
     {
         $this->weight = is_null($weight) ? null : ((float) $weight);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getHeight()
+    public function getHeight(): ?float
     {
         return $this->height;
     }
 
     /**
      * @param mixed $height
-     * @return Parcel
+     * @return self
      */
-    public function setHeight($height)
+    public function setHeight($height): self
     {
         $this->height = is_null($height) ? null : ((float) $height);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getWidth()
+    public function getWidth(): ?float
     {
         return $this->width;
     }
 
     /**
      * @param mixed $width
-     * @return Parcel
+     * @return self
      */
-    public function setWidth($width)
+    public function setWidth($width): self
     {
         $this->width = is_null($width) ? null : ((float) $width);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getLength()
+    public function getLength(): ?float
     {
         return $this->length;
     }
 
     /**
      * @param mixed $length
-     * @return Parcel
+     * @return self
      */
-    public function setLength($length)
+    public function setLength($length): self
     {
         $this->length = is_null($length) ? null : ((float) $length);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getFreetext()
+    public function getFreetext(): ?string
     {
         return $this->freetext;
     }
 
     /**
-     * @param mixed $freetext
-     * @return Parcel
+     * @param string|null $freetext
+     * @return self
      */
-    public function setFreetext($freetext)
+    public function setFreetext(?string $freetext): self
     {
         $this->freetext = $freetext;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return Item[]|null
      */
-    public function getItems()
+    public function getItems(): ?array
     {
         return $this->items;
     }
 
     /**
-     * @param array $items
-     * @return Parcel
+     * @param Item[] $items
+     * @return self
      */
-    public function setItems(Array $items)
+    public function setItems(array $items): self
     {
         $this->items = $items;
         return $this;
@@ -219,9 +219,9 @@ class Parcel implements \JsonSerializable
 
     /**
      * @param Item $item
-     * @return Parcel
+     * @return self
      */
-    public function addItem(Item $item)
+    public function addItem(Item $item): self
     {
         if (is_array($this->items)) {
             $this->items[] = $item;
@@ -233,54 +233,54 @@ class Parcel implements \JsonSerializable
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getTotalPriceExcludingTax()
+    public function getTotalPriceExcludingTax(): ?float
     {
         return $this->total_price_excluding_tax;
     }
 
     /**
      * @param mixed $total_price_excluding_tax
-     * @return Parcel
+     * @return self
      */
-    public function setTotalPriceExcludingTax($total_price_excluding_tax)
+    public function setTotalPriceExcludingTax($total_price_excluding_tax): self
     {
         $this->total_price_excluding_tax = is_null($total_price_excluding_tax) ? null : ((float) $total_price_excluding_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getTotalPriceIncludingTax()
+    public function getTotalPriceIncludingTax(): ?float
     {
         return $this->total_price_including_tax;
     }
 
     /**
      * @param mixed $total_price_including_tax
-     * @return Parcel
+     * @return self
      */
-    public function setTotalPriceIncludingTax($total_price_including_tax)
+    public function setTotalPriceIncludingTax($total_price_including_tax): self
     {
         $this->total_price_including_tax = is_null($total_price_including_tax) ? null : ((float) $total_price_including_tax);
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return float|null
      */
-    public function getTotalTaxAmount()
+    public function getTotalTaxAmount(): ?float
     {
         return $this->total_tax_amount;
     }
 
     /**
      * @param mixed $total_tax_amount
-     * @return Parcel
+     * @return self
      */
-    public function setTotalTaxAmount($total_tax_amount)
+    public function setTotalTaxAmount($total_tax_amount): self
     {
         $this->total_tax_amount = is_null($total_tax_amount) ? null : ((float) $total_tax_amount);
         return $this;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Receiver.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Receiver.php
@@ -4,8 +4,10 @@ namespace Smartsend\Models\Shipment;
 
 class Receiver implements \JsonSerializable
 {
-    private $internal_id;
-    private $internal_reference;
+    // Typed properties keep "= null" so get_object_vars() serialization is
+    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    private ?string $internal_id = null;
+    private ?string $internal_reference = null;
     private $company;
     private $name_line1;
     private $name_line2;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Receiver.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Receiver.php
@@ -5,19 +5,19 @@ namespace Smartsend\Models\Shipment;
 class Receiver implements \JsonSerializable
 {
     // Typed properties keep "= null" so get_object_vars() serialization is
-    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    // unchanged.
     private ?string $internal_id = null;
     private ?string $internal_reference = null;
-    private $company;
-    private $name_line1;
-    private $name_line2;
-    private $address_line1;
-    private $address_line2;
-    private $postal_code;
-    private $city;
-    private $country;
-    private $sms;
-    private $email;
+    private ?string $company = null;
+    private ?string $name_line1 = null;
+    private ?string $name_line2 = null;
+    private ?string $address_line1 = null;
+    private ?string $address_line2 = null;
+    private ?string $postal_code = null;
+    private ?string $city = null;
+    private ?string $country = null;
+    private ?string $sms = null;
+    private ?string $email = null;
 
     public function __construct($receiver=array())
     {
@@ -71,216 +71,216 @@ class Receiver implements \JsonSerializable
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalId()
+    public function getInternalId(): ?string
     {
         return $this->internal_id;
     }
 
     /**
      * @param string $internal_id
-     * @return Receiver
+     * @return self
      */
-    public function setInternalId($internal_id)
+    public function setInternalId($internal_id): self
     {
         $this->internal_id = (string) $internal_id;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalReference()
+    public function getInternalReference(): ?string
     {
         return $this->internal_reference;
     }
 
     /**
      * @param string $internal_reference
-     * @return Receiver
+     * @return self
      */
-    public function setInternalReference($internal_reference)
+    public function setInternalReference($internal_reference): self
     {
         $this->internal_reference = (string) $internal_reference;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCompany()
+    public function getCompany(): ?string
     {
         return $this->company;
     }
 
     /**
-     * @param mixed $company
-     * @return Receiver
+     * @param string|null $company
+     * @return self
      */
-    public function setCompany($company)
+    public function setCompany(?string $company): self
     {
         $this->company = $company;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getNameLine1()
+    public function getNameLine1(): ?string
     {
         return $this->name_line1;
     }
 
     /**
-     * @param mixed $name_line1
-     * @return Receiver
+     * @param string|null $name_line1
+     * @return self
      */
-    public function setNameLine1($name_line1)
+    public function setNameLine1(?string $name_line1): self
     {
         $this->name_line1 = $name_line1;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getNameLine2()
+    public function getNameLine2(): ?string
     {
         return $this->name_line2;
     }
 
     /**
-     * @param mixed $name_line2
-     * @return Receiver
+     * @param string|null $name_line2
+     * @return self
      */
-    public function setNameLine2($name_line2)
+    public function setNameLine2(?string $name_line2): self
     {
         $this->name_line2 = $name_line2;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAddressLine1()
+    public function getAddressLine1(): ?string
     {
         return $this->address_line1;
     }
 
     /**
-     * @param mixed $address_line1
-     * @return Receiver
+     * @param string|null $address_line1
+     * @return self
      */
-    public function setAddressLine1($address_line1)
+    public function setAddressLine1(?string $address_line1): self
     {
         $this->address_line1 = $address_line1;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAddressLine2()
+    public function getAddressLine2(): ?string
     {
         return $this->address_line2;
     }
 
     /**
-     * @param mixed $address_line2
-     * @return Receiver
+     * @param string|null $address_line2
+     * @return self
      */
-    public function setAddressLine2($address_line2)
+    public function setAddressLine2(?string $address_line2): self
     {
         $this->address_line2 = $address_line2;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getPostalCode()
+    public function getPostalCode(): ?string
     {
         return $this->postal_code;
     }
 
     /**
-     * @param mixed $postal_code
-     * @return Receiver
+     * @param string|null $postal_code
+     * @return self
      */
-    public function setPostalCode($postal_code)
+    public function setPostalCode(?string $postal_code): self
     {
         $this->postal_code = $postal_code;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCity()
+    public function getCity(): ?string
     {
         return $this->city;
     }
 
     /**
-     * @param mixed $city
-     * @return Receiver
+     * @param string|null $city
+     * @return self
      */
-    public function setCity($city)
+    public function setCity(?string $city): self
     {
         $this->city = $city;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCountry()
+    public function getCountry(): ?string
     {
         return $this->country;
     }
 
     /**
-     * @param mixed $country
-     * @return Receiver
+     * @param string|null $country
+     * @return self
      */
-    public function setCountry($country)
+    public function setCountry(?string $country): self
     {
         $this->country = $country;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getSms()
+    public function getSms(): ?string
     {
         return $this->sms;
     }
 
     /**
-     * @param mixed $sms
-     * @return Receiver
+     * @param string|null $sms
+     * @return self
      */
-    public function setSms($sms)
+    public function setSms(?string $sms): self
     {
         $this->sms = $sms;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
     /**
-     * @param mixed $email
-     * @return Receiver
+     * @param string|null $email
+     * @return self
      */
-    public function setEmail($email)
+    public function setEmail(?string $email): self
     {
         $this->email = $email;
         return $this;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Sender.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Sender.php
@@ -5,8 +5,10 @@ namespace Smartsend\Models\Shipment;
 
 class Sender implements \JsonSerializable
 {
-    private $internal_id;
-    private $internal_reference;
+    // Typed properties keep "= null" so get_object_vars() serialization is
+    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    private ?string $internal_id = null;
+    private ?string $internal_reference = null;
     private $company;
     private $name_line1;
     private $name_line2;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Sender.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Sender.php
@@ -6,19 +6,19 @@ namespace Smartsend\Models\Shipment;
 class Sender implements \JsonSerializable
 {
     // Typed properties keep "= null" so get_object_vars() serialization is
-    // unchanged; uncast public setters stay untyped (see Models/Shipment.php).
+    // unchanged.
     private ?string $internal_id = null;
     private ?string $internal_reference = null;
-    private $company;
-    private $name_line1;
-    private $name_line2;
-    private $address_line1;
-    private $address_line2;
-    private $postal_code;
-    private $city;
-    private $country;
-    private $sms;
-    private $email;
+    private ?string $company = null;
+    private ?string $name_line1 = null;
+    private ?string $name_line2 = null;
+    private ?string $address_line1 = null;
+    private ?string $address_line2 = null;
+    private ?string $postal_code = null;
+    private ?string $city = null;
+    private ?string $country = null;
+    private ?string $sms = null;
+    private ?string $email = null;
 
     public function __construct($receiver=array())
     {
@@ -72,216 +72,216 @@ class Sender implements \JsonSerializable
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalId()
+    public function getInternalId(): ?string
     {
         return $this->internal_id;
     }
 
     /**
      * @param string $internal_id
-     * @return Sender
+     * @return self
      */
-    public function setInternalId($internal_id)
+    public function setInternalId($internal_id): self
     {
         $this->internal_id = (string) $internal_id;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getInternalReference()
+    public function getInternalReference(): ?string
     {
         return $this->internal_reference;
     }
 
     /**
      * @param string $internal_reference
-     * @return Sender
+     * @return self
      */
-    public function setInternalReference($internal_reference)
+    public function setInternalReference($internal_reference): self
     {
         $this->internal_reference = (string) $internal_reference;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCompany()
+    public function getCompany(): ?string
     {
         return $this->company;
     }
 
     /**
-     * @param mixed $company
-     * @return Sender
+     * @param string|null $company
+     * @return self
      */
-    public function setCompany($company)
+    public function setCompany(?string $company): self
     {
         $this->company = $company;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getName1()
+    public function getName1(): ?string
     {
         return $this->name_line1;
     }
 
     /**
-     * @param mixed $name_line1
-     * @return Sender
+     * @param string|null $name_line1
+     * @return self
      */
-    public function setName1($name_line1)
+    public function setName1(?string $name_line1): self
     {
         $this->name_line1 = $name_line1;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getName2()
+    public function getName2(): ?string
     {
         return $this->name_line2;
     }
 
     /**
-     * @param mixed $name_line2
-     * @return Sender
+     * @param string|null $name_line2
+     * @return self
      */
-    public function setName2($name_line2)
+    public function setName2(?string $name_line2): self
     {
         $this->name_line2 = $name_line2;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAddressLine1()
+    public function getAddressLine1(): ?string
     {
         return $this->address_line1;
     }
 
     /**
-     * @param mixed $address_line1
-     * @return Sender
+     * @param string|null $address_line1
+     * @return self
      */
-    public function setAddressLine1($address_line1)
+    public function setAddressLine1(?string $address_line1): self
     {
         $this->address_line1 = $address_line1;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getAddressLine2()
+    public function getAddressLine2(): ?string
     {
         return $this->address_line2;
     }
 
     /**
-     * @param mixed $address_line2
-     * @return Sender
+     * @param string|null $address_line2
+     * @return self
      */
-    public function setAddressLine2($address_line2)
+    public function setAddressLine2(?string $address_line2): self
     {
         $this->address_line2 = $address_line2;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getPostalCode()
+    public function getPostalCode(): ?string
     {
         return $this->postal_code;
     }
 
     /**
-     * @param mixed $postal_code
-     * @return Sender
+     * @param string|null $postal_code
+     * @return self
      */
-    public function setPostalCode($postal_code)
+    public function setPostalCode(?string $postal_code): self
     {
         $this->postal_code = $postal_code;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCity()
+    public function getCity(): ?string
     {
         return $this->city;
     }
 
     /**
-     * @param mixed $city
-     * @return Sender
+     * @param string|null $city
+     * @return self
      */
-    public function setCity($city)
+    public function setCity(?string $city): self
     {
         $this->city = $city;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getCountry()
+    public function getCountry(): ?string
     {
         return $this->country;
     }
 
     /**
-     * @param mixed $country
-     * @return Sender
+     * @param string|null $country
+     * @return self
      */
-    public function setCountry($country)
+    public function setCountry(?string $country): self
     {
         $this->country = $country;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getSms()
+    public function getSms(): ?string
     {
         return $this->sms;
     }
 
     /**
-     * @param mixed $sms
-     * @return Sender
+     * @param string|null $sms
+     * @return self
      */
-    public function setSms($sms)
+    public function setSms(?string $sms): self
     {
         $this->sms = $sms;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
     /**
-     * @param mixed $email
-     * @return Sender
+     * @param string|null $email
+     * @return self
      */
-    public function setEmail($email)
+    public function setEmail(?string $email): self
     {
         $this->email = $email;
         return $this;

--- a/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Services.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Models/Shipment/Services.php
@@ -4,8 +4,13 @@ namespace Smartsend\Models\Shipment;
 
 class Services  implements \JsonSerializable
 {
-    private $email_notification;
-    private $sms_notification;
+    private ?string $email_notification = null;
+    private ?string $sms_notification = null;
+    // Untyped: never assigned anywhere in the plugin (always null in the
+    // payload golden tests) or by any test, so the real API contract for
+    // this field (bool flag vs. a delivery-window string) can't be
+    // confirmed from usage. Guessing a scalar type risks silently coercing
+    // a shape the API doesn't expect.
     private $flex_delivery;
 
     public function __construct(Array $services=array())
@@ -24,36 +29,36 @@ class Services  implements \JsonSerializable
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getEmailNotification()
+    public function getEmailNotification(): ?string
     {
         return $this->email_notification;
     }
 
     /**
-     * @param mixed $email_notification
-     * @return Services
+     * @param string|null $email_notification
+     * @return self
      */
-    public function setEmailNotification($email_notification)
+    public function setEmailNotification(?string $email_notification): self
     {
         $this->email_notification = $email_notification;
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
-    public function getSmsNotification()
+    public function getSmsNotification(): ?string
     {
         return $this->sms_notification;
     }
 
     /**
-     * @param mixed $sms_notification
-     * @return Services
+     * @param string|null $sms_notification
+     * @return self
      */
-    public function setSmsNotification($sms_notification)
+    public function setSmsNotification(?string $sms_notification): self
     {
         $this->sms_notification = $sms_notification;
         return $this;
@@ -69,9 +74,9 @@ class Services  implements \JsonSerializable
 
     /**
      * @param mixed $flex_delivery
-     * @return Services
+     * @return self
      */
-    public function setFlexDelivery($flex_delivery)
+    public function setFlexDelivery($flex_delivery): self
     {
         $this->flex_delivery = $flex_delivery;
         return $this;

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -49,22 +49,28 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 		/**
 		 * Smart Send Shipping Order for label and tracking.
 		 *
-		 * Public and deliberately untyped: merchant code snippets access it via
-		 * SS_SHIPPING_WC() and typing it would be a BC break for loose assignment.
+		 * Public: reachable via SS_SHIPPING_WC() from merchant code snippets.
+		 * It is only ever assigned the real SS_Shipping_WC_Order instance in
+		 * the constructor below, so typing it is a deliberate v9 breaking
+		 * change - a snippet that replaces it with something else now fatals
+		 * instead of silently corrupting state.
 		 *
 		 * @var SS_Shipping_WC_Order|null
 		 */
-		public $ss_shipping_wc_order = null;
+		public ?SS_Shipping_WC_Order $ss_shipping_wc_order = null;
 
 		/**
 		 * Smart Send Shipping Product
 		 *
-		 * Public and deliberately untyped: merchant code snippets access it via
-		 * SS_SHIPPING_WC() and typing it would be a BC break for loose assignment.
+		 * Public: reachable via SS_SHIPPING_WC() from merchant code snippets.
+		 * It is only ever assigned the real SS_Shipping_WC_Product instance
+		 * in the constructor below, so typing it is a deliberate v9 breaking
+		 * change - a snippet that replaces it with something else now fatals
+		 * instead of silently corrupting state.
 		 *
 		 * @var SS_Shipping_WC_Product|null
 		 */
-		public $ss_shipping_wc_product = null;
+		public ?SS_Shipping_WC_Product $ss_shipping_wc_product = null;
 
 		/**
 		 * Smart Send Frontend

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -37,55 +37,62 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
     class SS_Shipping_WC
     {
 
-		private $version = '8.2.0';
+		private string $version = '8.2.0';
 
-        /**
-         * Instance to call certain functions globally within the plugin
-         *
-         * @var SS_Shipping_WC
-         */
-        protected static $_instance = null;
+		/**
+		 * Instance to call certain functions globally within the plugin
+		 *
+		 * @var SS_Shipping_WC|null
+		 */
+		protected static ?SS_Shipping_WC $_instance = null; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore -- pre-existing name, renaming is out of scope here.
 
-        /**
-         * Smart Send Shipping Order for label and tracking.
-         *
-         * @var SS_Shipping_WC_Order
-         */
-        public $ss_shipping_wc_order = null;
-        /**
-         * Smart Send Shipping Product
-         *
-         * @var SS_Shipping_WC_Order
-         */
-        public $ss_shipping_wc_product = null;
+		/**
+		 * Smart Send Shipping Order for label and tracking.
+		 *
+		 * Public and deliberately untyped: merchant code snippets access it via
+		 * SS_SHIPPING_WC() and typing it would be a BC break for loose assignment.
+		 *
+		 * @var SS_Shipping_WC_Order|null
+		 */
+		public $ss_shipping_wc_order = null;
 
-        /**
-         * Smart Send Frontend
-         *
-         * @var SS_Shipping_Frontend
-         */
-        protected $ss_shipping_frontend = null;
+		/**
+		 * Smart Send Shipping Product
+		 *
+		 * Public and deliberately untyped: merchant code snippets access it via
+		 * SS_SHIPPING_WC() and typing it would be a BC break for loose assignment.
+		 *
+		 * @var SS_Shipping_WC_Product|null
+		 */
+		public $ss_shipping_wc_product = null;
 
-        /**
-         * Smart Send agent address formats
-         *
-         * @var array
-         */
-        protected $agents_address_format = array();
+		/**
+		 * Smart Send Frontend
+		 *
+		 * @var SS_Shipping_Frontend|null
+		 */
+		protected ?SS_Shipping_Frontend $ss_shipping_frontend = null;
 
-        /**
-         * Smart Send api handle
-         *
-         * @var object
-         */
-        protected $api_handle = null;
+		/**
+		 * Smart Send agent address formats
+		 *
+		 * @var array
+		 */
+		protected array $agents_address_format = array();
 
-        /**
-         * Smart Send Plugin Screen Updates
-         *
-         * @var object
-         */
-        protected $ss_plugin_screen_updates = null;
+		/**
+		 * Smart Send api handle
+		 *
+		 * @var \Smartsend\Api|null
+		 */
+		protected ?\Smartsend\Api $api_handle = null;
+
+		/**
+		 * Smart Send Plugin Screen Updates
+		 *
+		 * @var SS_Plugins_Screen_Updates|null
+		 */
+		protected ?SS_Plugins_Screen_Updates $ss_plugin_screen_updates = null;
 
         /**
          * Construct the plugin.


### PR DESCRIPTION
Implements #91: every property assigned on `$this` across `smart-send-logistics/` now has an explicit declaration, typed under the PHP 7.4 floor where the assignment sites guarantee the type. On top of that, since v9 is a new major and breaking a loosely-typed public setter is acceptable, the `Smartsend\Models\*` setters/getters, `Smartsend\Client`'s accessors, and two plugin-class public properties now carry parameter type hints and return type declarations too — only a handful of hard, PHP-language-level constraints remain untyped. Zero behaviour change — the integration suite (incl. the payload golden tests, untouched) is green under the strict deprecation handler on PHP 8.5, so no dynamic-property deprecations remain, and no golden-test payload had to change because every call site already produced the type the new hints require.

> Stacked PR: targets `chore/issue-90-existence-guards` (#98), which targets `feature/issue-72-order-data-utility` (#97). Merge in stack order.

## Newly declared (was a dynamic property)

- `SS_Plugins_Screen_Updates::$new_version` — the only true dynamic property left in the codebase; declared `protected ?string $new_version = null;`

## Property counts (commit 1: property declarations)

| Category | Count |
|---|---|
| Typed | 46 properties across 15 classes |
| Declared-untyped with documented reason | ~45 |
| Parent-owned, deliberately not re-declared | 9 (`SS_Shipping_WC_Method`, owned by `WC_Shipping_Flat_Rate` chain: `$id`, `$instance_id`, `$method_title`, `$method_description`, `$supports`, `$title`, `$tax_status`, `$form_fields`, `$instance_form_fields`) |

## Setter/getter counts (commit 2: method signatures)

| File group | Setters param-hinted | Getters return-hinted |
|---|---|---|
| `Models/Shipment.php` | 15 | 15 |
| `Models/Shipment/Sender.php` | 12 | 12 |
| `Models/Shipment/Receiver.php` | 12 | 12 |
| `Models/Shipment/Agent.php` | 13 | 13 |
| `Models/Shipment/Item.php` | 14 | 14 |
| `Models/Shipment/Parcel.php` | 11 | 11 |
| `Models/Shipment/Services.php` | 2 of 3 (`flex_delivery` stays untyped, see below) | 2 of 3 |
| `Models/Agent.php` (top-level pickup-point model) | 11 | 11 |
| `Models/Agent/Coordinates.php` | 2 | 2 |
| `Models/Agent/OpeningHour.php` | 3 | 3 |
| `Models/Error.php` | 5 (only `setMessage` gained a real type; the other 4 stay `mixed`-in/`mixed`-out, see below) | 1 of 5 typed |
| `Smartsend\Client` accessors | `setApiToken`, `setWebsite`, `setDemo`, `setRequestLogger` | `getWebsite`, `getApiToken` (private), `getDemo`, `getError`, `getRequestEndpoint`, `getRequestHeaders`, `getResponseBody`, `isSuccessful` |
| Plugin classes | — | `SS_Shipping_WC::$ss_shipping_wc_order`, `$ss_shipping_wc_product` (public properties, not accessor methods — see below) |

All fluent setters (everything except `Client::setApiToken/setWebsite/setDemo/setRequestLogger`, which were never fluent) now declare `: self`.

## Remaining untyped exceptions (shrunk from the previous list)

Only kept where a hard constraint remains — either PHP 7.4's lack of union types for a genuinely mixed-shape value, or an explicit instruction to preserve a documented test/runtime dependency:

| Property/parameter | Reason |
|---|---|
| `SS_Shipping_Logger::$logger` | Public static; integration tests inject an anonymous-class spy relying on `__call`, which does not implement `WC_Logger_Interface` — typing would break the spies (kept per explicit instruction) |
| `SS_Shipping_Shipment::$order` | `wc_get_order()` returns `WC_Order\|WC_Order_Refund\|false`; the constructor relies on the falsy value (kept per explicit instruction) |
| `SS_Plugins_Screen_Updates::$upgrade_notice` | `get_upgrade_notice()` returns `false` when the transient is empty and the readme fetch fails; not a public accessor so out of scope for this pass anyway |
| `Smartsend\Client::$api_host` | Assigned from the `smart_send_api_endpoint` filter — third-party return value, no fixed contract |
| `Smartsend\Client::$request_body` | `json_encode()` can return `false` on encoding failure — `string\|false\|null`, no union types in PHP 7.4 |
| `Smartsend\Client::$response_headers` | `wp_remote_retrieve_headers()` returns `array\|CaseInsensitiveDictionary` |
| `Smartsend\Client::$http_status_code` | `wp_remote_retrieve_response_code()` returns `int\|string` (`''` on transport failure) |
| `Smartsend\Client::$content_type` | `wp_remote_retrieve_header()` returns `string\|array` (array for duplicate headers) |
| `Smartsend\Client::$debug` | Holds the raw `wp_remote_request()` result: `array\|WP_Error` |
| `Smartsend\Client::$meta` | Never assigned anything but `null`, and no getter reads it — real contract unconfirmed, left alone rather than guessed |
| `Smartsend\Client::$data`, `$links` | Decoded-JSON API response fields of genuinely variable shape (object/array/scalar depending on endpoint) |
| `Smartsend\Client::$request_logger` (property) | PHP has no `callable` property type (still true in the latest PHP) — the **parameter** on `setRequestLogger()` is hinted `?callable` even though the backing property can't be |
| `Smartsend\Models\Shipment\Services::$flex_delivery` | Never assigned anywhere in the plugin or exercised by any test (always `null` in the golden payloads) — no observed usage to confirm whether the API contract is a bool flag or something else; typing it would be a guess |
| `Smartsend\Models\Error::$links` | Read as an object (`$error->links->about`) but could be an array depending on API response shape — `object\|array\|null`, no union types |
| `Smartsend\Models\Error::$id` | API error id can be string or int; no union types |
| `Smartsend\Models\Error::$code` | Proven to vary in shape — `SS_Shipping_Logger` and `SS_Shipping_Frontend` both guard it with `is_scalar()` before casting to string, so a scalar type would be actively wrong for real inputs |
| `Smartsend\Models\Error::$errors` | Either the internal `array()` default or a decoded-JSON value from the API (object or array) — iterated with `foreach` either way |

`Smartsend\Models\Error::$message` **is now typed** `?string` — every call site (internal `createError()` and the API's `message` field) produces a string, matching the field's contract as human-readable error text.

## Payload/type changes

None. Every call site already passed a value of the type the new hints require (strings for string fields, ints/floats coerced to float for money/weight/quantity fields already cast internally). The payload golden tests in `tests/Integration/ShipmentPayloadTest.php` needed **no changes** — verified by running the full suite both before and after this commit.

## Breaking changes (v9)

- Every `Smartsend\Models\*` public setter that now has a parameter type hint will **coerce** loosely-typed scalar input (e.g. an `int` postal code becomes `"123"`) or **fatal with a `TypeError`** on incompatible input (e.g. passing an array where a string is expected) — previously it silently accepted anything.
- `SS_Shipping_WC::$ss_shipping_wc_order` and `$ss_shipping_wc_product` are now typed public properties (`?SS_Shipping_WC_Order` / `?SS_Shipping_WC_Product`); a merchant snippet that reassigns them to something else will now fatal instead of silently corrupting plugin state.
- Merchant snippets hooking `smart_send_payload_receiver`, `smart_send_payload_items`, `smart_send_payload_totals`, `smart_send_payload_parcels`, `smart_send_receiver_phone`, or `smart_send_shipping_label_args` and returning a loosely-typed value (e.g. an `int` where a model setter now expects `?string`) will have that value coerced or, if it returns an incompatible shape (array/object for a scalar field), the request will fatal instead of silently sending malformed data to the API.

## Verification

- `composer test:integration`: **137 passed (532 assertions)** on PHP 8.5 under the strict deprecation handler — zero dynamic-property deprecations from plugin code; payload golden tests untouched and green, both before and after the setter/getter typing commit
- `vendor/bin/phpcs`: clean (0 errors, 0 warnings); `phpcs.baseline.xml` not modified
- `composer phpcs:compat`: clean (PHP 7.4 floor — nullable types (`?T`) and `self` return types only; no union types, no `readonly`, no constructor property promotion)

## Notes for the stack (#100, #101, #102)

- Anything constructing `Smartsend\Models\*` objects directly in tests (rather than through the plugin's builder methods) must now pass compatible scalar types to setters — e.g. `setAgentNo('1234')` not `setAgentNo(1234)` will still work (int coerces to string), but `setAgentNo([...])` will now fatal.
- `SS_Shipping_WC::$ss_shipping_wc_order` / `$ss_shipping_wc_product` can no longer be reassigned to a test double of an unrelated type; use the real classes or don't touch the properties.
- `Smartsend\Client::setRequestLogger()` now requires `?callable` — passing a non-callable (other than `null`) will fatal.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
