### PR TITLE
Audit define_constants(): remove constants that aren't earning their place

### DIFF
--- a/smart-send-logistics/admin/class-ss-shipping-method-settings.php
+++ b/smart-send-logistics/admin/class-ss-shipping-method-settings.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'SS_Shipping_Method_Settings' ) ) :
 					'desc_tip'    => false,
 				),
 				'api_token_validate'                => array(
-					'title'             => SS_BUTTON_TEST_CONNECTION,
+					'title'             => __( 'Validate API Token', 'smart-send-logistics' ),
 					'type'              => 'button',
 					'custom_attributes' => array(
 						'onclick' => "ssTestConnection('#woocommerce_smart_send_shipping_api_token_validate');",

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -136,20 +136,24 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
             return self::$_instance;
         }
 
-        /**
-         * Define WC Constants.
-         */
-        private function define_constants()
-        {
-            $upload_dir = wp_upload_dir();
-
-			// Path related defines
-			$this->define( 'SS_SHIPPING_PLUGIN_FILE', __FILE__ );
+		/**
+		 * Define WC Constants.
+		 */
+		private function define_constants() {
+			// Path related defines, used throughout includes() and
+			// include_shipping_method_class() for require_once paths.
 			$this->define( 'SS_SHIPPING_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 			$this->define( 'SS_SHIPPING_PLUGIN_DIR_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 			$this->define( 'SS_SHIPPING_PLUGIN_DIR_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
+			// Mirrors the private $version property for the handful of files
+			// (API client, logger, method class, upgrade notices) that need
+			// the version number but aren't handed the SS_Shipping_WC instance.
 			$this->define( 'SS_SHIPPING_VERSION', $this->version );
-			$this->define( 'SS_SHIPPING_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );
+			// The literal shipping method id ('smart_send_shipping'). Kept as a
+			// global constant rather than a class constant on
+			// SS_Shipping_WC_Method: it's read from files loaded well before
+			// that class (this file, SS_Shipping_Logger), and that class is
+			// only require_once'd lazily once WooCommerce is confirmed active.
 			$this->define( 'SS_SHIPPING_METHOD_ID', 'smart_send_shipping' );
 		}
 
@@ -223,12 +227,6 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
          * Initialize the plugin.
 		 */
 		public function init() {
-			// Translated string constants must not be defined before the init
-			// action: since WordPress 6.7 any translation call for our text
-			// domain that runs earlier triggers a _load_textdomain_just_in_time
-			// "called incorrectly" notice.
-			$this->define( 'SS_BUTTON_TEST_CONNECTION', __( 'Validate API Token', 'smart-send-logistics' ) );
-
 			// The single bootstrap-level WooCommerce-active gate: `Requires Plugins: woocommerce`
 			// already guarantees WooCommerce on WP >= 6.5, so this check is belt-and-braces for
 			// older WordPress. Everything downstream of it assumes WooCommerce is present.
@@ -619,11 +617,13 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 				SS_Shipping_Logger::info( 'API token connection test succeeded', array( 'message' => $connection_msg ) );
 			}
 
-            wp_send_json(array(
-                'message'    => $connection_msg,
-                'error'      => $error,
-                'button_txt' => SS_BUTTON_TEST_CONNECTION,
-            ));
+			wp_send_json(
+				array(
+					'message'    => $connection_msg,
+					'error'      => $error,
+					'button_txt' => __( 'Validate API Token', 'smart-send-logistics' ),
+				)
+			);
 
             wp_die();
         }


### PR DESCRIPTION
## Summary

Reconsiders each of the 8 constants defined by `SS_Shipping_WC::define_constants()` / `init()` per #108, and removes the ones that no longer earn a global slot.

## Per-constant decision

| Constant | Decision | Reason |
|---|---|---|
| `SS_SHIPPING_PLUGIN_FILE` | **Removed** | No readers anywhere in the codebase (not even in `smart-send-logistics.php` itself — `declaring_hpos_compatibility()` uses `__FILE__` directly). No evidence of external/support-snippet usage either. |
| `SS_SHIPPING_PLUGIN_BASENAME` | Kept | Read in `plugin_action_links_{basename}` hook registration and the `upgrader_process_complete` file-match check. |
| `SS_SHIPPING_PLUGIN_DIR_PATH` | Kept | Used throughout `includes()` / `include_shipping_method_class()` for `require_once` paths — this is the mechanism that replaced the custom autoloader in #43. |
| `SS_SHIPPING_PLUGIN_DIR_URL` | Kept | Used for CSS/JS enqueue URLs across `admin/` and `public/`. |
| `SS_SHIPPING_VERSION` | Kept | Genuine cross-file reader: the API client (`Client::getVersion()`), the logger, `SS_Shipping_WC_Method` script enqueues, `SS_Plugins_Screen_Updates`, and the order meta box, plus an integration test (`LoggerTest`) — mirroring the private `$version` property into a constant is warranted here since these files aren't handed the `SS_Shipping_WC` instance. |
| `SS_SHIPPING_LOG_DIR` | **Removed** | Dead since #22/#94 — the logger delegates to `wc_get_logger()`, which manages its own directory under `WC_LOG_DIR`. No readers found anywhere. |
| `SS_SHIPPING_METHOD_ID` | Kept — see note below for #106 | Read from `smart-send-logistics.php` (hook registration, rate reporting) and `SS_Shipping_Logger` — both loaded well before the lazily-`require_once`'d `SS_Shipping_WC_Method` class. |
| `SS_BUTTON_TEST_CONNECTION` | **Removed** | Held a translated string in a constant, defined at `init()` priority 0 solely to work around the #58 too-early-textdomain bug. Both call sites (the `ss_test_connection_callback` AJAX handler and `SS_Shipping_Method_Settings::build_form_fields()`) only ever execute well after WordPress has fully booted — the AJAX handler runs on `wp_ajax_*`, and the settings builder is only constructed when WooCommerce lazily instantiates `SS_Shipping_WC_Method`. Replaced both call sites with a direct `__( 'Validate API Token', 'smart-send-logistics' )` call, which needs no init-timing workaround at all. |

## Note for #106 (dynamic hook names)

`SS_SHIPPING_METHOD_ID` stays as a **global constant**, not a class constant on `SS_Shipping_WC_Method`. It's read from `smart-send-logistics.php` and `SS_Shipping_Logger` — both loaded unconditionally, well before `SS_Shipping_WC_Method` is `require_once`'d lazily (only once WooCommerce is confirmed active, per the architecture notes in CLAUDE.md). Moving the id to a class constant on the method class would force those earlier-loaded files to pull in the method class just to read an id string, working against the deliberate lazy-loading design.

Since the value is always the literal `'smart_send_shipping'`, #106 is free to register `woocommerce_update_options_shipping_smart_send_shipping` as a literal hook name instead of concatenating `SS_SHIPPING_METHOD_ID` — the constant's only remaining job is being the single source of truth for that literal, not enabling runtime variability.

## Test plan

- [x] `composer test:integration` green (150 passed, same count as baseline) — no test read a removed constant
- [x] `vendor/bin/phpcs` clean
- [x] `composer phpcs:compat` clean
- [x] `phpcs.baseline.xml` untouched; affected lines (opening brace + docblock indentation in `define_constants()`, the `wp_send_json()` call) brought fully to WPCS style

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)