### PR TITLE
Refactor string building: sprintf templates and full i18n coverage

### DIFF
--- a/smart-send-logistics/includes/class-ss-shipping-logger.php
+++ b/smart-send-logistics/includes/class-ss-shipping-logger.php
@@ -175,9 +175,12 @@ class SS_Shipping_Logger {
 		$endpoint = self::redact_endpoint( isset( $context['endpoint'] ) ? $context['endpoint'] : '' );
 		$path     = wp_parse_url( $endpoint, PHP_URL_PATH );
 
-		$message = ( isset( $context['method'] ) ? $context['method'] : '' )
-			. ' ' . ( $path ? $path : $endpoint )
-			. ' → ' . $status_code;
+		$message = sprintf(
+			'%1$s %2$s → %3$s',
+			isset( $context['method'] ) ? $context['method'] : '',
+			$path ? $path : $endpoint,
+			$status_code
+		);
 
 		$log_context = array(
 			'endpoint'    => $endpoint,
@@ -186,7 +189,7 @@ class SS_Shipping_Logger {
 
 		if ( isset( $context['start_time'], $context['end_time'] ) && is_numeric( $context['start_time'] ) && is_numeric( $context['end_time'] ) ) {
 			$duration_ms                = (int) round( abs( $context['end_time'] - $context['start_time'] ) * 1000 );
-			$message                   .= ' (' . $duration_ms . 'ms)';
+			$message                    = sprintf( '%1$s (%2$dms)', $message, $duration_ms );
 			$log_context['duration_ms'] = $duration_ms;
 		}
 

--- a/smart-send-logistics/includes/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-method.php
@@ -368,11 +368,11 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
                     'desc_tip' => true,
                     'options'  => $agents_address_format,
                 ),
-                'default_select_agent'              => array(
-                    'title'       => __('Select Default', 'smart-send-logistics'),
-                    'label'       => __('Enable Select Default', 'smart-send-logistics'),
-                    'description' => __('This will automatically select the closest pick-up point and let the customer change to a different pick-up point. This means that the customer will not be forced to select a pick-up point before completing the order.'),
-                    'default'     => 'no',
+				'default_select_agent'              => array(
+					'title'       => __( 'Select Default', 'smart-send-logistics' ),
+					'label'       => __( 'Enable Select Default', 'smart-send-logistics' ),
+					'description' => __( 'This will automatically select the closest pick-up point and let the customer change to a different pick-up point. This means that the customer will not be forced to select a pick-up point before completing the order.', 'smart-send-logistics' ),
+					'default'     => 'no',
                     'type'        => 'checkbox',
                     'desc_tip'    => true,
                 ),
@@ -975,14 +975,22 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 
 			// Log-file developer trace: the rate matched the zone, cost calculation starts.
 			SS_Shipping_Logger::debug(
-				'Calculating shipping cost for shipping rate ' . $rate['id'],
+				sprintf( 'Calculating shipping cost for shipping rate %s', $rate['id'] ),
 				array(
 					'rate_id' => $rate['id'],
 					'label'   => $rate['label'],
 					'method'  => $rate['meta_data']['smart_send_shipping_method'],
 				)
 			);
-			SS_Shipping_Checkout_Debug::add_notice( 'Smart Send: evaluated method "' . $rate['label'] . '" (' . $rate['meta_data']['smart_send_shipping_method'] . ', rate id ' . $rate['id'] . ').' );
+			SS_Shipping_Checkout_Debug::add_notice(
+				sprintf(
+					/* translators: 1: shipping rate label, 2: Smart Send shipping method code, 3: shipping rate id. */
+					__( 'Smart Send: evaluated method "%1$s" (%2$s, rate id %3$s).', 'smart-send-logistics' ),
+					$rate['label'],
+					$rate['meta_data']['smart_send_shipping_method'],
+					$rate['id']
+				)
+			);
 
             // Set tax status based on selection otherwise always taxed
             $this->tax_status = $this->get_option('tax_status');
@@ -992,15 +1000,21 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 
 				$rate['cost'] = $this->get_option( 'flatfee_cost' );
 				$this->add_rate( $rate );
-				$debug_message = 'Smart Send "' . $rate['label'] . '": free shipping applies - rate added with flat fee cost ' . $rate['cost'] . '.';
 				SS_Shipping_Logger::debug(
-					$debug_message,
+					sprintf( 'Smart Send "%1$s": free shipping applies - rate added with flat fee cost %2$s.', $rate['label'], $rate['cost'] ),
 					array(
 						'rate_id' => $rate['id'],
 						'cost'    => $rate['cost'],
 					)
 				);
-				SS_Shipping_Checkout_Debug::add_notice( $debug_message );
+				SS_Shipping_Checkout_Debug::add_notice(
+					sprintf(
+						/* translators: 1: shipping rate label, 2: flat fee cost. */
+						__( 'Smart Send "%1$s": free shipping applies - rate added with flat fee cost %2$s.', 'smart-send-logistics' ),
+						$rate['label'],
+						$rate['cost']
+					)
+				);
 
             } else {
                 $cart_weight = WC()->cart->get_cart_contents_weight();
@@ -1027,17 +1041,34 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 
 									$this->add_rate( $rate );
 									$rate_added     = true;
-									$matched_rows[] = $weight_cost['ss_min_weight'] . '-' . $weight_cost['ss_max_weight'] . ' ' . $weight_unit;
-									$debug_message  = 'Smart Send "' . $rate['label'] . '": cart weight ' . $cart_weight . ' ' . $weight_unit . ' matched weight table row ' . $weight_cost['ss_min_weight'] . '-' . $weight_cost['ss_max_weight'] . ' ' . $weight_unit . ' - rate added with cost ' . $rate['cost'] . '.';
+									$matched_row    = sprintf( '%1$s-%2$s %3$s', $weight_cost['ss_min_weight'], $weight_cost['ss_max_weight'], $weight_unit );
+									$matched_rows[] = $matched_row;
 									SS_Shipping_Logger::debug(
-										$debug_message,
+										sprintf(
+											'Smart Send "%1$s": cart weight %2$s %3$s matched weight table row %4$s - rate added with cost %5$s.',
+											$rate['label'],
+											$cart_weight,
+											$weight_unit,
+											$matched_row,
+											$rate['cost']
+										),
 										array(
 											'rate_id'     => $rate['id'],
 											'cost'        => $rate['cost'],
 											'cart_weight' => $cart_weight,
 										)
 									);
-									SS_Shipping_Checkout_Debug::add_notice( $debug_message );
+									SS_Shipping_Checkout_Debug::add_notice(
+										sprintf(
+											/* translators: 1: shipping rate label, 2: cart weight, 3: weight unit, 4: matched weight table row as "min-max unit", 5: rate cost. */
+											__( 'Smart Send "%1$s": cart weight %2$s %3$s matched weight table row %4$s - rate added with cost %5$s.', 'smart-send-logistics' ),
+											$rate['label'],
+											$cart_weight,
+											$weight_unit,
+											$matched_row,
+											$rate['cost']
+										)
+									);
 								}
                             }
                         }
@@ -1045,23 +1076,58 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
                 }
 
 				if ( count( $matched_rows ) > 1 ) {
-					$last_row      = $matched_rows[ count( $matched_rows ) - 1 ];
-					$debug_message = 'Smart Send "' . $rate['label'] . '": ' . count( $matched_rows ) . ' overlapping weight table rows matched (' . implode( ', ', $matched_rows ) . ') - the rows share rate id ' . $rate['id'] . ', so only the LAST matching row (' . $last_row . ') is offered and the earlier matches were overwritten.';
-					SS_Shipping_Logger::debug( $debug_message );
-					SS_Shipping_Checkout_Debug::add_notice( $debug_message );
+					$last_row = $matched_rows[ count( $matched_rows ) - 1 ];
+					SS_Shipping_Logger::debug(
+						sprintf(
+							'Smart Send "%1$s": %2$d overlapping weight table rows matched (%3$s) - the rows share rate id %4$s, so only the LAST matching row (%5$s) is offered and the earlier matches were overwritten.',
+							$rate['label'],
+							count( $matched_rows ),
+							implode( ', ', $matched_rows ),
+							$rate['id'],
+							$last_row
+						),
+						array(
+							'rate_id'      => $rate['id'],
+							'matched_rows' => $matched_rows,
+						)
+					);
+					SS_Shipping_Checkout_Debug::add_notice(
+						sprintf(
+							/* translators: 1: shipping rate label, 2: number of matched weight table rows, 3: list of matched rows, 4: shipping rate id, 5: last matched row. */
+							__( 'Smart Send "%1$s": %2$d overlapping weight table rows matched (%3$s) - the rows share rate id %4$s, so only the LAST matching row (%5$s) is offered and the earlier matches were overwritten.', 'smart-send-logistics' ),
+							$rate['label'],
+							count( $matched_rows ),
+							implode( ', ', $matched_rows ),
+							$rate['id'],
+							$last_row
+						)
+					);
 				}
 
 				if ( ! $rate_added ) {
-					$debug_message = 'Smart Send "' . $rate['label'] . '": no rate added - cart weight ' . $cart_weight . ' ' . $weight_unit . ' did not match any weight table row.';
-					SS_Shipping_Logger::debug( $debug_message );
-					SS_Shipping_Checkout_Debug::add_notice( $debug_message );
+					SS_Shipping_Logger::debug(
+						sprintf( 'Smart Send "%1$s": no rate added - cart weight %2$s %3$s did not match any weight table row.', $rate['label'], $cart_weight, $weight_unit ),
+						array(
+							'rate_id'     => $rate['id'],
+							'cart_weight' => $cart_weight,
+						)
+					);
+					SS_Shipping_Checkout_Debug::add_notice(
+						sprintf(
+							/* translators: 1: shipping rate label, 2: cart weight, 3: weight unit. */
+							__( 'Smart Send "%1$s": no rate added - cart weight %2$s %3$s did not match any weight table row.', 'smart-send-logistics' ),
+							$rate['label'],
+							$cart_weight,
+							$weight_unit
+						)
+					);
 				}
             }
 
 			// Log-file developer trace: the outcome of the cost calculation.
 			if ( isset( $this->rates[ $rate['id'] ] ) ) {
 				SS_Shipping_Logger::debug(
-					'Calculated shipping cost for shipping rate ' . $rate['id'] . ': ' . $this->rates[ $rate['id'] ]->get_cost(),
+					sprintf( 'Calculated shipping cost for shipping rate %1$s: %2$s', $rate['id'], $this->rates[ $rate['id'] ]->get_cost() ),
 					array(
 						'rate_id' => $rate['id'],
 						'cost'    => $this->rates[ $rate['id'] ]->get_cost(),
@@ -1069,7 +1135,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 				);
 			} else {
 				SS_Shipping_Logger::debug(
-					'Shipping rate ' . $rate['id'] . ' is not available for this package - no rate added',
+					sprintf( 'Shipping rate %s is not available for this package - no rate added', $rate['id'] ),
 					array( 'rate_id' => $rate['id'] )
 				);
 			}
@@ -1122,38 +1188,22 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 
                     $display_shipping_class_opt = $this->get_instance_option('display_shipping_class_opt');
 
-                    switch ($display_shipping_class_opt) {
-                        case 'all_shipping_class' :
-                            $is_available = $all_in_array;
-
-                            $class_log_message = ', because ALL products belong to one of the shipping classes';
-                            break;
-                        case 'one_shipping_class' :
-                            $is_available = $one_in_array;
-
-                            $class_log_message = ', because at least ONE product belongs to one of the shipping classes';
-                            break;
-                        case 'nall_shipping_class' :
-                            $is_available = !$one_in_array;
-
-                            $class_log_message = ', because ALL products do NOT belong to one of the shipping classes';
-                            break;
-                        case 'none_shipping_class' :
-                            $is_available = !$all_in_array;
-
-                            $class_log_message = ', because at least ONE product does NOT belongs to one of the shipping classes';
-                            break;
-                    }
-                }
-
-				if ( ! empty( $class_log_message ) ) {
-					if ( $is_available ) {
-						$debug_message = 'Smart Send "' . $this->title . '": shipping method IS available' . $class_log_message;
-					} else {
-						$debug_message = 'Smart Send "' . $this->title . '": shipping method is NOT available' . $class_log_message;
+					switch ( $display_shipping_class_opt ) {
+						case 'all_shipping_class':
+							$is_available = $all_in_array;
+							break;
+						case 'one_shipping_class':
+							$is_available = $one_in_array;
+							break;
+						case 'nall_shipping_class':
+							$is_available = ! $one_in_array;
+							break;
+						case 'none_shipping_class':
+							$is_available = ! $all_in_array;
+							break;
 					}
-					SS_Shipping_Logger::debug( $debug_message );
-					SS_Shipping_Checkout_Debug::add_notice( $debug_message );
+
+					$this->report_shipping_class_availability( $display_shipping_class_opt, $is_available );
 				}
 
                 // Exclude customer roles
@@ -1173,9 +1223,18 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
                         if (in_array($customer_role, $exclude_roles)) {
                             $is_available = false;
 
-							$debug_message = 'Smart Send "' . $this->title . '": shipping method is NOT available, because customer role "' . $customer_role . '" is being excluded.';
-							SS_Shipping_Logger::debug( $debug_message );
-							SS_Shipping_Checkout_Debug::add_notice( $debug_message );
+							SS_Shipping_Logger::debug(
+								sprintf( 'Smart Send "%1$s": shipping method is NOT available, because customer role "%2$s" is being excluded.', $this->title, $customer_role ),
+								array( 'customer_role' => $customer_role )
+							);
+							SS_Shipping_Checkout_Debug::add_notice(
+								sprintf(
+									/* translators: 1: shipping method title, 2: customer role. */
+									__( 'Smart Send "%1$s": shipping method is NOT available, because customer role "%2$s" is being excluded.', 'smart-send-logistics' ),
+									$this->title,
+									$customer_role
+								)
+							);
 							break;
                         }
                     }
@@ -1226,57 +1285,172 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
                 }
             }
 
-            switch ($requires) {
-                case 'min_amount' :
-                    $is_available = $has_met_min_amount;
-
-                    $free_log_message = ', because the total is ' . $total . ' a minimum order amount of ' . $min_amount . ' is needed.';
-                    break;
-                case 'coupon' :
-                    $is_available = $has_coupon;
-
-                    $free_log_message = ', because a coupon is needed.';
-                    break;
-                case 'both' :
-                    $is_available = $has_met_min_amount && $has_coupon;
-
-                    $free_log_message = ', because the total is ' . $total . ' a minimum order amount of ' . $min_amount . ' is needed AND a coupon is needed.';
-                    break;
-                case 'either' :
-                    $is_available = $has_met_min_amount || $has_coupon;
-
-                    $free_log_message = ', because the total is ' . $total . ' a minimum order amount of ' . $min_amount . ' is needed OR a coupon is needed.';
-                    break;
-                case 'enabled' :
-                    $is_available = true;
-
-                    $free_log_message = ', because it is always enabled.';
-                    break;
-                case 'disabled' :
-                    $is_available = false;
-
-                    $free_log_message = ', because it is always disabled.';
-                    break;
-                default :
-                    $is_available = false;
-
-                    $free_log_message = ', because it is not available.';
-                    break;
-            }
-
-			if ( $free_log_message ) {
-				if ( $is_available ) {
-					$debug_message = 'Smart Send "' . $this->title . '": free shipping (flat fee) IS available' . $free_log_message;
-				} else {
-					$debug_message = 'Smart Send "' . $this->title . '": free shipping (flat fee) is NOT available' . $free_log_message;
-				}
-				SS_Shipping_Logger::debug( $debug_message );
-				SS_Shipping_Checkout_Debug::add_notice( $debug_message );
+			switch ( $requires ) {
+				case 'min_amount':
+					$is_available = $has_met_min_amount;
+					break;
+				case 'coupon':
+					$is_available = $has_coupon;
+					break;
+				case 'both':
+					$is_available = $has_met_min_amount && $has_coupon;
+					break;
+				case 'either':
+					$is_available = $has_met_min_amount || $has_coupon;
+					break;
+				case 'enabled':
+					$is_available = true;
+					break;
+				case 'disabled':
+				default:
+					$is_available = false;
+					break;
 			}
+
+			$this->report_free_shipping_availability( $requires, $is_available, isset( $total ) ? $total : null, $min_amount );
 
             return apply_filters('woocommerce_shipping_' . $this->id . '_is_free_shipping', $is_available, $package,
                 $this);
         }
+
+		/**
+		 * Report the shipping-class availability outcome to the log (English)
+		 * and the checkout shipping debug bar (translated).
+		 *
+		 * @param string  $display_shipping_class_opt The configured shipping-class condition.
+		 * @param boolean $is_available               Whether the method ended up available.
+		 * @return void
+		 */
+		protected function report_shipping_class_availability( $display_shipping_class_opt, $is_available ) {
+			switch ( $display_shipping_class_opt ) {
+				case 'all_shipping_class':
+					if ( $is_available ) {
+						$log_message = sprintf( 'Smart Send "%s": shipping method IS available, because ALL products belong to one of the shipping classes', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": shipping method IS available, because ALL products belong to one of the shipping classes', 'smart-send-logistics' ), $this->title );
+					} else {
+						$log_message = sprintf( 'Smart Send "%s": shipping method is NOT available, because ALL products belong to one of the shipping classes', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": shipping method is NOT available, because ALL products belong to one of the shipping classes', 'smart-send-logistics' ), $this->title );
+					}
+					break;
+				case 'one_shipping_class':
+					if ( $is_available ) {
+						$log_message = sprintf( 'Smart Send "%s": shipping method IS available, because at least ONE product belongs to one of the shipping classes', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": shipping method IS available, because at least ONE product belongs to one of the shipping classes', 'smart-send-logistics' ), $this->title );
+					} else {
+						$log_message = sprintf( 'Smart Send "%s": shipping method is NOT available, because at least ONE product belongs to one of the shipping classes', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": shipping method is NOT available, because at least ONE product belongs to one of the shipping classes', 'smart-send-logistics' ), $this->title );
+					}
+					break;
+				case 'nall_shipping_class':
+					if ( $is_available ) {
+						$log_message = sprintf( 'Smart Send "%s": shipping method IS available, because ALL products do NOT belong to one of the shipping classes', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": shipping method IS available, because ALL products do NOT belong to one of the shipping classes', 'smart-send-logistics' ), $this->title );
+					} else {
+						$log_message = sprintf( 'Smart Send "%s": shipping method is NOT available, because ALL products do NOT belong to one of the shipping classes', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": shipping method is NOT available, because ALL products do NOT belong to one of the shipping classes', 'smart-send-logistics' ), $this->title );
+					}
+					break;
+				case 'none_shipping_class':
+					if ( $is_available ) {
+						$log_message = sprintf( 'Smart Send "%s": shipping method IS available, because at least ONE product does NOT belongs to one of the shipping classes', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": shipping method IS available, because at least ONE product does NOT belongs to one of the shipping classes', 'smart-send-logistics' ), $this->title );
+					} else {
+						$log_message = sprintf( 'Smart Send "%s": shipping method is NOT available, because at least ONE product does NOT belongs to one of the shipping classes', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": shipping method is NOT available, because at least ONE product does NOT belongs to one of the shipping classes', 'smart-send-logistics' ), $this->title );
+					}
+					break;
+				default:
+					return;
+			}
+
+			SS_Shipping_Logger::debug( $log_message, array( 'shipping_class_option' => $display_shipping_class_opt ) );
+			SS_Shipping_Checkout_Debug::add_notice( $notice_message );
+		}
+
+		/**
+		 * Report the free-shipping (flat fee) availability outcome to the log
+		 * (English) and the checkout shipping debug bar (translated).
+		 *
+		 * @param string     $requires     The configured free-shipping condition.
+		 * @param boolean    $is_available Whether free shipping ended up available.
+		 * @param mixed|null $total        The evaluated cart total (only set for amount-based conditions).
+		 * @param mixed      $min_amount   The configured minimum order amount.
+		 * @return void
+		 */
+		protected function report_free_shipping_availability( $requires, $is_available, $total, $min_amount ) {
+			switch ( $requires ) {
+				case 'min_amount':
+					if ( $is_available ) {
+						$log_message = sprintf( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed.', $this->title, $total, $min_amount );
+						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
+						$notice_message = sprintf( __( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed.', 'smart-send-logistics' ), $this->title, $total, $min_amount );
+					} else {
+						$log_message = sprintf( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed.', $this->title, $total, $min_amount );
+						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
+						$notice_message = sprintf( __( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed.', 'smart-send-logistics' ), $this->title, $total, $min_amount );
+					}
+					break;
+				case 'coupon':
+					if ( $is_available ) {
+						$log_message = sprintf( 'Smart Send "%s": free shipping (flat fee) IS available, because a coupon is needed.', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": free shipping (flat fee) IS available, because a coupon is needed.', 'smart-send-logistics' ), $this->title );
+					} else {
+						$log_message = sprintf( 'Smart Send "%s": free shipping (flat fee) is NOT available, because a coupon is needed.', $this->title );
+						/* translators: %s: shipping method title. */
+						$notice_message = sprintf( __( 'Smart Send "%s": free shipping (flat fee) is NOT available, because a coupon is needed.', 'smart-send-logistics' ), $this->title );
+					}
+					break;
+				case 'both':
+					if ( $is_available ) {
+						$log_message = sprintf( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.', $this->title, $total, $min_amount );
+						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
+						$notice_message = sprintf( __( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.', 'smart-send-logistics' ), $this->title, $total, $min_amount );
+					} else {
+						$log_message = sprintf( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.', $this->title, $total, $min_amount );
+						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
+						$notice_message = sprintf( __( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.', 'smart-send-logistics' ), $this->title, $total, $min_amount );
+					}
+					break;
+				case 'either':
+					if ( $is_available ) {
+						$log_message = sprintf( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.', $this->title, $total, $min_amount );
+						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
+						$notice_message = sprintf( __( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.', 'smart-send-logistics' ), $this->title, $total, $min_amount );
+					} else {
+						$log_message = sprintf( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.', $this->title, $total, $min_amount );
+						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
+						$notice_message = sprintf( __( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.', 'smart-send-logistics' ), $this->title, $total, $min_amount );
+					}
+					break;
+				case 'enabled':
+					$log_message = sprintf( 'Smart Send "%s": free shipping (flat fee) IS available, because it is always enabled.', $this->title );
+					/* translators: %s: shipping method title. */
+					$notice_message = sprintf( __( 'Smart Send "%s": free shipping (flat fee) IS available, because it is always enabled.', 'smart-send-logistics' ), $this->title );
+					break;
+				case 'disabled':
+					$log_message = sprintf( 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is always disabled.', $this->title );
+					/* translators: %s: shipping method title. */
+					$notice_message = sprintf( __( 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is always disabled.', 'smart-send-logistics' ), $this->title );
+					break;
+				default:
+					$log_message = sprintf( 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is not available.', $this->title );
+					/* translators: %s: shipping method title. */
+					$notice_message = sprintf( __( 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is not available.', 'smart-send-logistics' ), $this->title );
+					break;
+			}
+
+			SS_Shipping_Logger::debug( $log_message, array( 'requires' => $requires ) );
+			SS_Shipping_Checkout_Debug::add_notice( $notice_message );
+		}
 
 	    /**
 	     * Get the human readable name of the Smart Send shipping method

--- a/smart-send-logistics/includes/class-ss-shipping-wc-order.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc-order.php
@@ -48,18 +48,23 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
 			return $this->admin_notices;
 		}
 
-        /**
-         * Define constants
-         */
-        protected function define_constants()
-        {
-            SS_SHIPPING_WC()->define('SS_SHIPPING_BUTTON_LABEL_GEN',
-                (SS_SHIPPING_WC()->get_demo_mode_setting() ? __('DEMO MODE',
-                        'smart-send-logistics') . ': ' : '') . __('Generate label', 'smart-send-logistics'));
-            SS_SHIPPING_WC()->define('SS_SHIPPING_BUTTON_RETURN_LABEL_GEN',
-                (SS_SHIPPING_WC()->get_demo_mode_setting() ? __('DEMO MODE',
-                        'smart-send-logistics') . ': ' : '') . __('Generate return label', 'smart-send-logistics'));
-        }
+		/**
+		 * Define constants
+		 */
+		protected function define_constants() {
+			SS_SHIPPING_WC()->define(
+				'SS_SHIPPING_BUTTON_LABEL_GEN',
+				SS_SHIPPING_WC()->get_demo_mode_setting()
+					? __( 'DEMO MODE: Generate label', 'smart-send-logistics' )
+					: __( 'Generate label', 'smart-send-logistics' )
+			);
+			SS_SHIPPING_WC()->define(
+				'SS_SHIPPING_BUTTON_RETURN_LABEL_GEN',
+				SS_SHIPPING_WC()->get_demo_mode_setting()
+					? __( 'DEMO MODE: Generate return label', 'smart-send-logistics' )
+					: __( 'Generate return label', 'smart-send-logistics' )
+			);
+		}
 
         protected function init_hooks()
         {
@@ -167,12 +172,9 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
 								$array_messages_error,
 								array(
 									'message' => sprintf(
-										/* translators: %s: WooCommerce order id */
-										__( 'Order #%s', 'smart-send-logistics' ),
+										/* translators: %s: WooCommerce order id. */
+										__( 'Order #%s: The order could not be found', 'smart-send-logistics' ),
 										$order_id
-									) . ': ' . __(
-										'The order could not be found',
-										'smart-send-logistics'
 									),
 									'type'    => 'error',
 								)
@@ -188,44 +190,70 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
 
                             foreach ($response as $key => $value) {
 
-                                if (isset($value['success'])) {
-                                    array_push($array_messages_success, array(
-                                        'message' => sprintf(__('Order #%s', 'smart-send-logistics'),
-                                                $order->get_order_number()) . ': '
-                                            . (empty($value['success']->woocommerce['return']) ?
-                                                __('Shipping label created by Smart Send',
-                                                    'smart-send-logistics') : __('Return label created by Smart Send',
-                                                    'smart-send-logistics'))
-                                            . ': ' . $this->get_ss_shipping_label_link($value['success']->woocommerce['label_url'],
-                                                !empty($value['success']->woocommerce['return'])),
-                                        'type'    => 'success',
-                                    ));
+								if ( isset( $value['success'] ) ) {
+									$is_return_label = ! empty( $value['success']->woocommerce['return'] );
+									$label_link      = $this->get_ss_shipping_label_link( $value['success']->woocommerce['label_url'], $is_return_label );
 
-                                    array_push($array_shipment_ids, array(
-                                        'shipment_id' => $value['success']->shipment_id,
-                                        'order_id'    => $order->get_order_number(),
-                                    ));
+									if ( $is_return_label ) {
+										$message = sprintf(
+											/* translators: 1: WooCommerce order number, 2: link to download the return label. */
+											__( 'Order #%1$s: Return label created by Smart Send: %2$s', 'smart-send-logistics' ),
+											$order->get_order_number(),
+											$label_link
+										);
+									} else {
+										$message = sprintf(
+											/* translators: 1: WooCommerce order number, 2: link to download the shipping label. */
+											__( 'Order #%1$s: Shipping label created by Smart Send: %2$s', 'smart-send-logistics' ),
+											$order->get_order_number(),
+											$label_link
+										);
+									}
 
-                                } else {
-                                    // Print error message
-                                    $message = sprintf(__('Order #%s', 'smart-send-logistics'),
-                                            $order->get_order_number()) . ': ' . $value['error'];
+									array_push(
+										$array_messages_success,
+										array(
+											'message' => $message,
+											'type'    => 'success',
+										)
+									);
 
-                                    array_push($array_messages_error, array(
-                                        'message' => $message,
-                                        'type'    => 'error',
-                                    ));
-                                }
+									array_push(
+										$array_shipment_ids,
+										array(
+											'shipment_id' => $value['success']->shipment_id,
+											'order_id'    => $order->get_order_number(),
+										)
+									);
+								} else {
+									array_push(
+										$array_messages_error,
+										array(
+											'message' => sprintf(
+												/* translators: 1: WooCommerce order number, 2: error message. */
+												__( 'Order #%1$s: %2$s', 'smart-send-logistics' ),
+												$order->get_order_number(),
+												$value['error']
+											),
+											'type'    => 'error',
+										)
+									);
+								}
                             }
 
-                        } else {
-                            array_push($array_messages_error, array(
-                                'message' => sprintf(__('Order #%s', 'smart-send-logistics'),
-                                        $order->get_order_number()) . ': ' . __('The selected order did not include a Send Smart shipping method',
-                                        'smart-send-logistics'),
-                                'type'    => 'error',
-                            ));
-                        }
+						} else {
+							array_push(
+								$array_messages_error,
+								array(
+									'message' => sprintf(
+										/* translators: %s: WooCommerce order number. */
+										__( 'Order #%s: The selected order did not include a Send Smart shipping method', 'smart-send-logistics' ),
+										$order->get_order_number()
+									),
+									'type'    => 'error',
+								)
+							);
+						}
                     }
 
                     $array_combo_messages = $this->create_combo_file($array_messages_success, $array_messages_error,
@@ -315,23 +343,33 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
             echo '<h3>' . __('Shipping Method', 'smart-send-logistics') . '</h3>';
             echo '<p>' . $ss_shipping_method_name . '</p>';
 
-            // If debug is enabled then show the shipping method id and instance id
-            if (isset($shipping_ss_settings['ss_debug']) && $shipping_ss_settings['ss_debug'] == 'yes') {
-                foreach ($order->get_shipping_methods() as $method) {
-                    echo '<pre>' . __('Debug id', 'smart-send-logistics') . ': ' .
-                        $method->get_method_id() . ':' . $method->get_instance_id() . '</pre>';
-                }
-            }
+			// If debug is enabled then show the shipping method id and instance id.
+			if ( isset( $shipping_ss_settings['ss_debug'] ) && 'yes' === $shipping_ss_settings['ss_debug'] ) {
+				foreach ( $order->get_shipping_methods() as $method ) {
+					echo '<pre>' . sprintf(
+						/* translators: %s: shipping method id and instance id. */
+						esc_html__( 'Debug id: %s', 'smart-send-logistics' ),
+						esc_html( $method->get_method_id() . ':' . $method->get_instance_id() )
+					) . '</pre>';
+				}
+			}
 
-            echo '<p>' . sprintf(__('Weight: %0.2f kg', 'smart-send-logistics'),
-                    $this->getOrderWeight($order)) . '</p>';
+			echo '<p>' . sprintf(
+				/* translators: %0.2f: total order weight in kg. */
+				esc_html__( 'Weight: %0.2f kg', 'smart-send-logistics' ),
+				floatval( $this->getOrderWeight( $order ) )
+			) . '</p>';
 
-            // Display Agent No. field if pickup-point shipping method selected
-            if (stripos($shipping_method_type, 'agent') !== false) {
-                echo '<h3>' . __('Pick-up Point', 'smart-send-logistics') . '</h3>';
-                echo '<strong>' . __('Agent No.:', 'smart-send-logistics') . $ss_shipping_order_agent_no . '</strong>';
-                echo $this->get_formatted_address($ss_shipping_order_agent);
-            }
+			// Display Agent No. field if pickup-point shipping method selected.
+			if ( false !== stripos( $shipping_method_type, 'agent' ) ) {
+				echo '<h3>' . esc_html__( 'Pick-up Point', 'smart-send-logistics' ) . '</h3>';
+				echo '<strong>' . sprintf(
+					/* translators: %s: pick-up point agent number. */
+					esc_html__( 'Agent No.: %s', 'smart-send-logistics' ),
+					esc_html( (string) $ss_shipping_order_agent_no )
+				) . '</strong>';
+				echo wp_kses_post( $this->get_formatted_address( $ss_shipping_order_agent ) );
+			}
 
             echo '<hr>';
 
@@ -719,10 +757,10 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
 			if ( ! $order instanceof WC_Order ) {
 				return array(
 					'error' => sprintf(
-						/* translators: %s: WooCommerce order id */
-						__( 'Order #%s', 'smart-send-logistics' ),
+						/* translators: %s: WooCommerce order id. */
+						__( 'Order #%s: The order could not be found', 'smart-send-logistics' ),
 						$order_id
-					) . ': ' . __( 'The order could not be found', 'smart-send-logistics' ),
+					),
 				);
 			}
 
@@ -874,14 +912,20 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
         protected function get_formatted_order_note_with_label_and_tracking($order_id, $api_shipment_response, $return)
         {
 
-            $tracking_note = '<label>' . ($return ? __('Return shipping label',
-                    'smart-send-logistics') : __('Shipping label', 'smart-send-logistics')) . ': </label>'
-                . $this->get_ss_shipping_label_link($api_shipment_response->woocommerce['label_url'], $return);
+			$tracking_note = sprintf(
+				'<label>%1$s: </label>%2$s',
+				$return ? __( 'Return shipping label', 'smart-send-logistics' ) : __( 'Shipping label', 'smart-send-logistics' ),
+				$this->get_ss_shipping_label_link( $api_shipment_response->woocommerce['label_url'], $return )
+			);
 
-            foreach ($api_shipment_response->parcels as $parcel) {
-                $tracking_note .= '<br><label>' . __('Tracking number', 'smart-send-logistics') . ': </label>'
-                    . '<a href="' . $parcel->tracking_link . '" target="_blank">' . $parcel->tracking_code . '</a>';
-            }
+			foreach ( $api_shipment_response->parcels as $parcel ) {
+				$tracking_note .= sprintf(
+					'<br><label>%1$s: </label><a href="%2$s" target="_blank">%3$s</a>',
+					__( 'Tracking number', 'smart-send-logistics' ),
+					$parcel->tracking_link,
+					$parcel->tracking_code
+				);
+			}
 
             return $tracking_note;
         }
@@ -1193,20 +1237,22 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
             return $order_meta_query;
         }
 
-        /**
-         * Return Smart Send bulk actions
-         */
-        private function get_bulk_actions()
-        {
-            return array(
-                'ss_shipping_label_bulk'  => (SS_SHIPPING_WC()->get_demo_mode_setting() ? __('DEMO MODE',
-                            'smart-send-logistics') . ': ' : '') . __('Smart Send - Generate Labels',
-                        'smart-send-logistics'),
-                'ss_shipping_return_bulk' => (SS_SHIPPING_WC()->get_demo_mode_setting() ? __('DEMO MODE',
-                            'smart-send-logistics') . ': ' : '') . __('Smart Send - Generate Return Labels',
-                        'smart-send-logistics'),
-            );
-        }
+		/**
+		 * Return Smart Send bulk actions
+		 */
+		private function get_bulk_actions() {
+			if ( SS_SHIPPING_WC()->get_demo_mode_setting() ) {
+				return array(
+					'ss_shipping_label_bulk'  => __( 'DEMO MODE: Smart Send - Generate Labels', 'smart-send-logistics' ),
+					'ss_shipping_return_bulk' => __( 'DEMO MODE: Smart Send - Generate Return Labels', 'smart-send-logistics' ),
+				);
+			}
+
+			return array(
+				'ss_shipping_label_bulk'  => __( 'Smart Send - Generate Labels', 'smart-send-logistics' ),
+				'ss_shipping_return_bulk' => __( 'Smart Send - Generate Return Labels', 'smart-send-logistics' ),
+			);
+		}
 
         /**
          * Create Combo File
@@ -1252,7 +1298,11 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
 						array_push(
 							$array_messages,
 							array(
-								'message' => __( 'Error combining shipping labels:', 'smart-send-logistics' ) . ' ' . SS_SHIPPING_WC()->get_api_handle()->getErrorString(),
+								'message' => sprintf(
+									/* translators: %s: error message from the Smart Send API. */
+									__( 'Error combining shipping labels: %s', 'smart-send-logistics' ),
+									SS_SHIPPING_WC()->get_api_handle()->getErrorString()
+								),
 								'type'    => 'error',
 							)
 						);
@@ -1260,18 +1310,33 @@ if ( ! class_exists( 'SS_Shipping_WC_Order' ) ) :
 				}
 			}
 
-            if (!empty($combo_url)) {
-                $order_id_list = wp_list_pluck($array_shipment_ids, 'order_id');
-                $order_id_list = array_unique($order_id_list);
-                $label_count = count($order_id_list);
-                $order_ids_str = __('Orders: #', 'smart-send-logistics') . implode(', #', $order_id_list);
+			if ( ! empty( $combo_url ) ) {
+				$order_id_list = wp_list_pluck( $array_shipment_ids, 'order_id' );
+				$order_id_list = array_unique( $order_id_list );
+				$label_count   = count( $order_id_list );
+				$order_ids_str = sprintf(
+					/* translators: %s: list of order numbers, each prefixed with #. */
+					__( 'Orders: #%s', 'smart-send-logistics' ),
+					implode( ', #', $order_id_list )
+				);
 
-                array_push($array_messages, array(
-                    'message' => sprintf(__('Shipping labels created by Smart Send for %s orders: <a href="%s" target="_blank">Download combined pdf</a>',
-                            'smart-send-logistics'), $label_count, $combo_url)
-                        . '<br/>' . $order_ids_str,
-                    'type'    => 'success',
-                ));
+				array_push(
+					$array_messages,
+					array(
+						'message' => sprintf(
+							/* translators: 1: number of orders, 2: URL of the combined PDF file. */
+							_n(
+								'Shipping labels created by Smart Send for %1$s order: <a href="%2$s" target="_blank">Download combined pdf</a>',
+								'Shipping labels created by Smart Send for %1$s orders: <a href="%2$s" target="_blank">Download combined pdf</a>',
+								$label_count,
+								'smart-send-logistics'
+							),
+							$label_count,
+							$combo_url
+						) . '<br/>' . $order_ids_str,
+						'type'    => 'success',
+					)
+				);
 
                 $array_messages = array_merge($array_messages, $array_messages_error);
             } else {

--- a/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/includes/frontend/class-ss-shipping-frontend.php
@@ -212,15 +212,26 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 				 */
 				$ss_agents = apply_filters( 'smart_send_agents_found', $ss_agents, $search_params );
 
-				$summary = 'Smart Send: found ' . count( $ss_agents ) . ' ' . $carrier . ' pick-up points near the entered address.';
 				SS_Shipping_Logger::debug(
-					$summary,
+					sprintf( 'Smart Send: found %1$d %2$s pick-up points near the entered address.', count( $ss_agents ), $carrier ),
 					array(
 						'carrier'      => $carrier,
 						'result_count' => count( $ss_agents ),
 					)
 				);
-				SS_Shipping_Checkout_Debug::add_notice( $summary );
+				SS_Shipping_Checkout_Debug::add_notice(
+					sprintf(
+						/* translators: 1: number of pick-up points found, 2: carrier code. */
+						_n(
+							'Smart Send: found %1$d %2$s pick-up point near the entered address.',
+							'Smart Send: found %1$d %2$s pick-up points near the entered address.',
+							count( $ss_agents ),
+							'smart-send-logistics'
+						),
+						count( $ss_agents ),
+						$carrier
+					)
+				);
 
 				// Save all of the agents in sessions.
 				WC()->session->set( 'ss_shipping_agents', $ss_agents );
@@ -256,26 +267,44 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 			if ( 'NoResults' === $code ) {
 				// Not an error: the API answered, there are just no pick-up
 				// points near the entered address.
-				$reason = 'Smart Send: no ' . $carrier . ' pick-up points found near the entered address - falling back to "Shipping to closest pick-up point".';
-
-				SS_Shipping_Logger::debug( $reason );
-				SS_Shipping_Checkout_Debug::add_notice( $reason );
+				SS_Shipping_Logger::debug(
+					sprintf( 'Smart Send: no %s pick-up points found near the entered address - falling back to "Shipping to closest pick-up point".', $carrier ),
+					array( 'carrier' => $carrier )
+				);
+				SS_Shipping_Checkout_Debug::add_notice(
+					sprintf(
+						/* translators: %s: carrier code. */
+						__( 'Smart Send: no %s pick-up points found near the entered address - falling back to "Shipping to closest pick-up point".', 'smart-send-logistics' ),
+						$carrier
+					)
+				);
 
 				return;
 			}
 
 			if ( 0 === strpos( $code, 'transport-' ) ) {
-				$reason = 'Smart Send: pick-up point lookup for ' . $carrier . ' failed with a transport error (' . $code . '): ' . $message;
+				$log_message = sprintf( 'Smart Send: pick-up point lookup for %1$s failed with a transport error (%2$s): %3$s Falling back to "Shipping to closest pick-up point".', $carrier, $code, $message );
+				/* translators: 1: carrier code, 2: error code, 3: error message. */
+				$notice_message = sprintf( __( 'Smart Send: pick-up point lookup for %1$s failed with a transport error (%2$s): %3$s Falling back to "Shipping to closest pick-up point".', 'smart-send-logistics' ), $carrier, $code, $message );
 			} elseif ( '' !== $code || '' !== $message ) {
-				$reason = 'Smart Send: pick-up point lookup for ' . $carrier . ' failed with an API error (' . $code . '): ' . $message;
+				$log_message = sprintf( 'Smart Send: pick-up point lookup for %1$s failed with an API error (%2$s): %3$s Falling back to "Shipping to closest pick-up point".', $carrier, $code, $message );
+				/* translators: 1: carrier code, 2: error code, 3: error message. */
+				$notice_message = sprintf( __( 'Smart Send: pick-up point lookup for %1$s failed with an API error (%2$s): %3$s Falling back to "Shipping to closest pick-up point".', 'smart-send-logistics' ), $carrier, $code, $message );
 			} else {
-				$reason = 'Smart Send: pick-up point lookup for ' . $carrier . ' failed for an unknown reason.';
+				$log_message = sprintf( 'Smart Send: pick-up point lookup for %s failed for an unknown reason. Falling back to "Shipping to closest pick-up point".', $carrier );
+				/* translators: %s: carrier code. */
+				$notice_message = sprintf( __( 'Smart Send: pick-up point lookup for %s failed for an unknown reason. Falling back to "Shipping to closest pick-up point".', 'smart-send-logistics' ), $carrier );
 			}
 
-			$reason .= ' Falling back to "Shipping to closest pick-up point".';
-
-			SS_Shipping_Logger::error( $reason );
-			SS_Shipping_Checkout_Debug::add_notice( $reason );
+			SS_Shipping_Logger::error(
+				$log_message,
+				array(
+					'carrier'       => $carrier,
+					'error_code'    => $code,
+					'error_message' => $message,
+				)
+			);
+			SS_Shipping_Checkout_Debug::add_notice( $notice_message );
 		}
 
         /**
@@ -337,16 +366,16 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 
             $formatted_address = str_replace($place_holders, $place_holders_vals, $address_format);
 
-            if (!empty($agent->distance) && $format_id > 0) {
-                if ($agent->distance < 1) {
-                    $formatted_distance = number_format($agent->distance * 1000, 0, '.', '')
-                        . __('m', 'smart-send-logistics');
-                } else {
-                    $formatted_distance = number_format($agent->distance, 2, '.', '')
-                        . __('km', 'smart-send-logistics');
-                }
-                $formatted_address = $formatted_distance . ': ' . $formatted_address;
-            }
+			if ( ! empty( $agent->distance ) && $format_id > 0 ) {
+				if ( $agent->distance < 1 ) {
+					/* translators: %s: distance in meters. */
+					$formatted_distance = sprintf( __( '%sm', 'smart-send-logistics' ), number_format( $agent->distance * 1000, 0, '.', '' ) );
+				} else {
+					/* translators: %s: distance in kilometers. */
+					$formatted_distance = sprintf( __( '%skm', 'smart-send-logistics' ), number_format( $agent->distance, 2, '.', '' ) );
+				}
+				$formatted_address = sprintf( '%1$s: %2$s', $formatted_distance, $formatted_address );
+			}
 
             return $formatted_address;
         }

--- a/smart-send-logistics/lang/smart-send-logistics.pot
+++ b/smart-send-logistics/lang/smart-send-logistics.pot
@@ -1,0 +1,1114 @@
+# Copyright (C) 2026 Smart Send ApS
+# This file is distributed under the same license as the Smart Send Shipping for WooCommerce plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: Smart Send Shipping for WooCommerce 8.2.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smart-send-logistics\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-08-12T12:34:19+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.11.0\n"
+"X-Domain: smart-send-logistics\n"
+
+#. Plugin Name of the plugin
+#. Description of the plugin
+#: smart-send-logistics.php
+msgid "Smart Send Shipping for WooCommerce"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: smart-send-logistics.php
+msgid "https://wordpress.org/plugins/smart-send-logistics/"
+msgstr ""
+
+#. Author of the plugin
+#: smart-send-logistics.php
+msgid "Smart Send ApS"
+msgstr ""
+
+#. Author URI of the plugin
+#: smart-send-logistics.php
+msgid "https://www.smartsend.io"
+msgstr ""
+
+#: includes/class-ss-shipping-shipment.php:144
+msgid "No return method set"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:24
+#: includes/class-ss-shipping-wc-method.php:502
+msgid "Smart Send"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:25
+msgid "Advanced shipping solution for PostNord, GLS and Bring."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:35
+#: includes/class-ss-shipping-wc-method.php:197
+msgid "- Select Method -"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:38
+msgid "PostNord: Select pick-up point (MyPack Collect)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:40
+msgid "PostNord: Closest pick-up point (MyPack Collect)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:42
+msgid "PostNord: Private delivery to address (MyPack Home)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:44
+msgid "PostNord: Leave at door (Flexdelivery)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:46
+msgid "PostNord: Flexible home delivery (FlexChange)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:48
+msgid "PostNord: Private economy delivery to address (MyPack Home Economy)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:50
+msgid "PostNord: Private delivery to address Small (MyPack Home Small)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:52
+msgid "PostNord: Commercial delivery to address (Parcel)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:54
+msgid "PostNord: Valuable parcel"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:56
+msgid "PostNord: Tracked Valuemail Large"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:58
+msgid "PostNord: Tracked Valuemail Maxi"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:60
+msgid "PostNord: Tracked Valuemail First Class"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:62
+msgid "PostNord: Tracked Valuemail Economy"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:64
+msgid "PostNord: Tracked Valuemail Eco Friendly"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:66
+msgid "PostNord: Untracked Valuemail Large"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:68
+msgid "PostNord: Untracked Valuemail Maxi"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:70
+msgid "PostNord: Registred letter"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:72
+msgid "PostNord: Tracked letter"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:74
+msgid "PostNord: Tracked letter Large"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:76
+msgid "PostNord: Untracked letter"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:78
+msgid "PostNord: Express Letter"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:80
+msgid "PostNord: Full size pallet"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:82
+msgid "PostNord: Half size pallet"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:84
+msgid "PostNord: Quarter size pallet"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:86
+msgid "PostNord: Speciel size pallet"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:91
+msgid "GLS: Select pick-up point (ParcelShop)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:92
+msgid "GLS: Closest pick-up point (ParcelShop)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:93
+msgid "GLS: Private delivery to address (PrivateDelivery)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:95
+msgid "GLS: Leave at door (DepositService)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:96
+msgid "GLS: Flexible home delivery (FlexDelivery)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:97
+msgid "GLS: Commercial delivery to address (BusinessParcel)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:102
+msgid "DAO: Select pick-up point (ParcelShop)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:103
+msgid "DAO: Closest pick-up point (ParcelShop)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:104
+msgid "DAO: Leave at door (Direct)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:105
+msgid "DAO: From pick-up point to pick-up point (Shop2Shop)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:106
+msgid "DAO: From pick-up point to doorstep (ParcelShop to Direct)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:110
+msgid "Budbee: Home"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:114
+msgid "Burd: Home Delivery"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:118
+msgid "Bring: Select pick-up point (PickUp Parcel / Serviceparcel)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:120
+msgid "Bring: Select pick-up point, send as bulk (PickUp Parcel Bulk)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:122
+msgid "Bring: Closest pick-up point (PickUp Parcel / Serviceparcel)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:124
+msgid "Bring: Closest pick-up point, send as bulk (PickUp Parcel Bulk)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:126
+msgid "Bring: Private delivery to address (Home Delivery Parcel)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:128
+msgid "Bring: Commercial delivery to address (Business Parcel)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:130
+msgid "Bring: Commercial delivery to address, send as bulk (Business Parcel Bulk)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:132
+msgid "Bring: Commercial delivery of full size pallet (Business Pallet)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:134
+msgid "Bring: Commercial delivery of half size pallet (Business Pallet)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:136
+msgid "Bring: Commercial delivery of quarter size pallet (Business Pallet)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:138
+msgid "Bring: Express delivery before 9:00 (Express Nordic 09:00)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:140
+msgid "Bring: Express delivery before 9:00, send as bulk (Express Nordic 09:00 Bulk)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:146
+msgid "Bifrost Logistics: eTail Tracked"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:148
+msgid "Bifrost Logistics: eTail Tracked large"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:151
+msgid "Bifrost Logistics: eTail Gain small"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:153
+msgid "Bifrost Logistics: eTail Gain large"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:156
+msgid "Bifrost Logistics: Nordic Express Collect"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:158
+msgid "Bifrost Logistics: Nordic Express Home"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:200
+msgid "PostNord: Return from pick-up point (Return Drop Off)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:202
+msgid "PostNord: Return from address (Return Pickup)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:207
+msgid "GLS: Return from pick-up point (ShopReturn)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:212
+msgid "DAO: Return from pick-up point (ParcelShop Return)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:217
+msgid "Bring: Return from pick-up point (PickUp Parcel Return)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:219
+msgid "Bring: Return from address (Parcel Return)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:264
+msgid "Validating connection..."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:286
+msgid "API Token"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:289
+msgid "Sign up for a Smart Send account <a href=\"%s\" target=\"_blank\">here</a>."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:299
+msgid "Save the settings before clicking the button to validate API Token."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:304
+msgid "Demo mode"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:305
+msgid "Demo mode is used for testing on a staging site. No data will be send to the shipping carrier."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:309
+msgid "Enable demo mode"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:312
+msgid "Debug Log"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:314
+msgid "Enable logging"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:316
+msgid "A log file containing the communication to the Smart Send server will be maintained if this option is checked. This can be used in case of technical issues and can be found %shere%s."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:320
+msgid "Shipping Labels"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:322
+msgid "Settings for generating shipping labels."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:325
+msgid "Set order status after label print"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:330
+msgid "Do not change order status"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:334
+msgid "Shipping method used for WooCommerce method Free Shipping"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:338
+msgid "Selecting a shipping method will make it possible to make shipping labels for order places with WooCommerces native Free Shipping method."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:343
+msgid "Include order comment on label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:349
+msgid "Save a copy of the PDF"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:352
+msgid "This will save a copy of the generated PDF label in the WordPress uploads-folder"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:357
+msgid "Pick-up Points"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:359
+msgid "Settings for displaying pick-up points during checkout."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:363
+msgid "Dropdown format"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:364
+msgid "How the pick-up points are listed during checkout."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:372
+msgid "Select Default"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:373
+msgid "Enable Select Default"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:374
+msgid "This will automatically select the closest pick-up point and let the customer change to a different pick-up point. This means that the customer will not be forced to select a pick-up point before completing the order."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:380
+msgid "Shipping methods"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:382
+msgid "Settings for shipping methods."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:385
+msgid "Sort shipping methods"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:387
+msgid "Enable automatic sorting by cost on checkout page"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:389
+msgid "Shipping methods will be sorted in ascending order, according to the cost, instead of by order of appearance in Shipping Zone table as per default"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:414
+msgid "Demo mode can only be disabled with a valid API Token. Please enter a valid API Token and save the settings again."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:425
+msgid "Invalid API Token. Demo mode can only be disabled with a valid API Token for %s."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:498
+msgid "Method Title"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:500
+msgid "This controls the title which the user sees during checkout."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:506
+#: includes/class-ss-shipping-wc-order.php:343
+msgid "Shipping Method"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:509
+msgid "This is the shipping method used when generating shipping labels."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:515
+msgid "Tax status"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:518
+msgid "Determines if the shipping cost is taxable. Remember to set a shipping tax in WooCommerce."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:523
+msgid "Taxable"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:524
+msgctxt "Tax status"
+msgid "None"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:528
+#: includes/class-ss-shipping-wc-method.php:799
+msgid "Cost"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:530
+msgid "Configure the shipping method cost and free shipping."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:538
+msgid "Flat rate requires..."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:543
+msgid "Always disabled"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:544
+msgid "Always enabled"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:545
+msgid "A valid free shipping coupon"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:546
+msgid "A minimum order amount"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:547
+msgid "A minimum order amount OR a coupon"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:548
+msgid "A minimum order amount AND a coupon"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:552
+msgid "Flat fee cost"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:555
+msgid "Shipping method cost if rules apply. To apply free shipping the value must be \"0\"."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:561
+msgid "Minimum order amount"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:564
+msgid "Users will need to spend at least this amount (including VAT) to get free shipping (if enabled above)."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:570
+#: includes/class-ss-shipping-wc-method.php:575
+msgid "Advanced Settings"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:572
+msgid "Configure the advanced settings."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:577
+#: includes/class-ss-shipping-wc-method.php:652
+msgid "Enable"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:579
+msgid "Enable/disable advanced settings and to show/hide settings."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:584
+msgid "Display shipping method if..."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:587
+msgid "Select when to display the shipping method based on shipping class."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:591
+msgid "N/A"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:592
+msgid "ALL products belong to one of the shipping classes"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:594
+msgid "At least ONE product belongs to one of the shipping classes"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:596
+msgid "ALL products do NOT belong to one of the shipping classes"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:598
+msgid "At least ONE product does NOT belongs to one of the shipping classes"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:604
+msgid "Shipping classes"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:607
+msgid "Shipping classes used to display the shipping method."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:626
+msgid "Exclude User role"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:629
+msgid "Do NOT display shipping method for these user roles."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:634
+msgid "Return shipping"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:636
+msgid "Configure how to handle return shipping."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:640
+msgid "Return Shipping Method"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:643
+msgid "This is the shipping method used when generating a return shipping labels."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:650
+msgid "Auto Generate Return Label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:654
+msgid "Should a return label automatically be generated whenever a normal shipping labels is generated."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:678
+msgid "\"Method Title\" cannot be empty"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:682
+msgid "Change the \"Method Title\" field to something human readable. This is what your customers see at checkout."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:693
+msgid "Select a \"Shipping Method\""
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:777
+msgid "Enter a cost (excl. tax) or sum, e.g. 10.00 * [qty]."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:778
+msgid "Use [qty] for the number of items, <br/>[cost] for the total cost of items, and [fee percent='10' min_fee='20' max_fee=''] for percentage based fees."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:783
+msgid "Cost based on weight"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:789
+msgid "Minimum"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:791
+msgid "Cart weight should be equal to or larger than this value for the shipping rate to be applicable"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:794
+msgid "Maximum"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:796
+msgid "Cart weight should be strictly less than this value for the shipping rate to be applicable"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:833
+msgid "+ Add shipping rate"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:835
+msgid "Remove selected rate(s)"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-method.php:840
+msgid "Enter the shipping cost excluding tax"
+msgstr ""
+
+#. translators: 1: shipping rate label, 2: Smart Send shipping method code, 3: shipping rate id.
+#: includes/class-ss-shipping-wc-method.php:988
+msgid "Smart Send: evaluated method \"%1$s\" (%2$s, rate id %3$s)."
+msgstr ""
+
+#. translators: 1: shipping rate label, 2: flat fee cost.
+#: includes/class-ss-shipping-wc-method.php:1013
+msgid "Smart Send \"%1$s\": free shipping applies - rate added with flat fee cost %2$s."
+msgstr ""
+
+#. translators: 1: shipping rate label, 2: cart weight, 3: weight unit, 4: matched weight table row as "min-max unit", 5: rate cost.
+#: includes/class-ss-shipping-wc-method.php:1064
+msgid "Smart Send \"%1$s\": cart weight %2$s %3$s matched weight table row %4$s - rate added with cost %5$s."
+msgstr ""
+
+#. translators: 1: shipping rate label, 2: number of matched weight table rows, 3: list of matched rows, 4: shipping rate id, 5: last matched row.
+#: includes/class-ss-shipping-wc-method.php:1097
+msgid "Smart Send \"%1$s\": %2$d overlapping weight table rows matched (%3$s) - the rows share rate id %4$s, so only the LAST matching row (%5$s) is offered and the earlier matches were overwritten."
+msgstr ""
+
+#. translators: 1: shipping rate label, 2: cart weight, 3: weight unit.
+#: includes/class-ss-shipping-wc-method.php:1118
+msgid "Smart Send \"%1$s\": no rate added - cart weight %2$s %3$s did not match any weight table row."
+msgstr ""
+
+#. translators: 1: shipping method title, 2: customer role.
+#: includes/class-ss-shipping-wc-method.php:1233
+msgid "Smart Send \"%1$s\": shipping method is NOT available, because customer role \"%2$s\" is being excluded."
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1330
+msgid "Smart Send \"%s\": shipping method IS available, because ALL products belong to one of the shipping classes"
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1334
+msgid "Smart Send \"%s\": shipping method is NOT available, because ALL products belong to one of the shipping classes"
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1341
+msgid "Smart Send \"%s\": shipping method IS available, because at least ONE product belongs to one of the shipping classes"
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1345
+msgid "Smart Send \"%s\": shipping method is NOT available, because at least ONE product belongs to one of the shipping classes"
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1352
+msgid "Smart Send \"%s\": shipping method IS available, because ALL products do NOT belong to one of the shipping classes"
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1356
+msgid "Smart Send \"%s\": shipping method is NOT available, because ALL products do NOT belong to one of the shipping classes"
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1363
+msgid "Smart Send \"%s\": shipping method IS available, because at least ONE product does NOT belongs to one of the shipping classes"
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1367
+msgid "Smart Send \"%s\": shipping method is NOT available, because at least ONE product does NOT belongs to one of the shipping classes"
+msgstr ""
+
+#. translators: 1: shipping method title, 2: cart total, 3: minimum order amount.
+#: includes/class-ss-shipping-wc-method.php:1394
+msgid "Smart Send \"%1$s\": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed."
+msgstr ""
+
+#. translators: 1: shipping method title, 2: cart total, 3: minimum order amount.
+#: includes/class-ss-shipping-wc-method.php:1398
+msgid "Smart Send \"%1$s\": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed."
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1405
+msgid "Smart Send \"%s\": free shipping (flat fee) IS available, because a coupon is needed."
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1409
+msgid "Smart Send \"%s\": free shipping (flat fee) is NOT available, because a coupon is needed."
+msgstr ""
+
+#. translators: 1: shipping method title, 2: cart total, 3: minimum order amount.
+#: includes/class-ss-shipping-wc-method.php:1416
+msgid "Smart Send \"%1$s\": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed."
+msgstr ""
+
+#. translators: 1: shipping method title, 2: cart total, 3: minimum order amount.
+#: includes/class-ss-shipping-wc-method.php:1420
+msgid "Smart Send \"%1$s\": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed."
+msgstr ""
+
+#. translators: 1: shipping method title, 2: cart total, 3: minimum order amount.
+#: includes/class-ss-shipping-wc-method.php:1427
+msgid "Smart Send \"%1$s\": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed."
+msgstr ""
+
+#. translators: 1: shipping method title, 2: cart total, 3: minimum order amount.
+#: includes/class-ss-shipping-wc-method.php:1431
+msgid "Smart Send \"%1$s\": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed."
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1437
+msgid "Smart Send \"%s\": free shipping (flat fee) IS available, because it is always enabled."
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1442
+msgid "Smart Send \"%s\": free shipping (flat fee) is NOT available, because it is always disabled."
+msgstr ""
+
+#. translators: %s: shipping method title.
+#: includes/class-ss-shipping-wc-method.php:1447
+msgid "Smart Send \"%s\": free shipping (flat fee) is NOT available, because it is not available."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:58
+msgid "DEMO MODE: Generate label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:59
+msgid "Generate label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:64
+msgid "DEMO MODE: Generate return label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:65
+msgid "Generate return label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:154
+msgid "No orders selected, please select the orders to create labels for."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:160
+msgid "For now it is not possible to create labels for more than 5 orders at a time."
+msgstr ""
+
+#. translators: %s: WooCommerce order id.
+#: includes/class-ss-shipping-wc-order.php:176
+#: includes/class-ss-shipping-wc-order.php:761
+msgid "Order #%s: The order could not be found"
+msgstr ""
+
+#. translators: 1: WooCommerce order number, 2: link to download the return label.
+#: includes/class-ss-shipping-wc-order.php:200
+msgid "Order #%1$s: Return label created by Smart Send: %2$s"
+msgstr ""
+
+#. translators: 1: WooCommerce order number, 2: link to download the shipping label.
+#: includes/class-ss-shipping-wc-order.php:207
+msgid "Order #%1$s: Shipping label created by Smart Send: %2$s"
+msgstr ""
+
+#. translators: 1: WooCommerce order number, 2: error message.
+#: includes/class-ss-shipping-wc-order.php:234
+msgid "Order #%1$s: %2$s"
+msgstr ""
+
+#. translators: %s: WooCommerce order number.
+#: includes/class-ss-shipping-wc-order.php:250
+msgid "Order #%s: The selected order did not include a Send Smart shipping method"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:287
+msgid "Smart Send Shipping"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:322
+msgid "Order placed with a shipping method that is not from the Smart Send plugin"
+msgstr ""
+
+#. translators: %s: shipping method id and instance id.
+#: includes/class-ss-shipping-wc-order.php:351
+msgid "Debug id: %s"
+msgstr ""
+
+#. translators: %0.2f: total order weight in kg.
+#: includes/class-ss-shipping-wc-order.php:359
+msgid "Weight: %0.2f kg"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:365
+#: includes/frontend/class-ss-shipping-frontend.php:466
+msgid "Pick-up Point"
+msgstr ""
+
+#. translators: %s: pick-up point agent number.
+#: includes/class-ss-shipping-wc-order.php:368
+msgid "Agent No.: %s"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:397
+msgid "Split into parcels"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:444
+msgid "Read more"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:445
+msgid "Unique error id: "
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:446
+#: includes/class-ss-shipping-wc-order.php:1199
+msgid "Download shipping label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:447
+msgid "Download return label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:448
+msgid "Unexpected error"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:663
+msgid "The agent number entered, %s, was not found."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:917
+msgid "Return shipping label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:917
+msgid "Shipping label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:924
+msgid "Tracking number"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:940
+msgid "Shipment id is empty"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:944
+msgid "Label data empty"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:952
+msgid "Label file cannot be saved"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:1197
+msgid "Download return shipping label"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:1246
+msgid "DEMO MODE: Smart Send - Generate Labels"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:1247
+msgid "DEMO MODE: Smart Send - Generate Return Labels"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:1252
+msgid "Smart Send - Generate Labels"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-order.php:1253
+msgid "Smart Send - Generate Return Labels"
+msgstr ""
+
+#. translators: %s: error message from the Smart Send API.
+#: includes/class-ss-shipping-wc-order.php:1303
+msgid "Error combining shipping labels: %s"
+msgstr ""
+
+#. translators: %s: list of order numbers, each prefixed with #.
+#: includes/class-ss-shipping-wc-order.php:1319
+msgid "Orders: #%s"
+msgstr ""
+
+#. translators: 1: number of orders, 2: URL of the combined PDF file.
+#: includes/class-ss-shipping-wc-order.php:1328
+msgid "Shipping labels created by Smart Send for %1$s order: <a href=\"%2$s\" target=\"_blank\">Download combined pdf</a>"
+msgid_plural "Shipping labels created by Smart Send for %1$s orders: <a href=\"%2$s\" target=\"_blank\">Download combined pdf</a>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/class-ss-shipping-wc-product.php:42
+msgid "Select country"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-product.php:46
+msgid "Country of origin"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-product.php:47
+msgid "ISO3166-alpha2 code of the country where the item was produced"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-product.php:56
+msgid "Customs description"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-product.php:59
+msgid "Example: T-shirt"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-product.php:66
+msgid "Harmonized Tariff Schedule"
+msgstr ""
+
+#: includes/class-ss-shipping-wc-product.php:67
+msgid "Harmonized Tariff Schedule is a number assigned to every possible commodity that can be imported or exported from any country."
+msgstr ""
+
+#: includes/class-ss-shipping-wc-product.php:70
+msgid "Example: 12345678"
+msgstr ""
+
+#: includes/frontend/class-ss-shipping-frontend.php:88
+msgid "- Select Pick-up Point -"
+msgstr ""
+
+#: includes/frontend/class-ss-shipping-frontend.php:137
+msgid "Shipping to closest pick-up point"
+msgstr ""
+
+#: includes/frontend/class-ss-shipping-frontend.php:141
+msgid "Enter shipping information"
+msgstr ""
+
+#. translators: 1: number of pick-up points found, 2: carrier code.
+#: includes/frontend/class-ss-shipping-frontend.php:225
+msgid "Smart Send: found %1$d %2$s pick-up point near the entered address."
+msgid_plural "Smart Send: found %1$d %2$s pick-up points near the entered address."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: carrier code.
+#: includes/frontend/class-ss-shipping-frontend.php:277
+msgid "Smart Send: no %s pick-up points found near the entered address - falling back to \"Shipping to closest pick-up point\"."
+msgstr ""
+
+#. translators: 1: carrier code, 2: error code, 3: error message.
+#: includes/frontend/class-ss-shipping-frontend.php:288
+msgid "Smart Send: pick-up point lookup for %1$s failed with a transport error (%2$s): %3$s Falling back to \"Shipping to closest pick-up point\"."
+msgstr ""
+
+#. translators: 1: carrier code, 2: error code, 3: error message.
+#: includes/frontend/class-ss-shipping-frontend.php:292
+msgid "Smart Send: pick-up point lookup for %1$s failed with an API error (%2$s): %3$s Falling back to \"Shipping to closest pick-up point\"."
+msgstr ""
+
+#. translators: %s: carrier code.
+#: includes/frontend/class-ss-shipping-frontend.php:296
+msgid "Smart Send: pick-up point lookup for %s failed for an unknown reason. Falling back to \"Shipping to closest pick-up point\"."
+msgstr ""
+
+#. translators: %s: distance in meters.
+#: includes/frontend/class-ss-shipping-frontend.php:372
+msgid "%sm"
+msgstr ""
+
+#. translators: %s: distance in kilometers.
+#: includes/frontend/class-ss-shipping-frontend.php:375
+msgid "%skm"
+msgstr ""
+
+#: includes/frontend/class-ss-shipping-frontend.php:395
+msgid "A pick-up point must be selected."
+msgstr ""
+
+#: smart-send-logistics.php:187
+msgid "Validate API Token"
+msgstr ""
+
+#: smart-send-logistics.php:252
+msgid "View WooCommerce settings"
+msgstr ""
+
+#: smart-send-logistics.php:253
+msgid "Settings"
+msgstr ""
+
+#: smart-send-logistics.php:272
+#: smart-send-logistics.php:273
+msgid "Configuration guide"
+msgstr ""
+
+#: smart-send-logistics.php:276
+#: smart-send-logistics.php:277
+msgid "Support"
+msgstr ""
+
+#: smart-send-logistics.php:305
+msgid "Smart Send Shipping requires WooCommerce 2.6 and above to be installed and activated!"
+msgstr ""
+
+#: smart-send-logistics.php:330
+msgid "#Company, #Street"
+msgstr ""
+
+#: smart-send-logistics.php:331
+msgid "#Company, #Street, #Zipcode"
+msgstr ""
+
+#: smart-send-logistics.php:332
+msgid "#Company, #Street, #City"
+msgstr ""
+
+#: smart-send-logistics.php:333
+msgid "#Company, #Street, #Zipcode #City"
+msgstr ""
+
+#: smart-send-logistics.php:334
+msgid "#Company, #Zipcode"
+msgstr ""
+
+#: smart-send-logistics.php:335
+msgid "#Company, #Zipcode, #City"
+msgstr ""
+
+#: smart-send-logistics.php:336
+msgid "#Company, #City"
+msgstr ""
+
+#. translators: 1: email address of the connected Smart Send account, 2: website of the connected Smart Send account.
+#: smart-send-logistics.php:555
+msgid "API Token verified: Connected to Smart Send as %1$s from %2$s"
+msgstr ""
+
+#. translators: %s: error message returned by the Smart Send API.
+#: smart-send-logistics.php:563
+msgid "API Token validation failed: %s. Make sure to save the settings before validating."
+msgstr ""
+
+#: smart-send-logistics.php:568
+msgid "API Token validation failed: Please enter an API Token and save the settings before validating."
+msgstr ""
+
+#: smart-send-logistics.php:660
+msgid "Smart Send: no Smart Send rates offered for this package."
+msgstr ""
+
+#. translators: %s: list of offered rates, each as "label" (rate id, cost).
+#: smart-send-logistics.php:665
+msgid "Smart Send: rates offered for this package: %s."
+msgstr ""

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -327,28 +327,13 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 		public function get_agents_address_format() {
 			if ( empty( $this->agents_address_format ) ) {
 				$this->agents_address_format = array(
-					'1' => __( '#Company', 'smart-send-logistics' ) . ', ' . __( '#Street', 'smart-send-logistics' ),
-					'2' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
-						'#Street',
-						'smart-send-logistics'
-					) . ', ' . __( '#Zipcode', 'smart-send-logistics' ),
-					'3' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
-						'#Street',
-						'smart-send-logistics'
-					) . ', ' . __( '#City', 'smart-send-logistics' ),
-					'4' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
-						'#Street',
-						'smart-send-logistics'
-					) . ', ' . __( '#Zipcode', 'smart-send-logistics' ) . ' ' . __(
-						'#City',
-						'smart-send-logistics'
-					),
-					'5' => __( '#Company', 'smart-send-logistics' ) . ', ' . __( '#Zipcode', 'smart-send-logistics' ),
-					'6' => __( '#Company', 'smart-send-logistics' ) . ', ' . __(
-						'#Zipcode',
-						'smart-send-logistics'
-					) . ', ' . __( '#City', 'smart-send-logistics' ),
-					'7' => __( '#Company', 'smart-send-logistics' ) . ', ' . __( '#City', 'smart-send-logistics' ),
+					'1' => __( '#Company, #Street', 'smart-send-logistics' ),
+					'2' => __( '#Company, #Street, #Zipcode', 'smart-send-logistics' ),
+					'3' => __( '#Company, #Street, #City', 'smart-send-logistics' ),
+					'4' => __( '#Company, #Street, #Zipcode #City', 'smart-send-logistics' ),
+					'5' => __( '#Company, #Zipcode', 'smart-send-logistics' ),
+					'6' => __( '#Company, #Zipcode, #City', 'smart-send-logistics' ),
+					'7' => __( '#Company, #City', 'smart-send-logistics' ),
 				);
 			}
 
@@ -564,15 +549,21 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
         {
             check_ajax_referer('ss-test-connection', 'test_connection_nonce');
 
-            if ($this->validate_api_token()) {
-                $connection_msg = sprintf(__('API Token verified: Connected to Smart Send as %s from %s',
-                    'smart-send-logistics'), $this->get_api_handle()->getData()->email,
-                    $this->get_api_handle()->getData()->website);
-                $error = 0;
-            } elseif ($this->get_api_handle()) {
-                $connection_msg = sprintf(__('API Token validation failed: %s. Make sure to save the settings before validating.',
-                    'smart-send-logistics'), $this->get_api_handle()->getError()->message);
-                $error = 1;
+			if ( $this->validate_api_token() ) {
+				$connection_msg = sprintf(
+					/* translators: 1: email address of the connected Smart Send account, 2: website of the connected Smart Send account. */
+					__( 'API Token verified: Connected to Smart Send as %1$s from %2$s', 'smart-send-logistics' ),
+					$this->get_api_handle()->getData()->email,
+					$this->get_api_handle()->getData()->website
+				);
+				$error = 0;
+			} elseif ( $this->get_api_handle() ) {
+				$connection_msg = sprintf(
+					/* translators: %s: error message returned by the Smart Send API. */
+					__( 'API Token validation failed: %s. Make sure to save the settings before validating.', 'smart-send-logistics' ),
+					$this->get_api_handle()->getError()->message
+				);
+				$error = 1;
             } else {
                 $connection_msg = __('API Token validation failed: Please enter an API Token and save the settings before validating.',
                     'smart-send-logistics');
@@ -660,18 +651,22 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 
 			foreach ( $available_shipping_methods as $shipping_rate ) {
 				if ( $shipping_rate instanceof WC_Shipping_Rate && SS_SHIPPING_METHOD_ID === $shipping_rate->get_method_id() ) {
-					$offered[] = '"' . $shipping_rate->get_label() . '" (' . $shipping_rate->get_id() . ', cost ' . $shipping_rate->get_cost() . ')';
+					$offered[] = sprintf( '"%1$s" (%2$s, cost %3$s)', $shipping_rate->get_label(), $shipping_rate->get_id(), $shipping_rate->get_cost() );
 				}
 			}
 
 			if ( empty( $offered ) ) {
-				$message = 'Smart Send: no Smart Send rates offered for this package.';
+				$log_message    = 'Smart Send: no Smart Send rates offered for this package.';
+				$notice_message = __( 'Smart Send: no Smart Send rates offered for this package.', 'smart-send-logistics' );
 			} else {
-				$message = 'Smart Send: rates offered for this package: ' . implode( ', ', $offered ) . '.';
+				$rate_list   = implode( ', ', $offered );
+				$log_message = sprintf( 'Smart Send: rates offered for this package: %s.', $rate_list );
+				/* translators: %s: list of offered rates, each as "label" (rate id, cost). */
+				$notice_message = sprintf( __( 'Smart Send: rates offered for this package: %s.', 'smart-send-logistics' ), $rate_list );
 			}
 
-			SS_Shipping_Logger::debug( $message );
-			SS_Shipping_Checkout_Debug::add_notice( $message );
+			SS_Shipping_Logger::debug( $log_message, array( 'offered_rates' => $offered ) );
+			SS_Shipping_Checkout_Debug::add_notice( $notice_message );
 		}
     }
 

--- a/tests/Integration/NoticeTranslationTest.php
+++ b/tests/Integration/NoticeTranslationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * String building & i18n (#96): merchant-facing strings (including the
+ * checkout shipping debug bar) are full-sentence sprintf templates run
+ * through the translation functions, while log entries stay untranslated
+ * English so support can grep them across locales.
+ *
+ * NOTE: tests here assert on checkout notices and must run before the
+ * WC_DOING_AJAX-defining tests in ShippingDebugModeTest.php (alphabetical
+ * file order guarantees this). Reuses spy_on_logger() from LoggerTest.php
+ * and ss_policy_notices() from LoggingPolicyTest.php, both of which load
+ * earlier alphabetically.
+ */
+
+beforeEach(function (): void {
+    with_ss_settings();
+
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+    wc_clear_notices();
+    remember_cleanup_callback(function (): void {
+        wc_clear_notices();
+    });
+});
+
+it('renders the checkout debug notice through the translation functions while the log entry stays English', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    with_ss_settings(['ss_debug' => 'yes']); // Debug-level log entries require the plugin debug setting.
+    $spy = spy_on_logger();
+
+    $english = 'Smart Send: no Smart Send rates offered for this package.';
+    $translated = 'OVERSAT: ingen Smart Send-priser for denne pakke.';
+
+    $filter = function (string $translation, string $text, string $domain) use ($english, $translated): string {
+        if ('smart-send-logistics' === $domain && $english === $text) {
+            return $translated;
+        }
+
+        return $translation;
+    };
+    add_filter('gettext', $filter, 10, 3);
+    remember_cleanup_callback(function () use ($filter): void {
+        remove_filter('gettext', $filter, 10);
+    });
+
+    $other = new WC_Shipping_Rate('flat_rate:3', 'Flat rate', '10', [], 'flat_rate', 3);
+    SS_SHIPPING_WC()->ss_sort_shipping_methods(['flat_rate:3' => $other]);
+
+    // The merchant-facing debug bar notice is translated ...
+    expect(ss_policy_notices())->toContain($translated)
+        ->and(implode("\n", ss_policy_notices()))->not->toContain($english)
+        // ... while the log entry keeps the greppable English template.
+        ->and(implode("\n", array_map(
+            fn (array $entry): string => (string) $entry['message'],
+            array_filter($spy->entries, fn (array $entry): bool => 'debug' === $entry['level'])
+        )))->toContain($english)
+        ->and(implode("\n", array_map(
+            fn (array $entry): string => (string) $entry['message'],
+            $spy->entries
+        )))->not->toContain($translated);
+});
+
+it('substitutes values into a translated sprintf template on the debug bar', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    spy_on_logger();
+
+    $translated_template = 'OVERSAT: metode "%1$s" evalueret (%2$s, pris-id %3$s).';
+
+    $filter = function (string $translation, string $text, string $domain) use ($translated_template): string {
+        if ('smart-send-logistics' === $domain && 'Smart Send: evaluated method "%1$s" (%2$s, rate id %3$s).' === $text) {
+            return $translated_template;
+        }
+
+        return $translation;
+    };
+    add_filter('gettext', $filter, 10, 3);
+    remember_cleanup_callback(function () use ($filter): void {
+        remove_filter('gettext', $filter, 10);
+    });
+
+    $product = create_simple_product(['price' => 100, 'weight' => 2]);
+    $package = ss_policy_package([$product]);
+
+    $method = ss_policy_method([
+        'title'       => 'Oversat Metode',
+        'cost_weight' => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ], 99961);
+    $method->calculate_shipping($package);
+
+    expect(ss_policy_notices())->toContain(
+        'OVERSAT: metode "Oversat Metode" evalueret (postnord_agent, pris-id smart_send_shipping:99961).'
+    );
+});
+
+it('uses singular and plural pick-up point summaries via _n()', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    spy_on_logger();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent()]]);
+    });
+
+    SS_SHIPPING_WC()->ss_find_closest_agents_by_address('postnord', 'DK', '2300', 'Main Street 1', 'Copenhagen');
+
+    expect(ss_policy_notices())->toContain('Smart Send: found 1 postnord pick-up point near the entered address.');
+
+    wc_clear_notices();
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent(), sample_agent(['agent_no' => '5678'])]]);
+    });
+
+    SS_SHIPPING_WC()->ss_find_closest_agents_by_address('postnord', 'DK', '2300', 'Main Street 1', 'Copenhagen');
+
+    expect(ss_policy_notices())->toContain('Smart Send: found 2 postnord pick-up points near the entered address.');
+});


### PR DESCRIPTION
Implements #96 as the fifth PR of the v9 Phase 3 stack (stacked on #100 ← #99 ← #98 ← #97, targets `feature/issue-73-extension-api`).

## Policy applied

- **Display strings** (merchant-facing, incl. the checkout shipping debug bar per the decision on the issue): full-sentence `__()`/`esc_html__()` sprintf templates with numbered placeholders and `translators:` comments; plurals via `_n()`.
- **Log strings**: untranslated English sprintf templates, variable data duplicated into the context array.
- Call sites feeding both surfaces now pass an **English template to the logger and a translated template to the notice** — identical source text, so rendered output is unchanged under the default locale.
- Concatenation kept only for mechanical values (HTML markup around complete translated strings, URLs, `min-max unit` row labels).

## Audit summary per surface

| Surface | Converted | Already fine |
|---|---|---|
| `SS_Shipping_Checkout_Debug::add_notice()` (11 call sites) | 11 → translated sprintf templates (rate evaluation, free-shipping decision incl. all 7 `requires` cases, weight-row match, overlap explanation, shipping-class availability all 4 cases, role exclusion, pick-up lookup results/failures, rates-offered summary) | — |
| `SS_Shipping_Logger` | 10 concatenated messages → sprintf (rate trace ×4, `log_api_request` line, pick-up summary/failures ×5); contexts enriched (`offered_rates`, `matched_rows`, `carrier`, `error_code`, ...) | 12 call sites already fixed-template + context |
| `SS_Shipping_Admin_Notices` payloads (bulk actions) | 6 → single full-sentence templates (`Order #%s: ...` no longer glued from fragments); combined-labels message now `_n()` | renderer itself carries no strings |
| Order meta box | 4 (Debug id, Weight, Agent No., formatted agent address now escaped via `wp_kses_post`) | headings/buttons |
| Settings / connection feedback | connection test templates numbered + translators comments; dropdown display formats are now whole translatable strings (`'#Company, #Street'` instead of comma-gluing translated tokens); missing text domain fixed on "Select Default" description | remaining form-field descriptions were already whole sentences |
| Order notes | label/tracking note built with sprintf around mechanical markup | note text itself |
| `wc_add_notice` (checkout validation) | — | already a translated full sentence |

## Plural (`_n()`) cases

- Pick-up point summary on the debug bar: `found %1$d %2$s pick-up point(s) near the entered address.`
- Bulk combined-label notice: `Shipping labels created by Smart Send for %1$s order(s): ...`

## Notable wording/behaviour notes

- Rendered output is byte-identical under en_US except: the debug-bar pick-up summary now uses the singular for exactly 1 result (log line unchanged), the meta box shows `Agent No.: 1234` (space added after the colon), and demo-mode labels are now single translatable strings (`DEMO MODE: Generate label`) instead of a glued prefix — same rendered text.
- Translation keys changed for every converted string; existing (nonexistent) catalogs are unaffected since the plugin shipped no POT until now.

## POT regeneration

`smart-send-logistics/lang/smart-send-logistics.pot` is newly generated with `wp i18n make-pot` (261 entries, 2 plural forms). The plugin's `load_plugin_textdomain()` has always pointed at `lang/`, but the folder did not exist — this is the first shipped POT.

## Tests

- `composer test:integration`: **150 passed** (147 baseline + 3 new), zero assertion updates needed — English source templates were kept byte-identical to the previous concatenated output.
- New `NoticeTranslationTest`: proves a translated template renders with substituted values on the debug bar while the log entry stays English/greppable, plus singular/plural `_n()` coverage.
- `vendor/bin/phpcs` clean (zero new suppressions — `WordPress.WP.I18n` satisfied with real `translators:` comments); `composer phpcs:compat` clean (PHP 7.4 floor).

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)