### PR TITLE
Refactor weight-table matching loop to early returns

### DIFF
--- a/smart-send-logistics/admin/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/admin/class-ss-shipping-wc-method.php
@@ -288,54 +288,59 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 				if ( $weight_costs ) {
 					foreach ( $weight_costs as $weight_cost ) {
 
-						// If empty ignore field and continue, otherwise check if equal or greater than
-						if ( empty( $weight_cost['ss_min_weight'] ) || ( $cart_weight >= $weight_cost['ss_min_weight'] ) ) {
-							// IF empty ignore field and contine, otherwise check if less than
-							if ( empty( $weight_cost['ss_max_weight'] ) || ( $cart_weight < $weight_cost['ss_max_weight'] ) ) {
-								// If cost NOT empty add a fee
-								if ( ! empty( $weight_cost['ss_cost_weight'] ) ) {
-
-									$rate['cost'] = $this->evaluate_cost(
-										$weight_cost['ss_cost_weight'],
-										array(
-											'qty'  => $this->get_package_item_qty( $package ),
-											'cost' => $package['contents_cost'],
-										)
-									);
-
-									$this->add_rate( $rate );
-									$rate_added     = true;
-									$matched_row    = sprintf( '%1$s-%2$s %3$s', $weight_cost['ss_min_weight'], $weight_cost['ss_max_weight'], $weight_unit );
-									$matched_rows[] = $matched_row;
-									SS_Shipping_Logger::debug(
-										sprintf(
-											'Smart Send "%1$s": cart weight %2$s %3$s matched weight table row %4$s - rate added with cost %5$s.',
-											$rate['label'],
-											$cart_weight,
-											$weight_unit,
-											$matched_row,
-											$rate['cost']
-										),
-										array(
-											'rate_id'     => $rate['id'],
-											'cost'        => $rate['cost'],
-											'cart_weight' => $cart_weight,
-										)
-									);
-									SS_Shipping_Checkout_Debug::add_notice(
-										sprintf(
-											/* translators: 1: shipping rate label, 2: cart weight, 3: weight unit, 4: matched weight table row as "min-max unit", 5: rate cost. */
-											__( 'Smart Send "%1$s": cart weight %2$s %3$s matched weight table row %4$s - rate added with cost %5$s.', 'smart-send-logistics' ),
-											$rate['label'],
-											$cart_weight,
-											$weight_unit,
-											$matched_row,
-											$rate['cost']
-										)
-									);
-								}
-							}
+						// If min weight is set and the cart weight is below it, this row does not apply.
+						if ( ! empty( $weight_cost['ss_min_weight'] ) && ( $cart_weight < $weight_cost['ss_min_weight'] ) ) {
+							continue;
 						}
+
+						// If max weight is set and the cart weight is at or above it, this row does not apply.
+						if ( ! empty( $weight_cost['ss_max_weight'] ) && ( $cart_weight >= $weight_cost['ss_max_weight'] ) ) {
+							continue;
+						}
+
+						// No cost formula configured for this row - nothing to add.
+						if ( empty( $weight_cost['ss_cost_weight'] ) ) {
+							continue;
+						}
+
+						$rate['cost'] = $this->evaluate_cost(
+							$weight_cost['ss_cost_weight'],
+							array(
+								'qty'  => $this->get_package_item_qty( $package ),
+								'cost' => $package['contents_cost'],
+							)
+						);
+
+						$this->add_rate( $rate );
+						$rate_added     = true;
+						$matched_row    = sprintf( '%1$s-%2$s %3$s', $weight_cost['ss_min_weight'], $weight_cost['ss_max_weight'], $weight_unit );
+						$matched_rows[] = $matched_row;
+						SS_Shipping_Logger::debug(
+							sprintf(
+								'Smart Send "%1$s": cart weight %2$s %3$s matched weight table row %4$s - rate added with cost %5$s.',
+								$rate['label'],
+								$cart_weight,
+								$weight_unit,
+								$matched_row,
+								$rate['cost']
+							),
+							array(
+								'rate_id'     => $rate['id'],
+								'cost'        => $rate['cost'],
+								'cart_weight' => $cart_weight,
+							)
+						);
+						SS_Shipping_Checkout_Debug::add_notice(
+							sprintf(
+								/* translators: 1: shipping rate label, 2: cart weight, 3: weight unit, 4: matched weight table row as "min-max unit", 5: rate cost. */
+								__( 'Smart Send "%1$s": cart weight %2$s %3$s matched weight table row %4$s - rate added with cost %5$s.', 'smart-send-logistics' ),
+								$rate['label'],
+								$cart_weight,
+								$weight_unit,
+								$matched_row,
+								$rate['cost']
+							)
+						);
 					}
 				}
 


### PR DESCRIPTION
## Summary

`SS_Shipping_WC_Method::calculate_shipping()`'s weight-table row-matching loop nested three `if` statements (min weight → max weight → cost formula present) to decide whether a row applies. Rewritten with guard clauses instead:

**Before:**
```php
foreach ( $weight_costs as $weight_cost ) {
    if ( empty( min ) || ( cart_weight >= min ) ) {
        if ( empty( max ) || ( cart_weight < max ) ) {
            if ( ! empty( cost ) ) {
                // add rate, log, notice
            }
        }
    }
}
```

**After:**
```php
foreach ( $weight_costs as $weight_cost ) {
    if ( ! empty( min ) && ( cart_weight < min ) ) {
        continue;
    }
    if ( ! empty( max ) && ( cart_weight >= max ) ) {
        continue;
    }
    if ( empty( cost ) ) {
        continue;
    }
    // add rate, log, notice
}
```

Each guard is De Morgan's negation of the original condition, so the set of rows that add a rate is identical. The debug-bar/log trace lines (per-row match trace, overlapping-rows-matched trace, no-match trace) stay attached to exactly the same logical points as before — only the flow control around them changed. The v8 oddity where overlapping weight rows silently let the last match win is unchanged (still tracked separately in #16).

Nesting inside the loop went from 3 nested `if`s to 3 sibling guard `if`s (each a single level inside the `foreach`) — no nesting depth beyond 2 levels in the refactored method.

- `tests/Integration/RateCalculationTest.php` and `tests/Integration/ShipmentPayloadTest.php` were **not modified**.
- `composer test:integration`: 152 passed (593 assertions) — same count as the #122 baseline.
- `vendor/bin/phpcs`: clean.
- `composer phpcs:compat`: clean.

Closes #107

Stacked on #122 / #120 / #118 — this is the fourth and final PR in the v9 Phase 4 stack, based on and targeting `chore/issue-109-enum-constants`.

## Test plan
- [x] `composer test:integration` — 152 passed
- [x] `vendor/bin/phpcs` — clean
- [x] `composer phpcs:compat` — clean
- [x] Confirmed `RateCalculationTest.php` / `ShipmentPayloadTest.php` untouched via `git diff --stat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)