### PR TITLE
Maintain a v9 upgrade guide in readme.txt for all breaking changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,3 +92,5 @@ A version bump must update **three places in lockstep**:
 - `smart-send-logistics/readme.txt`: the `Stable tag:`
 
 Also add a changelog entry under `== Changelog ==` in `readme.txt` (WordPress.org readme format, not Keep a Changelog). When compatibility is verified against newer versions, bump `Tested up to:` / `WC tested up to:` in both files.
+
+Any PR that introduces a breaking change (hook rename, payload shape change, method/filter signature change, raised minimum PHP/WC version, etc.) must update the `== Upgrade Notice ==` section in `readme.txt` in the same PR — add the change to the entry for the next unreleased version (create that version's entry if it doesn't exist yet), so the guide always lists every breaking change since the last release in one place.

--- a/smart-send-logistics/readme.txt
+++ b/smart-send-logistics/readme.txt
@@ -284,7 +284,7 @@ This box appears when a "Select Pickup Point" shipping method is selected, but n
 = 8.2.0 =
 * Tested with WordPress 7.0
 * Tested with WooCommerce 11.0
-* Minimum required PHP version raised from 5.6 to 7.4 (sites on older PHP will not be offered this update)
+* Minimum required PHP version raised from 5.6 to 7.4 (sites on older PHP will not be offered this update) - see the "9.0.0" entry under Upgrade Notice for the full list of v9 breaking changes
 * Fix fatal error "Call to a member function get_meta() on bool" when order hooks run without a real order, e.g. the WooCommerce email preview
 * Fix "_load_textdomain_just_in_time was called incorrectly" notice on WordPress 6.7+ by deferring early translation calls
 * Fix incorrect import that could break instanceof checks in the order handling class
@@ -622,6 +622,14 @@ This box appears when a "Select Pickup Point" shipping method is selected, but n
 * Initial release for Wordpress.org
 
 == Upgrade Notice ==
+
+= 9.0.0 =
+9.0 is the v9 major release and carries several breaking changes for sites that rely on Smart Send hooks or filters, or that run on older PHP. Note: 9.0.0 has not been released yet as of this writing; this entry is maintained on develop ahead of the actual release and lists every breaking change shipped across v9 so far. Review before upgrading from 8.x:
+
+* Minimum required PHP raised from 5.6 to 7.4. Sites on PHP 5.6-7.3 will not be offered this update and must upgrade PHP first.
+* Shipment payload totals are now reconciled so that subtotal + shipping = total on both tax bases, and clamped to zero. This fixes negative totals but changes the exact numbers sent to Smart Send for orders where a gift card or coupon exceeds the item value.
+* `Smartsend\Models\*` setters and `Smartsend\Client` accessors are now type-hinted. Loosely-typed values passed in from custom code or filters (e.g. a numeric string where an int/float is expected) now coerce or raise a `TypeError` instead of being silently accepted.
+* Six hooks were renamed as part of the pickup-point terminology pass: `smart_send_agent_search_params` to `smart_send_pickup_point_search_params`, `smart_send_agents_found` to `smart_send_pickup_points_found`, `smart_send_agent_option_label` to `smart_send_pickup_point_option_label`, `smart_send_default_selected_agent` to `smart_send_default_selected_pickup_point`, `smart_send_agent_timeout` to `smart_send_pickup_point_timeout`, and `smart_send_order_agent` to `smart_send_order_pickup_point`. Update any code snippet or custom integration that hooks into the old names - the last two (`smart_send_agent_timeout`, `smart_send_order_agent`) were live in the 8.2.0 release, so sites upgrading from 8.2.0 or earlier are most likely to be affected.
 
 = 8.0 =
 8.0 is a major update. Shipping methods moved to WooCommerce Shipping Zones and must be setup again after upgrading. Make a full site backup, and [review update best practices](https://docs.woocommerce.com/document/how-to-update-your-site) before upgrading.


### PR DESCRIPTION
## Summary

- Adds a dedicated `= 9.0.0 =` entry under `== Upgrade Notice ==` in `smart-send-logistics/readme.txt` listing every v9 breaking change shipped so far: the PHP 5.6 -> 7.4 floor raise (#71), the shipment payload totals reconciliation/clamping rule (#72), the `Smartsend\Models\*`/`Client` type-hinting (#91), and all six pickup-point hook renames from #105 (noting that `smart_send_agent_timeout` and `smart_send_order_agent` were live in the released 8.2.0, so upgraders from 8.2.0 or earlier are most affected).
- Cross-links from the `= 8.2.0 =` `== Changelog ==` entry (the only item in the list that has actually shipped) to the new Upgrade Notice entry.
- Adds a line to CLAUDE.md's Releasing section establishing the convention: any PR introducing a breaking change must update this Upgrade Notice section in the same PR.

**Version number assumption:** the plugin is still at 8.2.0 (`smart-send-logistics.php`'s `Version:`/`$version` and `readme.txt`'s `Stable tag:` are unchanged by this PR). `readme.txt` already documents several new filters as "since 9.0.0" (see the "Pickup point lookup" and "Shipping label creation" hook sections), so I used **9.0.0** as the plausible next version for this entry, consistent with that existing precedent. This is a documentation-only placeholder — a human should confirm/correct the version number when v9 is actually released, and bump `Version:`/`$version`/`Stable tag:` at that time per the existing Releasing guidance.

Stacked on #119 (merged) — based on and targets `chore/issue-105-pickup-point-naming`, not `develop`.

## Test plan

- [x] `composer test:integration` — 151 passed (591 assertions), same baseline as #119
- [x] `vendor/bin/phpcs` — clean
- [x] `composer phpcs:compat` — clean
- [x] Manually reviewed `readme.txt` for valid WordPress.org readme format (Upgrade Notice / Changelog section structure preserved)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)