### PR TITLE
Consistent pickup-point terminology in display strings and new code

### DIFF
--- a/smart-send-logistics/admin/class-ss-shipping-method-catalog.php
+++ b/smart-send-logistics/admin/class-ss-shipping-method-catalog.php
@@ -35,11 +35,11 @@ if ( ! class_exists( 'SS_Shipping_Method_Catalog' ) ) :
 				'PostNord'          =>
 					array(
 						'postnord_agent'                   => __(
-							'PostNord: Select pick-up point (MyPack Collect)',
+							'PostNord: Select pickup point (MyPack Collect)',
 							'smart-send-logistics'
 						),
 						'postnord_collect'                 => __(
-							'PostNord: Closest pick-up point (MyPack Collect)',
+							'PostNord: Closest pickup point (MyPack Collect)',
 							'smart-send-logistics'
 						),
 						'postnord_homedelivery'            => __(
@@ -137,8 +137,8 @@ if ( ! class_exists( 'SS_Shipping_Method_Catalog' ) ) :
 					),
 				'GLS'               =>
 					array(
-						'gls_agent'        => __( 'GLS: Select pick-up point (ParcelShop)', 'smart-send-logistics' ),
-						'gls_collect'      => __( 'GLS: Closest pick-up point (ParcelShop)', 'smart-send-logistics' ),
+						'gls_agent'        => __( 'GLS: Select pickup point (ParcelShop)', 'smart-send-logistics' ),
+						'gls_collect'      => __( 'GLS: Closest pickup point (ParcelShop)', 'smart-send-logistics' ),
 						'gls_homedelivery' => __(
 							'GLS: Private delivery to address (PrivateDelivery)',
 							'smart-send-logistics'
@@ -152,11 +152,11 @@ if ( ! class_exists( 'SS_Shipping_Method_Catalog' ) ) :
 					),
 				'DAO'               =>
 					array(
-						'dao_agent'           => __( 'DAO: Select pick-up point (ParcelShop)', 'smart-send-logistics' ),
-						'dao_collect'         => __( 'DAO: Closest pick-up point (ParcelShop)', 'smart-send-logistics' ),
+						'dao_agent'           => __( 'DAO: Select pickup point (ParcelShop)', 'smart-send-logistics' ),
+						'dao_collect'         => __( 'DAO: Closest pickup point (ParcelShop)', 'smart-send-logistics' ),
 						'dao_doorstep'        => __( 'DAO: Leave at door (Direct)', 'smart-send-logistics' ),
-						'dao_dropoffagent'    => __( 'DAO: From pick-up point to pick-up point (Shop2Shop)', 'smart-send-logistics' ),
-						'dao_dropoffdoorstep' => __( 'DAO: From pick-up point to doorstep (ParcelShop to Direct)', 'smart-send-logistics' ),
+						'dao_dropoffagent'    => __( 'DAO: From pickup point to pickup point (Shop2Shop)', 'smart-send-logistics' ),
+						'dao_dropoffdoorstep' => __( 'DAO: From pickup point to doorstep (ParcelShop to Direct)', 'smart-send-logistics' ),
 					),
 				'Budbee'            =>
 						array(
@@ -169,19 +169,19 @@ if ( ! class_exists( 'SS_Shipping_Method_Catalog' ) ) :
 				'Bring'             =>
 					array(
 						'bring_agent'                   => __(
-							'Bring: Select pick-up point (PickUp Parcel / Serviceparcel)',
+							'Bring: Select pickup point (PickUp Parcel / Serviceparcel)',
 							'smart-send-logistics'
 						),
 						'bring_bulkagent'               => __(
-							'Bring: Select pick-up point, send as bulk (PickUp Parcel Bulk)',
+							'Bring: Select pickup point, send as bulk (PickUp Parcel Bulk)',
 							'smart-send-logistics'
 						),
 						'bring_collect'                 => __(
-							'Bring: Closest pick-up point (PickUp Parcel / Serviceparcel)',
+							'Bring: Closest pickup point (PickUp Parcel / Serviceparcel)',
 							'smart-send-logistics'
 						),
 						'bring_bulkcollect'             => __(
-							'Bring: Closest pick-up point, send as bulk (PickUp Parcel Bulk)',
+							'Bring: Closest pickup point, send as bulk (PickUp Parcel Bulk)',
 							'smart-send-logistics'
 						),
 						'bring_homedelivery'            => __(
@@ -289,7 +289,7 @@ if ( ! class_exists( 'SS_Shipping_Method_Catalog' ) ) :
 				'PostNord' =>
 					array(
 						'postnord_returndropoff' => __(
-							'PostNord: Return from pick-up point (Return Drop Off)',
+							'PostNord: Return from pickup point (Return Drop Off)',
 							'smart-send-logistics'
 						),
 						'postnord_returnpickup'  => __(
@@ -300,21 +300,21 @@ if ( ! class_exists( 'SS_Shipping_Method_Catalog' ) ) :
 				'GLS'      =>
 					array(
 						'gls_returndropoff' => __(
-							'GLS: Return from pick-up point (ShopReturn)',
+							'GLS: Return from pickup point (ShopReturn)',
 							'smart-send-logistics'
 						),
 					),
 				'DAO'      =>
 					array(
 						'dao_returndropoff' => __(
-							'DAO: Return from pick-up point (ParcelShop Return)',
+							'DAO: Return from pickup point (ParcelShop Return)',
 							'smart-send-logistics'
 						),
 					),
 				'Bring'    =>
 					array(
 						'bring_returndropoff' => __(
-							'Bring: Return from pick-up point (PickUp Parcel Return)',
+							'Bring: Return from pickup point (PickUp Parcel Return)',
 							'smart-send-logistics'
 						),
 						'bring_returnpickup'  => __(
@@ -344,7 +344,7 @@ if ( ! class_exists( 'SS_Shipping_Method_Catalog' ) ) :
 		}
 		/**
 		 * Get the human readable name of the Smart Send shipping method
-		 * Example: 'PostNord: Closest pick-up point (MyPack Collect)'
+		 * Example: 'PostNord: Closest pickup point (MyPack Collect)'
 		 *
 		 * Details: This method look for valid method with code $shipping_method_code
 		 * in the $shipping_method array from this SS_Shipping_WC_Method class

--- a/smart-send-logistics/admin/class-ss-shipping-method-settings.php
+++ b/smart-send-logistics/admin/class-ss-shipping-method-settings.php
@@ -156,16 +156,16 @@ if ( ! class_exists( 'SS_Shipping_Method_Settings' ) ) :
 					'desc_tip'    => true,
 				),
 				'title_pickup'                      => array(
-					'title'       => __( 'Pick-up Points', 'smart-send-logistics' ),
+					'title'       => __( 'Pickup Points', 'smart-send-logistics' ),
 					'type'        => 'title',
 					'description' => __(
-						'Settings for displaying pick-up points during checkout.',
+						'Settings for displaying pickup points during checkout.',
 						'smart-send-logistics'
 					),
 				),
 				'dropdown_display_format'           => array(
 					'title'    => __( 'Dropdown format', 'smart-send-logistics' ),
-					'desc'     => __( 'How the pick-up points are listed during checkout.', 'smart-send-logistics' ),
+					'desc'     => __( 'How the pickup points are listed during checkout.', 'smart-send-logistics' ),
 					'default'  => '4',
 					'type'     => 'select',
 					'class'    => 'wc-enhanced-select',
@@ -175,7 +175,7 @@ if ( ! class_exists( 'SS_Shipping_Method_Settings' ) ) :
 				'default_select_agent'              => array(
 					'title'       => __( 'Select Default', 'smart-send-logistics' ),
 					'label'       => __( 'Enable Select Default', 'smart-send-logistics' ),
-					'description' => __( 'This will automatically select the closest pick-up point and let the customer change to a different pick-up point. This means that the customer will not be forced to select a pick-up point before completing the order.', 'smart-send-logistics' ),
+					'description' => __( 'This will automatically select the closest pickup point and let the customer change to a different pickup point. This means that the customer will not be forced to select a pickup point before completing the order.', 'smart-send-logistics' ),
 					'default'     => 'no',
 					'type'        => 'checkbox',
 					'desc_tip'    => true,

--- a/smart-send-logistics/admin/class-ss-shipping-order-meta-box.php
+++ b/smart-send-logistics/admin/class-ss-shipping-order-meta-box.php
@@ -129,9 +129,9 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta_Box' ) ) :
 
 			// Display Agent No. field if pickup-point shipping method selected.
 			if ( false !== stripos( $shipping_method_type, 'agent' ) ) {
-				echo '<h3>' . esc_html__( 'Pick-up Point', 'smart-send-logistics' ) . '</h3>';
+				echo '<h3>' . esc_html__( 'Pickup Point', 'smart-send-logistics' ) . '</h3>';
 				echo '<strong>' . sprintf(
-					/* translators: %s: pick-up point agent number. */
+					/* translators: %s: pickup point agent number. */
 					esc_html__( 'Agent No.: %s', 'smart-send-logistics' ),
 					esc_html( (string) $ss_shipping_order_agent_no )
 				) . '</strong>';

--- a/smart-send-logistics/admin/class-ss-shipping-order-meta.php
+++ b/smart-send-logistics/admin/class-ss-shipping-order-meta.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Owns everything stored on (or read from) a WooCommerce order for the
  * Smart Send integration: the resolved shipping method id, the selected
- * pick-up point (agent) meta, the parcel split and the shipment ids.
+ * pickup point (agent) meta, the parcel split and the shipment ids.
  *
  * @package  SS_Shipping_Order_Meta
  * @category Shipping
@@ -187,7 +187,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 					if ( SS_SHIPPING_WC()->get_api_handle()->getAgentByAgentNo( $shipping_method_carrier, $shipping_address['country'], $ss_shipping_agent_no ) ) {
 
 						SS_Shipping_Logger::info(
-							'Pick-up point changed on order',
+							'Pickup point changed on order',
 							array(
 								'order_id' => $post_id,
 								'agent_no' => $ss_shipping_agent_no,
@@ -203,7 +203,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 					} else {
 
 						SS_Shipping_Logger::warning(
-							'Pick-up point not found - agent number rejected',
+							'Pickup point not found - agent number rejected',
 							array(
 								'order_id' => $post_id,
 								'agent_no' => $ss_shipping_agent_no,
@@ -212,7 +212,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 						);
 
 						$error_msg = sprintf(
-							/* translators: %s: the pick-up point agent number that was entered. */
+							/* translators: %s: the pickup point agent number that was entered. */
 							__(
 								'The agent number entered, %s, was not found.',
 								'smart-send-logistics'
@@ -343,7 +343,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 			// There are situations where the order has been deleted and cannot be found.
 			// We should gracefully handle this situation of failing to load the order.
 			if ( ! $order ) {
-				SS_Shipping_Logger::error( 'Failed to load WooCommerce order when deleting pick-up point meta - skipping', array( 'order_id' => $order_id ) );
+				SS_Shipping_Logger::error( 'Failed to load WooCommerce order when deleting pickup point meta - skipping', array( 'order_id' => $order_id ) );
 
 				return;
 			}

--- a/smart-send-logistics/admin/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/admin/class-ss-shipping-shipment.php
@@ -190,9 +190,9 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 			$receiver = $this->build_receiver();
 			$this->shipment->setReceiver( $receiver );
 
-			// Add the agent (pick-up point) to the shipment, if any.
+			// Add the agent (pickup point) to the shipment, if any.
 			$ss_agent = apply_filters(
-				'smart_send_order_agent',
+				'smart_send_order_pickup_point',
 				empty( $ss_args['ss_agent'] ) ? null : $ss_args['ss_agent'],
 				$order_id
 			);
@@ -323,7 +323,7 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 		}
 
 		/**
-		 * Build the agent (pick-up point) model from the stored agent object.
+		 * Build the agent (pickup point) model from the stored agent object.
 		 *
 		 * @param object $ss_agent The agent object stored on the order.
 		 *

--- a/smart-send-logistics/admin/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/admin/class-ss-shipping-wc-method.php
@@ -718,7 +718,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 
 		/**
 		 * Get the human readable name of the Smart Send shipping method
-		 * Example: 'PostNord: Closest pick-up point (MyPack Collect)'
+		 * Example: 'PostNord: Closest pickup point (MyPack Collect)'
 		 *
 		 * @see SS_Shipping_Method_Catalog::get_shipping_method_name()
 		 *

--- a/smart-send-logistics/includes/lib/Smartsend/Api.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Api.php
@@ -36,7 +36,7 @@ class Api extends Client
          *
          * @param int | timeout in seconds
          */
-        return apply_filters( 'smart_send_agent_timeout', self::AGENT_TIMEOUT);
+        return apply_filters( 'smart_send_pickup_point_timeout', self::AGENT_TIMEOUT);
     }
 
     public function getAgent($id)

--- a/smart-send-logistics/lang/smart-send-logistics.pot
+++ b/smart-send-logistics/lang/smart-send-logistics.pot
@@ -80,11 +80,11 @@ msgid "- Select Method -"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:37
-msgid "PostNord: Select pick-up point (MyPack Collect)"
+msgid "PostNord: Select pickup point (MyPack Collect)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:41
-msgid "PostNord: Closest pick-up point (MyPack Collect)"
+msgid "PostNord: Closest pickup point (MyPack Collect)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:45
@@ -180,11 +180,11 @@ msgid "PostNord: Speciel size pallet"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:140
-msgid "GLS: Select pick-up point (ParcelShop)"
+msgid "GLS: Select pickup point (ParcelShop)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:141
-msgid "GLS: Closest pick-up point (ParcelShop)"
+msgid "GLS: Closest pickup point (ParcelShop)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:142
@@ -204,11 +204,11 @@ msgid "GLS: Commercial delivery to address (BusinessParcel)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:155
-msgid "DAO: Select pick-up point (ParcelShop)"
+msgid "DAO: Select pickup point (ParcelShop)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:156
-msgid "DAO: Closest pick-up point (ParcelShop)"
+msgid "DAO: Closest pickup point (ParcelShop)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:157
@@ -216,11 +216,11 @@ msgid "DAO: Leave at door (Direct)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:158
-msgid "DAO: From pick-up point to pick-up point (Shop2Shop)"
+msgid "DAO: From pickup point to pickup point (Shop2Shop)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:159
-msgid "DAO: From pick-up point to doorstep (ParcelShop to Direct)"
+msgid "DAO: From pickup point to doorstep (ParcelShop to Direct)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:163
@@ -232,19 +232,19 @@ msgid "Burd: Home Delivery"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:171
-msgid "Bring: Select pick-up point (PickUp Parcel / Serviceparcel)"
+msgid "Bring: Select pickup point (PickUp Parcel / Serviceparcel)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:175
-msgid "Bring: Select pick-up point, send as bulk (PickUp Parcel Bulk)"
+msgid "Bring: Select pickup point, send as bulk (PickUp Parcel Bulk)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:179
-msgid "Bring: Closest pick-up point (PickUp Parcel / Serviceparcel)"
+msgid "Bring: Closest pickup point (PickUp Parcel / Serviceparcel)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:183
-msgid "Bring: Closest pick-up point, send as bulk (PickUp Parcel Bulk)"
+msgid "Bring: Closest pickup point, send as bulk (PickUp Parcel Bulk)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:187
@@ -304,7 +304,7 @@ msgid "Bifrost Logistics: Nordic Express Home"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:291
-msgid "PostNord: Return from pick-up point (Return Drop Off)"
+msgid "PostNord: Return from pickup point (Return Drop Off)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:295
@@ -312,15 +312,15 @@ msgid "PostNord: Return from address (Return Pickup)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:302
-msgid "GLS: Return from pick-up point (ShopReturn)"
+msgid "GLS: Return from pickup point (ShopReturn)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:309
-msgid "DAO: Return from pick-up point (ParcelShop Return)"
+msgid "DAO: Return from pickup point (ParcelShop Return)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:316
-msgid "Bring: Return from pick-up point (PickUp Parcel Return)"
+msgid "Bring: Return from pickup point (PickUp Parcel Return)"
 msgstr ""
 
 #: admin/class-ss-shipping-method-catalog.php:320
@@ -447,11 +447,11 @@ msgid "This will save a copy of the generated PDF label in the WordPress uploads
 msgstr ""
 
 #: admin/class-ss-shipping-method-settings.php:159
-msgid "Pick-up Points"
+msgid "Pickup Points"
 msgstr ""
 
 #: admin/class-ss-shipping-method-settings.php:161
-msgid "Settings for displaying pick-up points during checkout."
+msgid "Settings for displaying pickup points during checkout."
 msgstr ""
 
 #: admin/class-ss-shipping-method-settings.php:167
@@ -459,7 +459,7 @@ msgid "Dropdown format"
 msgstr ""
 
 #: admin/class-ss-shipping-method-settings.php:168
-msgid "How the pick-up points are listed during checkout."
+msgid "How the pickup points are listed during checkout."
 msgstr ""
 
 #: admin/class-ss-shipping-method-settings.php:176
@@ -471,7 +471,7 @@ msgid "Enable Select Default"
 msgstr ""
 
 #: admin/class-ss-shipping-method-settings.php:178
-msgid "This will automatically select the closest pick-up point and let the customer change to a different pick-up point. This means that the customer will not be forced to select a pick-up point before completing the order."
+msgid "This will automatically select the closest pickup point and let the customer change to a different pickup point. This means that the customer will not be forced to select a pickup point before completing the order."
 msgstr ""
 
 #: admin/class-ss-shipping-method-settings.php:184
@@ -769,10 +769,10 @@ msgstr ""
 
 #: admin/class-ss-shipping-order-meta-box.php:132
 #: public/class-ss-shipping-frontend.php:478
-msgid "Pick-up Point"
+msgid "Pickup Point"
 msgstr ""
 
-#. translators: %s: pick-up point agent number.
+#. translators: %s: pickup point agent number.
 #: admin/class-ss-shipping-order-meta-box.php:135
 msgid "Agent No.: %s"
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Unexpected error"
 msgstr ""
 
-#. translators: %s: the pick-up point agent number that was entered.
+#. translators: %s: the pickup point agent number that was entered.
 #: admin/class-ss-shipping-order-meta.php:216
 msgid "The agent number entered, %s, was not found."
 msgstr ""
@@ -988,42 +988,42 @@ msgid "Example: 12345678"
 msgstr ""
 
 #: public/class-ss-shipping-frontend.php:90
-msgid "- Select Pick-up Point -"
+msgid "- Select Pickup Point -"
 msgstr ""
 
 #: public/class-ss-shipping-frontend.php:142
-msgid "Shipping to closest pick-up point"
+msgid "Shipping to closest pickup point"
 msgstr ""
 
 #: public/class-ss-shipping-frontend.php:149
 msgid "Enter shipping information"
 msgstr ""
 
-#. translators: 1: number of pick-up points found, 2: carrier code.
+#. translators: 1: number of pickup points found, 2: carrier code.
 #: public/class-ss-shipping-frontend.php:236
-msgid "Smart Send: found %1$d %2$s pick-up point near the entered address."
-msgid_plural "Smart Send: found %1$d %2$s pick-up points near the entered address."
+msgid "Smart Send: found %1$d %2$s pickup point near the entered address."
+msgid_plural "Smart Send: found %1$d %2$s pickup points near the entered address."
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %s: carrier code.
 #: public/class-ss-shipping-frontend.php:288
-msgid "Smart Send: no %s pick-up points found near the entered address - falling back to \"Shipping to closest pick-up point\"."
+msgid "Smart Send: no %s pickup points found near the entered address - falling back to \"Shipping to closest pickup point\"."
 msgstr ""
 
 #. translators: 1: carrier code, 2: error code, 3: error message.
 #: public/class-ss-shipping-frontend.php:299
-msgid "Smart Send: pick-up point lookup for %1$s failed with a transport error (%2$s): %3$s Falling back to \"Shipping to closest pick-up point\"."
+msgid "Smart Send: pickup point lookup for %1$s failed with a transport error (%2$s): %3$s Falling back to \"Shipping to closest pickup point\"."
 msgstr ""
 
 #. translators: 1: carrier code, 2: error code, 3: error message.
 #: public/class-ss-shipping-frontend.php:303
-msgid "Smart Send: pick-up point lookup for %1$s failed with an API error (%2$s): %3$s Falling back to \"Shipping to closest pick-up point\"."
+msgid "Smart Send: pickup point lookup for %1$s failed with an API error (%2$s): %3$s Falling back to \"Shipping to closest pickup point\"."
 msgstr ""
 
 #. translators: %s: carrier code.
 #: public/class-ss-shipping-frontend.php:307
-msgid "Smart Send: pick-up point lookup for %s failed for an unknown reason. Falling back to \"Shipping to closest pick-up point\"."
+msgid "Smart Send: pickup point lookup for %s failed for an unknown reason. Falling back to \"Shipping to closest pickup point\"."
 msgstr ""
 
 #. translators: %s: distance in meters.
@@ -1037,7 +1037,7 @@ msgid "%skm"
 msgstr ""
 
 #: public/class-ss-shipping-frontend.php:405
-msgid "A pick-up point must be selected."
+msgid "A pickup point must be selected."
 msgstr ""
 
 #: smart-send-logistics.php:230

--- a/smart-send-logistics/public/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/public/class-ss-shipping-frontend.php
@@ -34,12 +34,12 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 		}
 
 		/**
-		 * Display the pick-up points next to the Smart Send method
+		 * Display the pickup points next to the Smart Send method
 		 */
 		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $index is part of the woocommerce_after_shipping_rate hook signature.
 		public function display_ss_pickup_points( $method, $index ) {
 
-			// Only display agents on checkout
+			// Only display pickup points on checkout
 			if ( ! is_checkout() ) {
 				return;
 			}
@@ -79,68 +79,68 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 
 					$carrier = SS_SHIPPING_WC()->get_shipping_method_carrier( $meta_data['smart_send_shipping_method'] );
 
-					$ss_agents = $this->find_closest_agents_by_address( $carrier, $country, $postal_code, $city, $street );
+					$ss_pickup_points = $this->find_closest_agents_by_address( $carrier, $country, $postal_code, $city, $street );
 
-					if ( ! empty( $ss_agents ) ) {
+					if ( ! empty( $ss_pickup_points ) ) {
 
 						$ss_setting = SS_SHIPPING_WC()->get_ss_shipping_settings();
 
-						$ss_agent_options = array();
+						$pickup_point_options = array();
 						if ( ! isset( $ss_setting['default_select_agent'] ) || 'no' == $ss_setting['default_select_agent'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #43 move.
-							$ss_agent_options[0] = __(
-								'- Select Pick-up Point -',
+							$pickup_point_options[0] = __(
+								'- Select Pickup Point -',
 								'smart-send-logistics'
 							);
 						}
 
-						foreach ( $ss_agents as $key => $agent ) {
-							$formatted_address = $this->get_formatted_address( $agent );
+						foreach ( $ss_pickup_points as $key => $pickup_point ) {
+							$formatted_address = $this->get_formatted_address( $pickup_point );
 
 							/*
-							 * Filter the label shown for a pick-up point in the
+							 * Filter the label shown for a pickup point in the
 							 * checkout drop-down.
 							 *
 							 * @since 9.0.0
 							 *
 							 * @param string $formatted_address The label formatted per the "Dropdown display format" setting.
-							 * @param object $agent             The pick-up point (agent_no, company, address_line1, postal_code, city, country, distance, ...).
+							 * @param object $pickup_point      The pickup point (agent_no, company, address_line1, postal_code, city, country, distance, ...).
 							 *
 							 * @return string The option label to render.
 							 */
-							$ss_agent_options[ $agent->agent_no ] = apply_filters( 'smart_send_agent_option_label', $formatted_address, $agent );
+							$pickup_point_options[ $pickup_point->agent_no ] = apply_filters( 'smart_send_pickup_point_option_label', $formatted_address, $pickup_point );
 						}
 
 						/*
-						 * Filter which pick-up point is pre-selected in the
+						 * Filter which pickup point is pre-selected in the
 						 * checkout drop-down. Return the agent_no of one of the
-						 * found pick-up points to pre-select it; return an empty
+						 * found pickup points to pre-select it; return an empty
 						 * string to keep the default behaviour (the first option,
-						 * which is the "- Select Pick-up Point -" placeholder
-						 * unless the "Default select agent" setting is enabled).
+						 * which is the "- Select Pickup Point -" placeholder
+						 * unless the "Select Default" setting is enabled).
 						 *
 						 * @since 9.0.0
 						 *
-						 * @param string   $default_agent_no The pre-selected agent_no ('' selects the first option).
-						 * @param object[] $ss_agents        The pick-up points shown in the drop-down.
+						 * @param string   $default_pickup_point_no The pre-selected agent_no ('' selects the first option).
+						 * @param object[] $ss_pickup_points        The pickup points shown in the drop-down.
 						 *
 						 * @return string The agent_no to pre-select, or '' for the first option.
 						 */
-						$default_agent_no = apply_filters( 'smart_send_default_selected_agent', '', $ss_agents );
+						$default_pickup_point_no = apply_filters( 'smart_send_default_selected_pickup_point', '', $ss_pickup_points );
 
 						woocommerce_form_field(
 							'ss_shipping_store_pickup',
 							array(
 								'type'        => 'select',
-								'options'     => $ss_agent_options,
+								'options'     => $pickup_point_options,
 								'input_class' => array( 'ss-agent-list' ),
-								'default'     => $default_agent_no,
+								'default'     => $default_pickup_point_no,
 							)
 						);
 
 					} else {
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-existing static translated string in static markup; escaping is a behaviour change out of scope for the #43 move.
 						echo '<div class="woocommerce-info ss-agent-info">' . __(
-							'Shipping to closest pick-up point',
+							'Shipping to closest pickup point',
 							'smart-send-logistics'
 						) . '</div>';
 					}
@@ -156,7 +156,7 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 		}
 
 		/**
-		 * Find the closest agents by address
+		 * Find the closest pickup points by address
 		 *
 		 * @param $carrier string | unique carrier code
 		 * @param $country string | ISO3166-A2 Country code
@@ -169,16 +169,16 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 		public function find_closest_agents_by_address( $carrier, $country, $postal_code, $city, $street ) {
 			/*
 			 * Filter the search parameters used when looking up the closest
-			 * pick-up points at checkout, before the API call is made.
+			 * pickup points at checkout, before the API call is made.
 			 *
-			 * The number of returned pick-up points is determined by the API
-			 * and cannot be requested here; use the smart_send_agents_found
+			 * The number of returned pickup points is determined by the API
+			 * and cannot be requested here; use the smart_send_pickup_points_found
 			 * filter to trim the returned list.
 			 *
 			 * @since 9.0.0
 			 *
 			 * @param array $search_params {
-			 *     The pick-up point search parameters.
+			 *     The pickup point search parameters.
 			 *
 			 *     @type string      $carrier     Unique carrier code (e.g. 'postnord').
 			 *     @type string      $country     ISO3166-A2 country code.
@@ -190,7 +190,7 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 			 * @return array The search parameters to use for the lookup.
 			 */
 			$search_params = apply_filters(
-				'smart_send_agent_search_params',
+				'smart_send_pickup_point_search_params',
 				array(
 					'carrier'     => $carrier,
 					'country'     => $country,
@@ -206,48 +206,48 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 			// are logged by the client's request logger.
 			if ( SS_SHIPPING_WC()->get_api_handle()->findClosestAgentByAddress( $carrier, $search_params['country'], $search_params['postal_code'], $search_params['city'], $search_params['street'] ) ) {
 
-				$ss_agents = SS_SHIPPING_WC()->get_api_handle()->getData();
+				$ss_pickup_points = SS_SHIPPING_WC()->get_api_handle()->getData();
 
 				/*
-				 * Filter the pick-up points returned by the lookup before they
+				 * Filter the pickup points returned by the lookup before they
 				 * are cached in the session and rendered in the checkout
 				 * drop-down. Return a smaller (or re-ordered) array to limit
 				 * or re-rank the choices offered to the customer.
 				 *
 				 * @since 9.0.0
 				 *
-				 * @param object[] $ss_agents     The pick-up points returned by the API.
+				 * @param object[] $ss_pickup_points     The pickup points returned by the API.
 				 * @param array    $search_params The (filtered) search parameters used for the lookup.
 				 *
-				 * @return object[] The pick-up points to cache and render.
+				 * @return object[] The pickup points to cache and render.
 				 */
-				$ss_agents = apply_filters( 'smart_send_agents_found', $ss_agents, $search_params );
+				$ss_pickup_points = apply_filters( 'smart_send_pickup_points_found', $ss_pickup_points, $search_params );
 
 				SS_Shipping_Logger::debug(
-					sprintf( 'Smart Send: found %1$d %2$s pick-up points near the entered address.', count( $ss_agents ), $carrier ),
+					sprintf( 'Smart Send: found %1$d %2$s pickup points near the entered address.', count( $ss_pickup_points ), $carrier ),
 					array(
 						'carrier'      => $carrier,
-						'result_count' => count( $ss_agents ),
+						'result_count' => count( $ss_pickup_points ),
 					)
 				);
 				SS_Shipping_Checkout_Debug::add_notice(
 					sprintf(
-						/* translators: 1: number of pick-up points found, 2: carrier code. */
+						/* translators: 1: number of pickup points found, 2: carrier code. */
 						_n(
-							'Smart Send: found %1$d %2$s pick-up point near the entered address.',
-							'Smart Send: found %1$d %2$s pick-up points near the entered address.',
-							count( $ss_agents ),
+							'Smart Send: found %1$d %2$s pickup point near the entered address.',
+							'Smart Send: found %1$d %2$s pickup points near the entered address.',
+							count( $ss_pickup_points ),
 							'smart-send-logistics'
 						),
-						count( $ss_agents ),
+						count( $ss_pickup_points ),
 						$carrier
 					)
 				);
 
-				// Save all of the agents in sessions.
-				WC()->session->set( 'ss_shipping_agents', $ss_agents );
+				// Save all of the pickup points in the session.
+				WC()->session->set( 'ss_shipping_agents', $ss_pickup_points );
 
-				return $ss_agents;
+				return $ss_pickup_points;
 			} else {
 				$this->report_agent_lookup_failure( $carrier, SS_SHIPPING_WC()->get_api_handle()->getError() );
 
@@ -256,11 +256,11 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 		}
 
 		/**
-		 * Log why a pick-up point lookup failed and surface the reason in
+		 * Log why a pickup point lookup failed and surface the reason in
 		 * WooCommerce's shipping debug mode.
 		 *
-		 * The checkout falls back to the "Shipping to closest pick-up point"
-		 * text whenever no agents are available. That fallback hides several
+		 * The checkout falls back to the "Shipping to closest pickup point"
+		 * text whenever no pickup points are available. That fallback hides several
 		 * distinct causes, so this classifies the failure (transport error,
 		 * API error response, empty result) and reports it: always to the log
 		 * (error level for failures, debug level for an empty result) and via
@@ -276,16 +276,16 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 			$message = ( is_object( $error ) && isset( $error->message ) && is_scalar( $error->message ) ) ? (string) $error->message : '';
 
 			if ( 'NoResults' === $code ) {
-				// Not an error: the API answered, there are just no pick-up
+				// Not an error: the API answered, there are just no pickup
 				// points near the entered address.
 				SS_Shipping_Logger::debug(
-					sprintf( 'Smart Send: no %s pick-up points found near the entered address - falling back to "Shipping to closest pick-up point".', $carrier ),
+					sprintf( 'Smart Send: no %s pickup points found near the entered address - falling back to "Shipping to closest pickup point".', $carrier ),
 					array( 'carrier' => $carrier )
 				);
 				SS_Shipping_Checkout_Debug::add_notice(
 					sprintf(
 						/* translators: %s: carrier code. */
-						__( 'Smart Send: no %s pick-up points found near the entered address - falling back to "Shipping to closest pick-up point".', 'smart-send-logistics' ),
+						__( 'Smart Send: no %s pickup points found near the entered address - falling back to "Shipping to closest pickup point".', 'smart-send-logistics' ),
 						$carrier
 					)
 				);
@@ -294,17 +294,17 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 			}
 
 			if ( 0 === strpos( $code, 'transport-' ) ) {
-				$log_message = sprintf( 'Smart Send: pick-up point lookup for %1$s failed with a transport error (%2$s): %3$s Falling back to "Shipping to closest pick-up point".', $carrier, $code, $message );
+				$log_message = sprintf( 'Smart Send: pickup point lookup for %1$s failed with a transport error (%2$s): %3$s Falling back to "Shipping to closest pickup point".', $carrier, $code, $message );
 				/* translators: 1: carrier code, 2: error code, 3: error message. */
-				$notice_message = sprintf( __( 'Smart Send: pick-up point lookup for %1$s failed with a transport error (%2$s): %3$s Falling back to "Shipping to closest pick-up point".', 'smart-send-logistics' ), $carrier, $code, $message );
+				$notice_message = sprintf( __( 'Smart Send: pickup point lookup for %1$s failed with a transport error (%2$s): %3$s Falling back to "Shipping to closest pickup point".', 'smart-send-logistics' ), $carrier, $code, $message );
 			} elseif ( '' !== $code || '' !== $message ) {
-				$log_message = sprintf( 'Smart Send: pick-up point lookup for %1$s failed with an API error (%2$s): %3$s Falling back to "Shipping to closest pick-up point".', $carrier, $code, $message );
+				$log_message = sprintf( 'Smart Send: pickup point lookup for %1$s failed with an API error (%2$s): %3$s Falling back to "Shipping to closest pickup point".', $carrier, $code, $message );
 				/* translators: 1: carrier code, 2: error code, 3: error message. */
-				$notice_message = sprintf( __( 'Smart Send: pick-up point lookup for %1$s failed with an API error (%2$s): %3$s Falling back to "Shipping to closest pick-up point".', 'smart-send-logistics' ), $carrier, $code, $message );
+				$notice_message = sprintf( __( 'Smart Send: pickup point lookup for %1$s failed with an API error (%2$s): %3$s Falling back to "Shipping to closest pickup point".', 'smart-send-logistics' ), $carrier, $code, $message );
 			} else {
-				$log_message = sprintf( 'Smart Send: pick-up point lookup for %s failed for an unknown reason. Falling back to "Shipping to closest pick-up point".', $carrier );
+				$log_message = sprintf( 'Smart Send: pickup point lookup for %s failed for an unknown reason. Falling back to "Shipping to closest pickup point".', $carrier );
 				/* translators: %s: carrier code. */
-				$notice_message = sprintf( __( 'Smart Send: pick-up point lookup for %s failed for an unknown reason. Falling back to "Shipping to closest pick-up point".', 'smart-send-logistics' ), $carrier );
+				$notice_message = sprintf( __( 'Smart Send: pickup point lookup for %s failed for an unknown reason. Falling back to "Shipping to closest pickup point".', 'smart-send-logistics' ), $carrier );
 			}
 
 			SS_Shipping_Logger::error(
@@ -321,7 +321,7 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 		/**
 		 * Get the formatted address to display on the frontend
 		 */
-		protected function get_formatted_address( $agent, $format_id = 0 ) {
+		protected function get_formatted_address( $pickup_point, $format_id = 0 ) {
 
 			if ( 0 == $format_id ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #43 move.
 				// Find the setting
@@ -366,23 +366,23 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 			);
 
 			$place_holders_vals = array(
-				$agent->agent_no,
-				$agent->company,
-				$agent->address_line1,
-				$agent->postal_code,
-				$agent->city,
-				$agent->country,
+				$pickup_point->agent_no,
+				$pickup_point->company,
+				$pickup_point->address_line1,
+				$pickup_point->postal_code,
+				$pickup_point->city,
+				$pickup_point->country,
 			);
 
 			$formatted_address = str_replace( $place_holders, $place_holders_vals, $address_format );
 
-			if ( ! empty( $agent->distance ) && $format_id > 0 ) {
-				if ( $agent->distance < 1 ) {
+			if ( ! empty( $pickup_point->distance ) && $format_id > 0 ) {
+				if ( $pickup_point->distance < 1 ) {
 					/* translators: %s: distance in meters. */
-					$formatted_distance = sprintf( __( '%sm', 'smart-send-logistics' ), number_format( $agent->distance * 1000, 0, '.', '' ) );
+					$formatted_distance = sprintf( __( '%sm', 'smart-send-logistics' ), number_format( $pickup_point->distance * 1000, 0, '.', '' ) );
 				} else {
 					/* translators: %s: distance in kilometers. */
-					$formatted_distance = sprintf( __( '%skm', 'smart-send-logistics' ), number_format( $agent->distance, 2, '.', '' ) );
+					$formatted_distance = sprintf( __( '%skm', 'smart-send-logistics' ), number_format( $pickup_point->distance, 2, '.', '' ) );
 				}
 				$formatted_address = sprintf( '%1$s: %2$s', $formatted_distance, $formatted_address );
 			}
@@ -400,9 +400,9 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 				return;
 			}
 
-			// If agent drop down exists and is empty, cannot checkout
+			// If pickup point drop down exists and is empty, cannot checkout
 			if ( isset( $_POST['ss_shipping_store_pickup'] ) && empty( $_POST['ss_shipping_store_pickup'] ) ) {
-				wc_add_notice( __( 'A pick-up point must be selected.', 'smart-send-logistics' ), 'error' );
+				wc_add_notice( __( 'A pickup point must be selected.', 'smart-send-logistics' ), 'error' );
 				return;
 			}
 			// phpcs:enable WordPress.Security.NonceVerification.Missing
@@ -425,57 +425,57 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 
 			$ss_shipping_store_pickup = wc_clean( $_POST['ss_shipping_store_pickup'] );
 			// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput
-			$retrive_data = WC()->session->get( 'ss_shipping_agents' );
+			$retrieved_pickup_points = WC()->session->get( 'ss_shipping_agents' );
 
-			$selected_agent_no = 0;
-			if ( $retrive_data ) {
-				foreach ( $retrive_data as $agent_key => $agent_value ) {
-					// If agent selected for the order, save it
-					if ( $agent_value->agent_no == $ss_shipping_store_pickup ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #43 move.
+			$selected_pickup_point_no = 0;
+			if ( $retrieved_pickup_points ) {
+				foreach ( $retrieved_pickup_points as $pickup_point_key => $pickup_point_value ) {
+					// If pickup point selected for the order, save it
+					if ( $pickup_point_value->agent_no == $ss_shipping_store_pickup ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #43 move.
 
-						$selected_agent_no = $agent_value->agent_no;
-						$selected_agent    = $agent_value;
+						$selected_pickup_point_no = $pickup_point_value->agent_no;
+						$selected_pickup_point    = $pickup_point_value;
 						break;
 					}
 				}
 			}
 
-			// Saving posted agent information.
-			if ( ! empty( $selected_agent_no ) ) {
+			// Saving posted pickup point information.
+			if ( ! empty( $selected_pickup_point_no ) ) {
 				SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent_no(
 					$order_id,
-					$selected_agent_no
+					$selected_pickup_point_no
 				);
-				SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent( $order_id, $selected_agent );
+				SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent( $order_id, $selected_pickup_point );
 
 				SS_Shipping_Logger::info(
-					'Pick-up point selected at checkout',
+					'Pickup point selected at checkout',
 					array(
 						'order_id' => $order_id,
-						'agent_no' => $selected_agent_no,
+						'agent_no' => $selected_pickup_point_no,
 					)
 				);
 			}
 		}
 
 		/**
-		 * Display the Smart Sent Pick-up Point on Thank You order details
+		 * Display the Smart Sent Pickup Point on Thank You order details
 		 */
 		public function display_ss_shipping_agent( $order ) {
 
-			$order_id         = $this->getOrderId( $order );
-			$ordered_agent_no = SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_ss_shipping_order_agent_no( $order_id );
+			$order_id                = $this->getOrderId( $order );
+			$ordered_pickup_point_no = SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_ss_shipping_order_agent_no( $order_id );
 
-			if ( $ordered_agent_no ) {
+			if ( $ordered_pickup_point_no ) {
 
-				$ordered_agent = SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_ss_shipping_order_agent( $order_id );
+				$ordered_pickup_point = SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_ss_shipping_order_agent( $order_id );
 
-				$formatted_address = $this->get_formatted_address( $ordered_agent, -1 );
+				$formatted_address = $this->get_formatted_address( $ordered_pickup_point, -1 );
 				// Display in block instead of one line
 				$formatted_address = str_replace( ',', '<br/>', $formatted_address );
 
-				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-existing behaviour: the formatted pick-up point address deliberately carries <br/> markup; escaping is a behaviour change out of scope for the #43 move.
-				echo '<h2>' . __( 'Pick-up Point', 'smart-send-logistics' ) . '</h2>'
+				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-existing behaviour: the formatted pickup point address deliberately carries <br/> markup; escaping is a behaviour change out of scope for the #43 move.
+				echo '<h2>' . __( 'Pickup Point', 'smart-send-logistics' ) . '</h2>'
 					. '<address>' . $formatted_address . '</address>';
 				// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 			}

--- a/smart-send-logistics/readme.txt
+++ b/smart-send-logistics/readme.txt
@@ -5,7 +5,7 @@ Author: SmartSend
 Author URI: https://smartsend.io/
 Developer: SmartSend
 Developer URI: https://smartsend.io/
-Tags: shipping, pick-up-points, shipping-label, postnord, smart send
+Tags: shipping, pickup-points, shipping-label, postnord, smart send
 Requires at least: 3.0.1
 Tested up to: 7.0
 Stable tag: 8.2.0
@@ -20,7 +20,7 @@ Complete WooCommerce shipping solution for PostNord, GLS, DAO, Burd, Budbee and 
 
 == Description ==
 
-Complete shipping solution for PostNord, GLS, DAO, Budbee, Burd and Bring. Setup shipping methods with rates calculated based on products, shipping address, weight, subtotal, user roles, shipping classes and much more. Show pick-up points to the customer during checkout and create shipping labels directly from the WooCommerce admin panel.
+Complete shipping solution for PostNord, GLS, DAO, Budbee, Burd and Bring. Setup shipping methods with rates calculated based on products, shipping address, weight, subtotal, user roles, shipping classes and much more. Show pickup points to the customer during checkout and create shipping labels directly from the WooCommerce admin panel.
 
 From now on, everything is incorporated directly into your WooCommerce store.
 
@@ -55,22 +55,22 @@ Enable services for shipping methods:
 
 * Customer notification by email
 * Customer notification by SMS
-* Pick-up point (collect the parcel at a shop near the customer)
+* Pickup point (collect the parcel at a shop near the customer)
 * Flex delivery (leave parcel at specified location)
 * Home delivery
 * Handling of special good, eg food
 * TAX handling
 * Enable free delivery based on condition
 
-= Pick-up point =
-Let the customer choose a pick-up point close to them during checkout. The package will be delivered to the selected pick-up point, where the customer can collect the package at their own convenience.
+= Pickup point =
+Let the customer choose a pickup point close to them during checkout. The package will be delivered to the selected pickup point, where the customer can collect the package at their own convenience.
 
-* Nearest pick-up points based on entered shipping address
+* Nearest pickup points based on entered shipping address
 * Automatically updated list
 * User friendly dropdown list
 * One step/page checkout compatible
 
-Shipping to pick-up points are the most widely used shipping method due to it's flexibility and the reduced shipping cost.
+Shipping to pickup points are the most widely used shipping method due to it's flexibility and the reduced shipping cost.
 
 = Shipping labels =
 Create shipping labels directly from the backend by a single click. The information is automatically formatted and send to the carrier for processing. A PDF label is immediately shown and ready to print. Tracking information is automatically saved in the system and can be included in customer emails or can be sendt by text message.
@@ -122,36 +122,36 @@ The plugin implements a formal extension API of `smart_send_*` hooks: filters fo
     A filter to change the API endpoint the plugin talks to, e.g. to point at the Smart Send sandbox environment
 * **smart_send_sslverify**
     A filter to disable SSL certificate verification for API requests (only for local development)
-* **smart_send_agent_timeout**
-    A filter to change the timeout (seconds) used when searching for pick-up points on the checkout page
+* **smart_send_pickup_point_timeout**
+    A filter to change the timeout (seconds) used when searching for pickup points on the checkout page
 
-= Pick-up point lookup and selector (checkout) =
+= Pickup point lookup and selector (checkout) =
 
-* **smart_send_agent_search_params** (since 9.0.0)
-    A filter on the search parameters (carrier, country, postal_code, city, street) used to look up the closest pick-up points, before the API call is made
-* **smart_send_agents_found** (since 9.0.0)
-    A filter on the list of pick-up points returned by the lookup, before it is cached in the session and rendered - return fewer entries to limit the choices, or re-order them
-* **smart_send_agent_option_label** (since 9.0.0)
-    A filter on the label shown for each pick-up point in the checkout drop-down
-* **smart_send_default_selected_agent** (since 9.0.0)
-    A filter on which pick-up point is pre-selected in the checkout drop-down - return the agent_no of one of the found pick-up points
+* **smart_send_pickup_point_search_params** (since 9.0.0)
+    A filter on the search parameters (carrier, country, postal_code, city, street) used to look up the closest pickup points, before the API call is made
+* **smart_send_pickup_points_found** (since 9.0.0)
+    A filter on the list of pickup points returned by the lookup, before it is cached in the session and rendered - return fewer entries to limit the choices, or re-order them
+* **smart_send_pickup_point_option_label** (since 9.0.0)
+    A filter on the label shown for each pickup point in the checkout drop-down
+* **smart_send_default_selected_pickup_point** (since 9.0.0)
+    A filter on which pickup point is pre-selected in the checkout drop-down - return the agent_no of one of the found pickup points
 
-Example: show at most 5 pick-up points and pre-select the closest one:
+Example: show at most 5 pickup points and pre-select the closest one:
 
-    add_filter('smart_send_agents_found', function ($agents, $search_params) {
-        return array_slice($agents, 0, 5);
+    add_filter('smart_send_pickup_points_found', function ($pickup_points, $search_params) {
+        return array_slice($pickup_points, 0, 5);
     }, 10, 2);
 
-    add_filter('smart_send_default_selected_agent', function ($default_agent_no, $agents) {
-        return $agents ? $agents[0]->agent_no : $default_agent_no;
+    add_filter('smart_send_default_selected_pickup_point', function ($default_pickup_point_no, $pickup_points) {
+        return $pickup_points ? $pickup_points[0]->agent_no : $default_pickup_point_no;
     }, 10, 2);
 
 = Shipping label creation =
 
 * **smart_send_shipping_label_args**
-    A filter to modify the order parameters (carrier, method, pick-up point, parcel split) that are used when creating shipping labels
-* **smart_send_order_agent**
-    A filter to change the pick-up point (agent) used when creating a shipping label
+    A filter to modify the order parameters (carrier, method, pickup point, parcel split) that are used when creating shipping labels
+* **smart_send_order_pickup_point**
+    A filter to change the pickup point (agent) used when creating a shipping label
 * **smart_send_order_parcels** (since 9.0.0)
     A filter on the parcel split stored for the order, before the shipment payload is assembled - return an array of rows (id, name, value) to split the items into numbered boxes
 * **smart_send_order_receiver**
@@ -224,12 +224,12 @@ The following filters are inherited from WooCommerce and can be used as well:
 * **woocommerce_shipping_instance_form_fields_smart_send_shipping**
     A filter to override shipping method settings.
 
-The plugin shows the selected pick-up point relevant places using these two hooks:
+The plugin shows the selected pickup point relevant places using these two hooks:
 
 * **woocommerce_order_details_after_order_table**
-    Show the selected pick-up point below the table of order items
+    Show the selected pickup point below the table of order items
 * **woocommerce_email_after_order_table**
-   Show the selected pick-up point below the table of order items
+   Show the selected pickup point below the table of order items
 
 = Meta fields =
 
@@ -244,9 +244,9 @@ The following meta fields are used by the plugin:
 * **ss_shipping_order_parcels**
     Used for storing information how the orders items are split into parcels
 * **ss_shipping_order_agent_no**
-    Used for storing the id of the selected pick-up point
+    Used for storing the id of the selected pickup point
 * **_ss_shipping_order_agent**
-    Hidden field used for storing the address of the selected pick-up point
+    Hidden field used for storing the address of the selected pickup point
 * **_ss_shipping_label_id**
     Hidden field used for storing the unique Smart Send id of the generated shipping label
 * **_ss_shipping_return_label_id**
@@ -260,18 +260,18 @@ The following meta fields are used by the plugin:
 
 == Frequently Asked Questions ==
 
-= Why are no pick-up point shown at checkout? =
-Make sure, that the selected shipping method is "Select Pick-up Point".
+= Why are no pickup point shown at checkout? =
+Make sure, that the selected shipping method is "Select Pickup Point".
 
-= Info box: Shipping to closest pick-up point =
-This box appears when a "Select Pick-up Point" shipping method is selected, but no pick-up points were found. Check that the entered shipping address is valid, that pick-up points are possible in the selected region and that a valid API Token is entered in the plugins settings.
+= Info box: Shipping to closest pickup point =
+This box appears when a "Select Pickup Point" shipping method is selected, but no pickup points were found. Check that the entered shipping address is valid, that pickup points are possible in the selected region and that a valid API Token is entered in the plugins settings.
 
 = Info box: Enter shipping information =
-This box appears when a "Select Pick-up Point" shipping method is selected, but no shipping address is entered. Enter a valid shipping address so that the plugin can search for nearby pick-up points.
+This box appears when a "Select Pickup Point" shipping method is selected, but no shipping address is entered. Enter a valid shipping address so that the plugin can search for nearby pickup points.
 
 == Screenshots ==
 
-1. Show closest pick-up points during checkout
+1. Show closest pickup points during checkout
 2. Create PDF shipping labels from backend with just one click
 3. Save tracking information automatically after creating shipping labels
 4. Get detailed error description if something is incorrect
@@ -355,7 +355,7 @@ This box appears when a "Select Pick-up Point" shipping method is selected, but 
 * Add field name to error message when failing to create shipping labels
 * Add support for using multiple API Tokens on one site (useful for WPML and other plugins)
 * Update PostNord shipping method order
-* Remove input field to change pick-up point while creating a label
+* Remove input field to change pickup point while creating a label
 * Show upgrade notices in Wordpress Plugin list
 * Bugfix: Drop usage of deprecated methods get_order_currency() and get_total_shipping()
 * Bugfix: Order status was changed before saving meta data, tracking data and other important information
@@ -364,7 +364,7 @@ This box appears when a "Select Pick-up Point" shipping method is selected, but 
 * Bugfix: Invalid API endpoint for old cURL versions
 
 = 8.0.13 =
-* Bugfix: City was not used when looking for closest pick-up points
+* Bugfix: City was not used when looking for closest pickup points
 * Change from cURL to wp_remote_request
 
 = 8.0.12 =
@@ -377,7 +377,7 @@ This box appears when a "Select Pick-up Point" shipping method is selected, but 
 * Change WooCommerce minimum requirement to WC 2.7
 
 = 8.0.10 =
-* Add convenience wrapper for pick-up point function
+* Add convenience wrapper for pickup point function
 * Add PostNord shipping method: Private delivery to address Small (MyPack Home Small)
 
 = 8.0.9 =
@@ -395,13 +395,13 @@ This box appears when a "Select Pick-up Point" shipping method is selected, but 
 
 = 8.0.7 =
 * Add order weight to Smart Send meta box on admin order page
-* Bugfix: Some translation plugins caused the pick-up point to not display properly
+* Bugfix: Some translation plugins caused the pickup point to not display properly
 
 = 8.0.6 =
 * Add support for extra shipping methods from the plugin: vConnect PostNord Delivery Checkout
 
 = 8.0.5 =
-* Bugfix: Show selected pick-up point on order confirmation page and confirmation email
+* Bugfix: Show selected pickup point on order confirmation page and confirmation email
 * Changing default setting whether or not to include order comment on shipping labels
 * Make label links open in a new tab
 * Add carrier Bifrost Logistics
@@ -411,7 +411,7 @@ This box appears when a "Select Pick-up Point" shipping method is selected, but 
 * Fix unexpected error when no API Token is entered in the plugin settings
 
 = 8.0.3 =
-* Fix problem with pick-up point format
+* Fix problem with pickup point format
 
 = 8.0.2 =
 * Fix problem with demo-mode disabling not working
@@ -425,7 +425,7 @@ This box appears when a "Select Pick-up Point" shipping method is selected, but 
 * Using Shipping Zones instead of WooCommerce legacy shipping API
 * Plugin is not backwards compatible. All settings must be setup from scratch
 * Separates standard settings from the more advanced settings for simplicity
-* Includes more information about pick-up points in checkout page
+* Includes more information about pickup points in checkout page
 * Limit shipping methods by weight, price, user role, shipping zone, shipping class and much more
 
 = 7.2.0 =

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -392,9 +392,9 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
         }
 
         /**
-         * Get the human readable name of the Smart Send shipping method
-         * Example: 'PostNord: Closest pick-up point (MyPack Collect)'
-         *
+		 * Get the human readable name of the Smart Send shipping method
+		 * Example: 'PostNord: Closest pickup point (MyPack Collect)'
+		 *
          * Details: This method loops over all WC_Shipping methods and finds the
          * instance of SS_Shipping_WC_Method. It then takes the SS_Shipping_WC_Method
          * instance and finds the human readable shipping method name using this.

--- a/tests/Browser/SmartSendFlowsTest.php
+++ b/tests/Browser/SmartSendFlowsTest.php
@@ -4,7 +4,7 @@
  * End-to-end characterization of the three big Smart Send flows against a
  * running store:
  *
- *  - classic checkout with an agent method: pick-up point selector shown,
+ *  - classic checkout with an agent method: pickup point selector shown,
  *    a point chosen, order placed, agent shown on the thank-you page;
  *  - generating a label from the admin order screen;
  *  - the bulk "Generate Labels" action on two orders.
@@ -198,7 +198,7 @@ if (!$instance_id) {
     $created_instance = 1;
 }
 update_option('woocommerce_smart_send_shipping_' . $instance_id . '_settings', array(
-    'title' => 'Smart Send Pick-up Point',
+    'title' => 'Smart Send Pickup Point',
     'method' => 'postnord_agent',
     'return_method' => 'postnord_returndropoff',
     'auto_generate_return_label' => 'no',
@@ -210,7 +210,7 @@ update_option('woocommerce_smart_send_shipping_' . $instance_id . '_settings', a
     'cost_weight' => array(array('ss_min_weight' => '', 'ss_max_weight' => '', 'ss_cost_weight' => '29')),
 ));
 
-// A classic (shortcode) checkout page; the pick-up point selector only
+// A classic (shortcode) checkout page; the pickup point selector only
 // renders in the classic checkout.
 $page_id = wp_insert_post(array(
     'post_title'   => 'SS Classic Checkout',
@@ -245,7 +245,7 @@ $make_order = function () use ($product_id) {
     $order->set_address(array_merge($address, array('email' => 'ss-browser-test@smartsend.io', 'phone' => '+4512345678')), 'billing');
     $order->set_address($address, 'shipping');
     $item = new WC_Order_Item_Shipping();
-    $item->set_method_title('Smart Send Pick-up Point');
+    $item->set_method_title('Smart Send Pickup Point');
     $item->set_method_id('smart_send_shipping');
     $item->set_instance_id(1);
     $item->set_total('29');
@@ -350,7 +350,7 @@ beforeEach(function (): void {
     }
 });
 
-it('shows the pick-up point selector on classic checkout and stores the chosen agent on the order', function () {
+it('shows the pickup point selector on classic checkout and stores the chosen agent on the order', function () {
     $state = ss_browser_state();
 
     $page = visit(base_url('/?add-to-cart=' . $state['product_id']));
@@ -366,7 +366,7 @@ it('shows the pick-up point selector on classic checkout and stores the chosen a
         ->fill('#billing_email', 'ss-browser-test@smartsend.io');
 
     // Choose the Smart Send agent method; the checkout refreshes and the
-    // plugin renders the pick-up point dropdown (fed by the mocked API).
+    // plugin renders the pickup point dropdown (fed by the mocked API).
     // WooCommerce derives the radio id from the rate id
     // ('smart_send_shipping:N' -> 'smart_send_shippingN').
     $page->click('#shipping_method_0_smart_send_shipping' . $state['instance_id'])
@@ -384,10 +384,10 @@ it('shows the pick-up point selector on classic checkout and stores the chosen a
         // by their value and hang instead of failing.
         ->click('#place_order');
 
-    // Thank-you page: the frontend hook renders the stored pick-up point,
+    // Thank-you page: the frontend hook renders the stored pickup point,
     // which proves the agent meta ended up on the order.
     $page->assertSee('order has been received')
-        ->assertSee('Pick-up Point')
+        ->assertSee('Pickup Point')
         ->assertSee('Browser Test Shop')
         ->assertSee('Main Street 1');
 });
@@ -398,7 +398,7 @@ it('generates a shipping label from the admin order screen', function () {
     login_as_admin()
         ->navigate(base_url($state['order_a_edit_path']))
         ->assertSee('Smart Send Shipping')
-        ->assertSee('Pick-up Point')
+        ->assertSee('Pickup Point')
         ->assertSee('Browser Test Shop')
         ->click('#ss-shipping-label-button')
         ->assertSeeIn('#ss-label-created', 'Download shipping label');

--- a/tests/Integration/FrontendAgentDisplayTest.php
+++ b/tests/Integration/FrontendAgentDisplayTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Characterization tests for SS_Shipping_Frontend: the pick-up point block
+ * Characterization tests for SS_Shipping_Frontend: the pickup point block
  * on the thank-you page and in order emails, the checkout validation and
  * agent persistence, and the invalid-order guard from #60.
  */
@@ -36,7 +36,7 @@ it('hooks the agent display into the thank-you page and order emails', function 
         ->and(has_action('woocommerce_checkout_order_processed'))->not->toBeFalse();
 });
 
-it('renders the pick-up point block for an order with a selected agent', function () {
+it('renders the pickup point block for an order with a selected agent', function () {
     $product = create_simple_product(['price' => 100, 'weight' => 1]);
     $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_agent']);
 
@@ -46,7 +46,7 @@ it('renders the pick-up point block for an order with a selected agent', functio
 
     $output = capture_agent_display($order);
 
-    expect($output)->toContain('Pick-up Point')
+    expect($output)->toContain('Pickup Point')
         ->toContain('Corner Shop')
         ->toContain('Main Street 1')
         ->toContain('DK 2300 Copenhagen')
@@ -88,7 +88,7 @@ it('survives deleting the agent meta of an order that no longer exists', functio
     expect(true)->toBeTrue();
 });
 
-it('rejects checkout when the pick-up point dropdown is present but empty', function () {
+it('rejects checkout when the pickup point dropdown is present but empty', function () {
     if (is_null(WC()->cart)) {
         wc_load_cart();
     }
@@ -105,10 +105,10 @@ it('rejects checkout when the pick-up point dropdown is present but empty', func
     expect(wc_notice_count('error'))->toBe(1);
 
     $notices = wc_get_notices('error');
-    expect($notices[0]['notice'])->toBe('A pick-up point must be selected.');
+    expect($notices[0]['notice'])->toBe('A pickup point must be selected.');
 });
 
-it('accepts checkout when a pick-up point is selected', function () {
+it('accepts checkout when a pickup point is selected', function () {
     if (is_null(WC()->cart)) {
         wc_load_cart();
     }

--- a/tests/Integration/FrontendSelectorHooksTest.php
+++ b/tests/Integration/FrontendSelectorHooksTest.php
@@ -1,11 +1,14 @@
 <?php
 
 /*
- * Tests for the checkout pick-up point selector extension hooks added in
- * v9 (#73): smart_send_agent_search_params, smart_send_agents_found,
- * smart_send_agent_option_label and smart_send_default_selected_agent.
+ * Tests for the checkout pickup point selector extension hooks: the four
+ * added in v9 (#73) - smart_send_pickup_point_search_params,
+ * smart_send_pickup_points_found, smart_send_pickup_point_option_label and
+ * smart_send_default_selected_pickup_point - plus smart_send_pickup_point_timeout,
+ * which shipped in 8.2.0 (as smart_send_agent_timeout) and was renamed
+ * alongside the others in #105.
  *
- * Each test renders the pick-up point block the way checkout does (mocked
+ * Each test renders the pickup point block the way checkout does (mocked
  * Smart Send API) and asserts the hook fires with the documented params and
  * that its return value is respected.
  *
@@ -14,7 +17,7 @@
  */
 
 /**
- * Render the pick-up point block for a Smart Send agent rate the way
+ * Render the pickup point block for a Smart Send agent rate the way
  * checkout does: is_checkout() forced true, a posted shipping address, the
  * rate chosen in the session.
  */
@@ -53,7 +56,31 @@ beforeEach(function (): void {
     with_ss_settings();
 });
 
-it('passes the documented params to smart_send_agent_search_params and uses the filtered values', function () {
+it('lets smart_send_pickup_point_timeout change the timeout used for the pickup point lookup request', function () {
+    // This hook shipped in 8.2.0 as smart_send_agent_timeout and was renamed
+    // to smart_send_pickup_point_timeout in #105 - a breaking change for
+    // merchants already hooking the old name (see the v9 upgrade guide).
+    $capture = mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent()]]);
+    });
+
+    $filter = function ($timeout) {
+        expect($timeout)->toBe(4);
+
+        return 9;
+    };
+    add_filter('smart_send_pickup_point_timeout', $filter);
+    remember_cleanup_callback(function () use ($filter): void {
+        remove_filter('smart_send_pickup_point_timeout', $filter);
+    });
+
+    selector_hooks_render();
+
+    $request = end($capture->requests);
+    expect($request['timeout'])->toBe(9);
+});
+
+it('passes the documented params to smart_send_pickup_point_search_params and uses the filtered values', function () {
     $capture = mock_smart_send_api(function () {
         return ss_api_response(200, ['data' => [sample_agent()]]);
     });
@@ -72,9 +99,9 @@ it('passes the documented params to smart_send_agent_search_params and uses the 
 
         return $search_params;
     };
-    add_filter('smart_send_agent_search_params', $filter);
+    add_filter('smart_send_pickup_point_search_params', $filter);
     remember_cleanup_callback(function () use ($filter): void {
-        remove_filter('smart_send_agent_search_params', $filter);
+        remove_filter('smart_send_pickup_point_search_params', $filter);
     });
 
     $output = selector_hooks_render();
@@ -85,7 +112,7 @@ it('passes the documented params to smart_send_agent_search_params and uses the 
         ->and($output)->toContain('ss_shipping_store_pickup');
 });
 
-it('lets smart_send_agents_found trim the list before rendering and caching', function () {
+it('lets smart_send_pickup_points_found trim the list before rendering and caching', function () {
     mock_smart_send_api(function () {
         return ss_api_response(200, ['data' => [
             sample_agent(['agent_no' => '1111', 'company' => 'First Shop']),
@@ -97,12 +124,12 @@ it('lets smart_send_agents_found trim the list before rendering and caching', fu
         expect($ss_agents)->toHaveCount(2)
             ->and($search_params['carrier'])->toBe('postnord');
 
-        // Keep only the second pick-up point.
+        // Keep only the second pickup point.
         return [$ss_agents[1]];
     };
-    add_filter('smart_send_agents_found', $filter, 10, 2);
+    add_filter('smart_send_pickup_points_found', $filter, 10, 2);
     remember_cleanup_callback(function () use ($filter): void {
-        remove_filter('smart_send_agents_found', $filter, 10);
+        remove_filter('smart_send_pickup_points_found', $filter, 10);
     });
 
     $output = selector_hooks_render();
@@ -112,7 +139,7 @@ it('lets smart_send_agents_found trim the list before rendering and caching', fu
         ->and(WC()->session->get('ss_shipping_agents'))->toHaveCount(1);
 });
 
-it('lets smart_send_agent_option_label rewrite the drop-down option label', function () {
+it('lets smart_send_pickup_point_option_label rewrite the drop-down option label', function () {
     mock_smart_send_api(function () {
         return ss_api_response(200, ['data' => [sample_agent()]]);
     });
@@ -124,9 +151,9 @@ it('lets smart_send_agent_option_label rewrite the drop-down option label', func
 
         return 'Custom Label ' . $agent->agent_no;
     };
-    add_filter('smart_send_agent_option_label', $filter, 10, 2);
+    add_filter('smart_send_pickup_point_option_label', $filter, 10, 2);
     remember_cleanup_callback(function () use ($filter): void {
-        remove_filter('smart_send_agent_option_label', $filter, 10);
+        remove_filter('smart_send_pickup_point_option_label', $filter, 10);
     });
 
     $output = selector_hooks_render();
@@ -135,7 +162,7 @@ it('lets smart_send_agent_option_label rewrite the drop-down option label', func
         ->and($output)->not->toContain('Corner Shop');
 });
 
-it('lets smart_send_default_selected_agent pre-select a pick-up point', function () {
+it('lets smart_send_default_selected_pickup_point pre-select a pickup point', function () {
     mock_smart_send_api(function () {
         return ss_api_response(200, ['data' => [
             sample_agent(['agent_no' => '1111', 'company' => 'First Shop']),
@@ -149,9 +176,9 @@ it('lets smart_send_default_selected_agent pre-select a pick-up point', function
 
         return '2222';
     };
-    add_filter('smart_send_default_selected_agent', $filter, 10, 2);
+    add_filter('smart_send_default_selected_pickup_point', $filter, 10, 2);
     remember_cleanup_callback(function () use ($filter): void {
-        remove_filter('smart_send_default_selected_agent', $filter, 10);
+        remove_filter('smart_send_default_selected_pickup_point', $filter, 10);
     });
 
     $output = selector_hooks_render();
@@ -169,7 +196,7 @@ it('renders the drop-down unchanged when no selector hooks are registered', func
 
     // Placeholder first, no option pre-selected, default-formatted label.
     expect($output)->toContain('ss_shipping_store_pickup')
-        ->and($output)->toContain('- Select Pick-up Point -')
+        ->and($output)->toContain('- Select Pickup Point -')
         ->and($output)->not->toMatch('/value="1234"[^>]*selected/')
         ->and($output)->toContain('Corner Shop, Main Street 1, 2300 Copenhagen');
 });

--- a/tests/Integration/Helpers.php
+++ b/tests/Integration/Helpers.php
@@ -132,9 +132,10 @@ function mock_smart_send_api(?callable $responder = null): object
         }
 
         $capture->requests[] = [
-            'url'    => $url,
-            'method' => $args['method'] ?? null,
-            'body'   => $args['body'] ?? null,
+            'url'     => $url,
+            'method'  => $args['method'] ?? null,
+            'body'    => $args['body'] ?? null,
+            'timeout' => $args['timeout'] ?? null,
         ];
 
         return $responder($url, $args);
@@ -201,7 +202,7 @@ function ss_api_error_body(string $message = 'The given data was invalid.'): arr
 }
 
 /**
- * A pick-up point agent object as the plugin stores it in order meta.
+ * A pickup point agent object as the plugin stores it in order meta.
  */
 function sample_agent(array $overrides = []): object
 {

--- a/tests/Integration/LabelGenerationTest.php
+++ b/tests/Integration/LabelGenerationTest.php
@@ -144,7 +144,7 @@ it('auto-generates the return label after a successful normal label', function (
     $return_payload = json_decode($capture->requests[1]['body'], true);
     expect($return_payload['shipping_carrier'])->toBe('postnord')
         ->and($return_payload['shipping_method'])->toBe('returndropoff')
-        // Return shipments never include a pick-up point agent.
+        // Return shipments never include a pickup point agent.
         ->and($return_payload['agent'])->toBeNull();
 
     $fresh = wc_get_order($order->get_id());

--- a/tests/Integration/LoggingPolicyTest.php
+++ b/tests/Integration/LoggingPolicyTest.php
@@ -3,7 +3,7 @@
 /*
  * Logging policy (#92): the WooCommerce log is an audit trail of business
  * events at the info level (label created, order note added, tracking number
- * stored, pick-up point selected/changed) plus developer trace at the debug
+ * stored, pickup point selected/changed) plus developer trace at the debug
  * level, while the checkout shipping debug bar surfaces which Smart Send
  * rates ended up offered for the package and the overlapping-weight-row
  * outcome (the "uniqueness filtering": every matching weight row calls
@@ -155,7 +155,7 @@ it('logs "Return shipping label created" for return labels without a tracking ev
         ->and($infos)->not->toContain('Tracking number stored');
 });
 
-it('logs an info event when the shopper selects a pick-up point at checkout', function () {
+it('logs an info event when the shopper selects a pickup point at checkout', function () {
     $spy     = spy_on_logger();
     $product = create_simple_product(['price' => 100, 'weight' => 1]);
     $order   = create_order(['products' => [$product], 'shipping_method' => 'postnord_agent']);
@@ -169,7 +169,7 @@ it('logs an info event when the shopper selects a pick-up point at checkout', fu
 
     (new SS_Shipping_Frontend())->process_ss_pickup_points($order->get_id(), null);
 
-    $selected = ss_policy_entry($spy, 'Pick-up point selected at checkout');
+    $selected = ss_policy_entry($spy, 'Pickup point selected at checkout');
     expect($selected)->not->toBeNull()
         ->and($selected['level'])->toBe('info')
         ->and($selected['context']['order_id'])->toBe($order->get_id())
@@ -178,7 +178,7 @@ it('logs an info event when the shopper selects a pick-up point at checkout', fu
     expect(SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_ss_shipping_order_agent_no($order->get_id()))->toBe('1234');
 });
 
-it('logs an info event when the pick-up point is changed on an order', function () {
+it('logs an info event when the pickup point is changed on an order', function () {
     $spy = spy_on_logger();
     mock_smart_send_api(function () {
         return ss_api_response(200, ['data' => sample_agent(['agent_no' => '5678'])]);
@@ -191,7 +191,7 @@ it('logs an info event when the pick-up point is changed on an order', function 
 
     expect($result)->toBeTrue();
 
-    $changed = ss_policy_entry($spy, 'Pick-up point changed on order');
+    $changed = ss_policy_entry($spy, 'Pickup point changed on order');
     expect($changed)->not->toBeNull()
         ->and($changed['level'])->toBe('info')
         ->and($changed['context']['order_id'])->toBe($order->get_id())
@@ -213,7 +213,7 @@ it('logs a warning when the agent number is rejected, even with the debug settin
 
     expect($result)->toBeString();
 
-    $rejected = ss_policy_entry($spy, 'Pick-up point not found - agent number rejected');
+    $rejected = ss_policy_entry($spy, 'Pickup point not found - agent number rejected');
     expect($rejected)->not->toBeNull()
         ->and($rejected['level'])->toBe('warning')
         ->and($rejected['context']['agent_no'])->toBe('9999');
@@ -346,13 +346,13 @@ it('logs a not-available outcome when the cost calculation adds no rate', functi
         ->and($debugs)->toContain('Shipping rate smart_send_shipping:99956 is not available for this package - no rate added');
 });
 
-it('logs an error when the order cannot be loaded while deleting pick-up point meta, even with debug off', function () {
+it('logs an error when the order cannot be loaded while deleting pickup point meta, even with debug off', function () {
     with_ss_settings(['ss_debug' => 'no']);
     $spy = spy_on_logger();
 
     SS_SHIPPING_WC()->get_ss_shipping_wc_order()->delete_ss_shipping_order_agent(999999999);
 
-    $failed = ss_policy_entry($spy, 'Failed to load WooCommerce order when deleting pick-up point meta - skipping');
+    $failed = ss_policy_entry($spy, 'Failed to load WooCommerce order when deleting pickup point meta - skipping');
     expect($failed)->not->toBeNull()
         ->and($failed['level'])->toBe('error')
         ->and($failed['context']['order_id'])->toBe(999999999);

--- a/tests/Integration/NoticeTranslationTest.php
+++ b/tests/Integration/NoticeTranslationTest.php
@@ -94,7 +94,7 @@ it('substitutes values into a translated sprintf template on the debug bar', fun
     );
 });
 
-it('uses singular and plural pick-up point summaries via _n()', function () {
+it('uses singular and plural pickup point summaries via _n()', function () {
     with_option('woocommerce_shipping_debug_mode', 'yes');
     spy_on_logger();
     mock_smart_send_api(function () {
@@ -103,7 +103,7 @@ it('uses singular and plural pick-up point summaries via _n()', function () {
 
     SS_SHIPPING_WC()->ss_find_closest_agents_by_address('postnord', 'DK', '2300', 'Main Street 1', 'Copenhagen');
 
-    expect(ss_policy_notices())->toContain('Smart Send: found 1 postnord pick-up point near the entered address.');
+    expect(ss_policy_notices())->toContain('Smart Send: found 1 postnord pickup point near the entered address.');
 
     wc_clear_notices();
     mock_smart_send_api(function () {
@@ -112,5 +112,5 @@ it('uses singular and plural pick-up point summaries via _n()', function () {
 
     SS_SHIPPING_WC()->ss_find_closest_agents_by_address('postnord', 'DK', '2300', 'Main Street 1', 'Copenhagen');
 
-    expect(ss_policy_notices())->toContain('Smart Send: found 2 postnord pick-up points near the entered address.');
+    expect(ss_policy_notices())->toContain('Smart Send: found 2 postnord pickup points near the entered address.');
 });

--- a/tests/Integration/PickupLookupDebugTest.php
+++ b/tests/Integration/PickupLookupDebugTest.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * Pick-up point lookup failure reasons (#47): when the agents request at
+ * Pickup point lookup failure reasons (#47): when the agents request at
  * checkout fails, the shopper still sees the unchanged "Shipping to closest
- * pick-up point" fallback, while the classified reason (transport error,
+ * pickup point" fallback, while the classified reason (transport error,
  * API error response, empty result) is logged - error level for failures,
  * debug level for an empty result - and, with WooCommerce shipping debug
  * mode enabled, surfaced as a checkout debug notice via
@@ -18,7 +18,7 @@
  */
 
 /**
- * Render the pick-up point block for a Smart Send agent rate the way
+ * Render the pickup point block for a Smart Send agent rate the way
  * checkout does: is_checkout() forced true, a posted shipping address, the
  * rate chosen in the session.
  */
@@ -80,7 +80,7 @@ function pickup_debug_logged(object $spy, string $level): array
     return $messages;
 }
 
-const PICKUP_DEBUG_FALLBACK = '<div class="woocommerce-info ss-agent-info">Shipping to closest pick-up point</div>';
+const PICKUP_DEBUG_FALLBACK = '<div class="woocommerce-info ss-agent-info">Shipping to closest pickup point</div>';
 
 beforeEach(function (): void {
     with_ss_settings();
@@ -103,10 +103,10 @@ it('surfaces a transport failure as a debug notice and logs it at error level', 
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: pick-up point lookup for postnord failed with a transport error (transport-timeout): '
+    $expected = 'Smart Send: pickup point lookup for postnord failed with a transport error (transport-timeout): '
         . 'The connection to the Smart Send API timed out. Please try again. If the problem persists, ask your host '
         . 'whether outgoing requests to app.smartsend.io are blocked or slow.'
-        . ' Falling back to "Shipping to closest pick-up point".';
+        . ' Falling back to "Shipping to closest pickup point".';
 
     // The customer-facing fallback is byte-for-byte unchanged.
     expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
@@ -126,8 +126,8 @@ it('surfaces an API error response as a debug notice and logs it at error level'
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: pick-up point lookup for postnord failed with an API error (Unauthenticated): '
-        . 'The API token is invalid. Falling back to "Shipping to closest pick-up point".';
+    $expected = 'Smart Send: pickup point lookup for postnord failed with an API error (Unauthenticated): '
+        . 'The API token is invalid. Falling back to "Shipping to closest pickup point".';
 
     expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
         ->and(pickup_debug_notice_texts())->toContain($expected)
@@ -145,8 +145,8 @@ it('falls back to the HTTP status when a validation error body has no code', fun
 
     expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
         ->and(pickup_debug_notice_texts())->toContain(
-            'Smart Send: pick-up point lookup for postnord failed with an API error (422): '
-            . 'The given data was invalid. Falling back to "Shipping to closest pick-up point".'
+            'Smart Send: pickup point lookup for postnord failed with an API error (422): '
+            . 'The given data was invalid. Falling back to "Shipping to closest pickup point".'
         );
 });
 
@@ -160,13 +160,13 @@ it('reports an empty agent list as a debug notice and logs it at debug level onl
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: no postnord pick-up points found near the entered address'
-        . ' - falling back to "Shipping to closest pick-up point".';
+    $expected = 'Smart Send: no postnord pickup points found near the entered address'
+        . ' - falling back to "Shipping to closest pickup point".';
 
     expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
         ->and(pickup_debug_notice_texts())->toContain($expected)
         ->and(implode("\n", pickup_debug_logged($spy, 'debug')))->toContain($expected)
-        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->not->toContain('no postnord pick-up points');
+        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->not->toContain('no postnord pickup points');
 });
 
 it('adds no notice when shipping debug mode is off but still logs the error', function () {
@@ -182,7 +182,7 @@ it('adds no notice when shipping debug mode is off but still logs the error', fu
     expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
         ->and(wc_notice_count())->toBe(0)
         ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain(
-            'Smart Send: pick-up point lookup for postnord failed with a transport error (transport-connection):'
+            'Smart Send: pickup point lookup for postnord failed with a transport error (transport-connection):'
         );
 });
 
@@ -209,8 +209,8 @@ it('renders the agent dropdown and no failure notice when the lookup succeeds', 
     $output = pickup_debug_render();
 
     expect($output)->toContain('ss_shipping_store_pickup')
-        ->and($output)->not->toContain('Shipping to closest pick-up point')
-        ->and(implode("\n", pickup_debug_notice_texts()))->not->toContain('pick-up point lookup');
+        ->and($output)->not->toContain('Shipping to closest pickup point')
+        ->and(implode("\n", pickup_debug_notice_texts()))->not->toContain('pickup point lookup');
 });
 
 it('surfaces a success summary with the carrier and result count (#92)', function () {
@@ -223,7 +223,7 @@ it('surfaces a success summary with the carrier and result count (#92)', functio
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: found 2 postnord pick-up points near the entered address.';
+    $expected = 'Smart Send: found 2 postnord pickup points near the entered address.';
 
     expect($output)->toContain('ss_shipping_store_pickup')
         ->and(pickup_debug_notice_texts())->toContain($expected)

--- a/tests/Integration/ShipmentPayloadTest.php
+++ b/tests/Integration/ShipmentPayloadTest.php
@@ -729,7 +729,7 @@ it('lets the smart_send_order_parcels filter inject a parcel split (#73)', funct
         ->and($payload['parcels'][1]['items'][0]['name'])->toBe('Filter Box Two');
 });
 
-it('lets the smart_send_order_agent filter replace the pick-up point', function () {
+it('lets the smart_send_order_pickup_point filter replace the pickup point', function () {
     $product = create_simple_product(['price' => 100, 'weight' => 1]);
     $order   = create_order([
         'products'        => [$product],
@@ -743,9 +743,9 @@ it('lets the smart_send_order_agent filter replace the pick-up point', function 
 
         return sample_agent(['agent_no' => '9999', 'company' => 'Override Shop']);
     };
-    add_filter('smart_send_order_agent', $filter, 10, 2);
+    add_filter('smart_send_order_pickup_point', $filter, 10, 2);
     remember_cleanup_callback(function () use ($filter): void {
-        remove_filter('smart_send_order_agent', $filter, 10);
+        remove_filter('smart_send_order_pickup_point', $filter, 10);
     });
 
     $payload = capture_shipment_payload($order);


### PR DESCRIPTION
## Summary

Implements #105: consistent "pickup point" (no hyphen) terminology across merchant-facing strings, docblock prose, and the six `smart_send_*agent*` extension hooks.

- All merchant-facing strings (settings UI, checkout debug bar, admin notices, order notes, meta box, `readme.txt`) now say "pickup point" instead of "pick-up point".
- Docblock/comment prose prefers "pickup point" over "agent" when describing the concept to a human reader.
- Renames the four hooks added in #73/PR #100 that were still unreleased (only on `develop`, no released version), **and** the two hooks that shipped in 8.2.0 (per issue Update 2) — this is a genuine breaking change for merchants already hooking the old names on those two.
- `readme.txt`'s Developers section (hook docs + example snippets) is updated for all six.
- `tests/Integration/FrontendSelectorHooksTest.php` and `tests/Integration/ShipmentPayloadTest.php` are updated to fire/assert the new hook names. Added a new firing test for `smart_send_pickup_point_timeout` (this hook had no prior test coverage).
- Renamed local PHP variables in `public/class-ss-shipping-frontend.php` that only hold pickup-point data internally (`$ss_agent_options` → `$pickup_point_options`, `$default_agent_no` → `$default_pickup_point_no`, `$ss_agents` → `$ss_pickup_points`, plus the loop/derived variables that carry the same data) — without touching the `->agent_no` property access itself, since that's the literal Smart Send API field name (`Smartsend\Models\Agent`).
- Out of scope, confirmed untouched: `Smartsend\Models\Agent` / `Smartsend\Models\Shipment\Agent` class names, order meta keys (`ss_shipping_order_agent_no`, `_ss_shipping_order_agent`), and everything else in `includes/lib/Smartsend/` except the one filter-name string in `Api.php` required by the `smart_send_pickup_point_timeout` rename (that hook is defined in the lib client, so renaming it necessarily touches that one line).

## Hook renames

This table is meant to be copied directly into the v9 upgrade guide (#111/#110):

| Old name | New name | Previously released? |
|---|---|---|
| `smart_send_agent_search_params` | `smart_send_pickup_point_search_params` | No — added in #73/PR #100, only on `develop` |
| `smart_send_agents_found` | `smart_send_pickup_points_found` | No — added in #73/PR #100, only on `develop` |
| `smart_send_agent_option_label` | `smart_send_pickup_point_option_label` | No — added in #73/PR #100, only on `develop` |
| `smart_send_default_selected_agent` | `smart_send_default_selected_pickup_point` | No — added in #73/PR #100, only on `develop` |
| `smart_send_agent_timeout` | `smart_send_pickup_point_timeout` | **Yes — shipped in 8.2.0** (breaking) |
| `smart_send_order_agent` | `smart_send_order_pickup_point` | **Yes — shipped in 8.2.0** (breaking) |

Verified against `origin/main` (the last released version, 8.2.0): only `smart_send_agent_timeout` and `smart_send_order_agent` appear in the released `readme.txt`; the other four are undocumented on `main` and exist only on `develop`.

## Test plan

- [x] `composer test:integration` — 151 passed (150 baseline + 1 new firing test for `smart_send_pickup_point_timeout`)
- [x] `vendor/bin/phpcs` — clean
- [x] `composer phpcs:compat` — clean
- [x] Manually verified no `pick-up` (hyphenated) string remains anywhere in `smart-send-logistics/` or `tests/`

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
