### PR TITLE
Extract enum-like setting strings (shipping-class/free-shipping modes) into constants

### DIFF
--- a/smart-send-logistics/admin/class-ss-shipping-method-settings.php
+++ b/smart-send-logistics/admin/class-ss-shipping-method-settings.php
@@ -25,6 +25,86 @@ if ( ! class_exists( 'SS_Shipping_Method_Settings' ) ) :
 	class SS_Shipping_Method_Settings {
 
 		/**
+		 * Shipping-class requirement mode: no restriction ("N/A").
+		 *
+		 * @var string
+		 */
+		const SHIPPING_CLASS_OPT_NA = 'no_shipping_class';
+
+		/**
+		 * Shipping-class requirement mode: ALL products belong to one of the shipping classes.
+		 *
+		 * @var string
+		 */
+		const SHIPPING_CLASS_OPT_ALL = 'all_shipping_class';
+
+		/**
+		 * Shipping-class requirement mode: at least ONE product belongs to one of the shipping classes.
+		 *
+		 * @var string
+		 */
+		const SHIPPING_CLASS_OPT_ONE = 'one_shipping_class';
+
+		/**
+		 * Shipping-class requirement mode: ALL products do NOT belong to one of the shipping classes.
+		 *
+		 * Spelling ("nall") is preserved exactly as persisted in existing merchant
+		 * settings - see the #109 investigation note in this class's docblock.
+		 *
+		 * @var string
+		 */
+		const SHIPPING_CLASS_OPT_NALL = 'nall_shipping_class';
+
+		/**
+		 * Shipping-class requirement mode: at least ONE product does NOT belong to one of the shipping classes.
+		 *
+		 * @var string
+		 */
+		const SHIPPING_CLASS_OPT_NONE = 'none_shipping_class';
+
+		/**
+		 * Free-shipping (flat fee) requirement mode: always disabled.
+		 *
+		 * @var string
+		 */
+		const REQUIRES_DISABLED = 'disabled';
+
+		/**
+		 * Free-shipping (flat fee) requirement mode: always enabled.
+		 *
+		 * @var string
+		 */
+		const REQUIRES_ENABLED = 'enabled';
+
+		/**
+		 * Free-shipping (flat fee) requirement mode: a valid free shipping coupon.
+		 *
+		 * @var string
+		 */
+		const REQUIRES_COUPON = 'coupon';
+
+		/**
+		 * Free-shipping (flat fee) requirement mode: a minimum order amount.
+		 *
+		 * @var string
+		 */
+		const REQUIRES_MIN_AMOUNT = 'min_amount';
+
+		/**
+		 * Free-shipping (flat fee) requirement mode: a minimum order amount OR a coupon.
+		 *
+		 * @var string
+		 */
+		const REQUIRES_EITHER = 'either';
+
+		/**
+		 * Free-shipping (flat fee) requirement mode: a minimum order amount AND a coupon.
+		 *
+		 * @var string
+		 */
+		const REQUIRES_BOTH = 'both';
+
+		/**
 		 * The shipping method instance the settings belong to.
 		 *
 		 * @var SS_Shipping_WC_Method
@@ -325,12 +405,12 @@ if ( ! class_exists( 'SS_Shipping_Method_Settings' ) ) :
 					'class'   => 'wc-enhanced-select',
 					'default' => '',
 					'options' => array(
-						'disabled'   => __( 'Always disabled', 'smart-send-logistics' ),
-						'enabled'    => __( 'Always enabled', 'smart-send-logistics' ),
-						'coupon'     => __( 'A valid free shipping coupon', 'smart-send-logistics' ),
-						'min_amount' => __( 'A minimum order amount', 'smart-send-logistics' ),
-						'either'     => __( 'A minimum order amount OR a coupon', 'smart-send-logistics' ),
-						'both'       => __( 'A minimum order amount AND a coupon', 'smart-send-logistics' ),
+						self::REQUIRES_DISABLED   => __( 'Always disabled', 'smart-send-logistics' ),
+						self::REQUIRES_ENABLED    => __( 'Always enabled', 'smart-send-logistics' ),
+						self::REQUIRES_COUPON     => __( 'A valid free shipping coupon', 'smart-send-logistics' ),
+						self::REQUIRES_MIN_AMOUNT => __( 'A minimum order amount', 'smart-send-logistics' ),
+						self::REQUIRES_EITHER     => __( 'A minimum order amount OR a coupon', 'smart-send-logistics' ),
+						self::REQUIRES_BOTH       => __( 'A minimum order amount AND a coupon', 'smart-send-logistics' ),
 					),
 				),
 				'flatfee_cost'               => array(
@@ -381,20 +461,20 @@ if ( ! class_exists( 'SS_Shipping_Method_Settings' ) ) :
 					),
 					'default'     => '',
 					'options'     => array(
-						'no_shipping_class'   => __( 'N/A', 'smart-send-logistics' ),
-						'all_shipping_class'  => __(
+						self::SHIPPING_CLASS_OPT_NA   => __( 'N/A', 'smart-send-logistics' ),
+						self::SHIPPING_CLASS_OPT_ALL  => __(
 							'ALL products belong to one of the shipping classes',
 							'smart-send-logistics'
 						),
-						'one_shipping_class'  => __(
+						self::SHIPPING_CLASS_OPT_ONE  => __(
 							'At least ONE product belongs to one of the shipping classes',
 							'smart-send-logistics'
 						),
-						'nall_shipping_class' => __(
+						self::SHIPPING_CLASS_OPT_NALL => __(
 							'ALL products do NOT belong to one of the shipping classes',
 							'smart-send-logistics'
 						),
-						'none_shipping_class' => __(
+						self::SHIPPING_CLASS_OPT_NONE => __(
 							'At least ONE product does NOT belongs to one of the shipping classes',
 							'smart-send-logistics'
 						),

--- a/smart-send-logistics/admin/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/admin/class-ss-shipping-wc-method.php
@@ -453,16 +453,16 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 					$display_shipping_class_opt = $this->get_instance_option( 'display_shipping_class_opt' );
 
 					switch ( $display_shipping_class_opt ) {
-						case 'all_shipping_class':
+						case SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_ALL:
 							$is_available = $all_in_array;
 							break;
-						case 'one_shipping_class':
+						case SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_ONE:
 							$is_available = $one_in_array;
 							break;
-						case 'nall_shipping_class':
+						case SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_NALL:
 							$is_available = ! $one_in_array;
 							break;
-						case 'none_shipping_class':
+						case SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_NONE:
 							$is_available = ! $all_in_array;
 							break;
 					}
@@ -522,7 +522,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			$requires           = $this->get_instance_option( 'requires' );
 			$min_amount         = $this->get_instance_option( 'min_amount' );
 
-			if ( in_array( $requires, array( 'coupon', 'either', 'both' ) ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict -- pre-existing loose in_array; tightening is a behaviour change out of scope for the #43 move.
+			if ( in_array( $requires, array( SS_Shipping_Method_Settings::REQUIRES_COUPON, SS_Shipping_Method_Settings::REQUIRES_EITHER, SS_Shipping_Method_Settings::REQUIRES_BOTH ) ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict -- pre-existing loose in_array; tightening is a behaviour change out of scope for the #43 move.
 				$coupons = WC()->cart->get_coupons();
 				if ( $coupons ) {
 					foreach ( $coupons as $code => $coupon ) {
@@ -534,7 +534,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 				}
 			}
 
-			if ( in_array( $requires, array( 'min_amount', 'either', 'both' ) ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict -- pre-existing loose in_array; tightening is a behaviour change out of scope for the #43 move.
+			if ( in_array( $requires, array( SS_Shipping_Method_Settings::REQUIRES_MIN_AMOUNT, SS_Shipping_Method_Settings::REQUIRES_EITHER, SS_Shipping_Method_Settings::REQUIRES_BOTH ) ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict -- pre-existing loose in_array; tightening is a behaviour change out of scope for the #43 move.
 				$total = WC()->cart->get_displayed_subtotal();
 
 				if ( 'incl' === WC()->cart->get_tax_price_display_mode() ) {
@@ -552,22 +552,22 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			}
 
 			switch ( $requires ) {
-				case 'min_amount':
+				case SS_Shipping_Method_Settings::REQUIRES_MIN_AMOUNT:
 					$is_available = $has_met_min_amount;
 					break;
-				case 'coupon':
+				case SS_Shipping_Method_Settings::REQUIRES_COUPON:
 					$is_available = $has_coupon;
 					break;
-				case 'both':
+				case SS_Shipping_Method_Settings::REQUIRES_BOTH:
 					$is_available = $has_met_min_amount && $has_coupon;
 					break;
-				case 'either':
+				case SS_Shipping_Method_Settings::REQUIRES_EITHER:
 					$is_available = $has_met_min_amount || $has_coupon;
 					break;
-				case 'enabled':
+				case SS_Shipping_Method_Settings::REQUIRES_ENABLED:
 					$is_available = true;
 					break;
-				case 'disabled':
+				case SS_Shipping_Method_Settings::REQUIRES_DISABLED:
 				default:
 					$is_available = false;
 					break;
@@ -593,7 +593,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 		 */
 		protected function report_shipping_class_availability( $display_shipping_class_opt, $is_available ) {
 			switch ( $display_shipping_class_opt ) {
-				case 'all_shipping_class':
+				case SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_ALL:
 					if ( $is_available ) {
 						$log_message = sprintf( 'Smart Send "%s": shipping method IS available, because ALL products belong to one of the shipping classes', $this->title );
 						/* translators: %s: shipping method title. */
@@ -604,7 +604,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 						$notice_message = sprintf( __( 'Smart Send "%s": shipping method is NOT available, because ALL products belong to one of the shipping classes', 'smart-send-logistics' ), $this->title );
 					}
 					break;
-				case 'one_shipping_class':
+				case SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_ONE:
 					if ( $is_available ) {
 						$log_message = sprintf( 'Smart Send "%s": shipping method IS available, because at least ONE product belongs to one of the shipping classes', $this->title );
 						/* translators: %s: shipping method title. */
@@ -615,7 +615,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 						$notice_message = sprintf( __( 'Smart Send "%s": shipping method is NOT available, because at least ONE product belongs to one of the shipping classes', 'smart-send-logistics' ), $this->title );
 					}
 					break;
-				case 'nall_shipping_class':
+				case SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_NALL:
 					if ( $is_available ) {
 						$log_message = sprintf( 'Smart Send "%s": shipping method IS available, because ALL products do NOT belong to one of the shipping classes', $this->title );
 						/* translators: %s: shipping method title. */
@@ -626,7 +626,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 						$notice_message = sprintf( __( 'Smart Send "%s": shipping method is NOT available, because ALL products do NOT belong to one of the shipping classes', 'smart-send-logistics' ), $this->title );
 					}
 					break;
-				case 'none_shipping_class':
+				case SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_NONE:
 					if ( $is_available ) {
 						$log_message = sprintf( 'Smart Send "%s": shipping method IS available, because at least ONE product does NOT belongs to one of the shipping classes', $this->title );
 						/* translators: %s: shipping method title. */
@@ -657,7 +657,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 		 */
 		protected function report_free_shipping_availability( $requires, $is_available, $total, $min_amount ) {
 			switch ( $requires ) {
-				case 'min_amount':
+				case SS_Shipping_Method_Settings::REQUIRES_MIN_AMOUNT:
 					if ( $is_available ) {
 						$log_message = sprintf( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed.', $this->title, $total, $min_amount );
 						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
@@ -668,7 +668,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 						$notice_message = sprintf( __( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed.', 'smart-send-logistics' ), $this->title, $total, $min_amount );
 					}
 					break;
-				case 'coupon':
+				case SS_Shipping_Method_Settings::REQUIRES_COUPON:
 					if ( $is_available ) {
 						$log_message = sprintf( 'Smart Send "%s": free shipping (flat fee) IS available, because a coupon is needed.', $this->title );
 						/* translators: %s: shipping method title. */
@@ -679,7 +679,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 						$notice_message = sprintf( __( 'Smart Send "%s": free shipping (flat fee) is NOT available, because a coupon is needed.', 'smart-send-logistics' ), $this->title );
 					}
 					break;
-				case 'both':
+				case SS_Shipping_Method_Settings::REQUIRES_BOTH:
 					if ( $is_available ) {
 						$log_message = sprintf( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.', $this->title, $total, $min_amount );
 						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
@@ -690,7 +690,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 						$notice_message = sprintf( __( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.', 'smart-send-logistics' ), $this->title, $total, $min_amount );
 					}
 					break;
-				case 'either':
+				case SS_Shipping_Method_Settings::REQUIRES_EITHER:
 					if ( $is_available ) {
 						$log_message = sprintf( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.', $this->title, $total, $min_amount );
 						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
@@ -701,12 +701,12 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 						$notice_message = sprintf( __( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.', 'smart-send-logistics' ), $this->title, $total, $min_amount );
 					}
 					break;
-				case 'enabled':
+				case SS_Shipping_Method_Settings::REQUIRES_ENABLED:
 					$log_message = sprintf( 'Smart Send "%s": free shipping (flat fee) IS available, because it is always enabled.', $this->title );
 					/* translators: %s: shipping method title. */
 					$notice_message = sprintf( __( 'Smart Send "%s": free shipping (flat fee) IS available, because it is always enabled.', 'smart-send-logistics' ), $this->title );
 					break;
-				case 'disabled':
+				case SS_Shipping_Method_Settings::REQUIRES_DISABLED:
 					$log_message = sprintf( 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is always disabled.', $this->title );
 					/* translators: %s: shipping method title. */
 					$notice_message = sprintf( __( 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is always disabled.', 'smart-send-logistics' ), $this->title );


### PR DESCRIPTION
## Summary

Introduces class constants on `SS_Shipping_Method_Settings` for the two enum-like setting families referenced in `SS_Shipping_WC_Method`'s switch/case/comparison blocks, and points the form-fields options arrays at the same constants so there is exactly one source of truth. No persisted string value changes.

### Shipping-class requirement mode (`display_shipping_class_opt`)

| Constant | Value |
|---|---|
| `SHIPPING_CLASS_OPT_NA` | `no_shipping_class` |
| `SHIPPING_CLASS_OPT_ALL` | `all_shipping_class` |
| `SHIPPING_CLASS_OPT_ONE` | `one_shipping_class` |
| `SHIPPING_CLASS_OPT_NALL` | `nall_shipping_class` |
| `SHIPPING_CLASS_OPT_NONE` | `none_shipping_class` |

### Free-shipping (flat fee) requirement mode (`requires`)

| Constant | Value |
|---|---|
| `REQUIRES_DISABLED` | `disabled` |
| `REQUIRES_ENABLED` | `enabled` |
| `REQUIRES_COUPON` | `coupon` |
| `REQUIRES_MIN_AMOUNT` | `min_amount` |
| `REQUIRES_EITHER` | `either` |
| `REQUIRES_BOTH` | `both` |

## `nall_shipping_class` investigation

Checked whether `nall_shipping_class` is reachable/real or a historical typo for `not_all_shipping_class`. It is genuinely reachable: it's one of the five options defined in the `display_shipping_class_opt` `<select>` in `SS_Shipping_Method_Settings::build_form_fields()` (label: "ALL products do NOT belong to one of the shipping classes"), and both `is_available()`'s switch and `report_shipping_class_availability()`'s switch have a case for it. Since it's a genuine, reachable, persisted option value (shorthand for "not all"), the constant preserves the exact existing spelling — `SHIPPING_CLASS_OPT_NALL = 'nall_shipping_class'` — per the issue's explicit instruction not to "fix" it (that would require a settings migration and is a separate, deliberate decision out of scope here).

## Scope discipline

Kept this to value-level changes only (bare string literals → constants) — no control-flow restructuring — so #107's early-return refactor of `calculate_shipping` can stack cleanly on top of these switch/case blocks afterward.

## Test plan

- [x] `composer test:integration` — 152 passed (593 assertions), same count as the #120 baseline; characterization test files themselves were not modified (confirms persisted values are byte-identical before/after)
- [x] `vendor/bin/phpcs` — clean
- [x] `composer phpcs:compat` — clean

Stacked on #120 (`chore/issue-106-dynamic-hooks`, merged). Base branch is `chore/issue-106-dynamic-hooks`, not `develop`.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)