### PR TITLE
Land #106/#120's dynamic-hook fix and drift-safety follow-up into develop

### DIFF
--- a/smart-send-logistics/admin/class-ss-shipping-order-bulk-actions.php
+++ b/smart-send-logistics/admin/class-ss-shipping-order-bulk-actions.php
@@ -69,16 +69,18 @@ if ( ! class_exists( 'SS_Shipping_Order_Bulk_Actions' ) ) :
 		 */
 		public function register_bulk_order_actions( SS_Shipping_WC_Order $order_integration ) {
 			// The HPOS CustomOrdersTableController exists since WC 6.4; the plugin's WC floor is 4.7.
-			$screen = class_exists( '\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' )
-				&& wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
-				? 'woocommerce_page_wc-orders' // function not available wc_get_page_screen_id( 'shop-order' )
-				: 'edit-shop_order'; // Index page is called 'edit-shop_order' and not just 'shop_order' as stated in the url
+			$hpos_enabled = class_exists( '\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' )
+				&& wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
 
-			// An actions in the dropdown
-			add_filter( "bulk_actions-{$screen}", array( $order_integration, 'add_bulk_order_actions' ) );
-
-			// Handling the form submission
-			add_filter( "handle_bulk_actions-{$screen}", array( $order_integration, 'handle_bulk_order_actions' ), 10, 3 );
+			if ( $hpos_enabled ) {
+				// function not available wc_get_page_screen_id( 'shop-order' )
+				add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $order_integration, 'add_bulk_order_actions' ) );
+				add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( $order_integration, 'handle_bulk_order_actions' ), 10, 3 );
+			} else {
+				// Index page is called 'edit-shop_order' and not just 'shop_order' as stated in the url
+				add_filter( 'bulk_actions-edit-shop_order', array( $order_integration, 'add_bulk_order_actions' ) );
+				add_filter( 'handle_bulk_actions-edit-shop_order', array( $order_integration, 'handle_bulk_order_actions' ), 10, 3 );
+			}
 		}
 
 		public function add_bulk_order_actions( $bulk_actions ) {

--- a/smart-send-logistics/admin/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/admin/class-ss-shipping-wc-method.php
@@ -68,7 +68,8 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			// Set title so can be viewed in zone screen
 			$this->title = $this->get_option( 'title' );
 
-			add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
+			// $this->id is always SS_SHIPPING_METHOD_ID ('smart_send_shipping'), see #106.
+			add_action( 'woocommerce_update_options_shipping_smart_send_shipping', array( $this, 'process_admin_options' ) );
 			// Admin script
 			add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
 		}
@@ -419,7 +420,8 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			 *            $method->add_rate( $new_rate );
 			 *        }.
 			 */
-			do_action( 'woocommerce_' . $this->id . '_shipping_add_rate', $this, $rate );
+			// $this->id is always SS_SHIPPING_METHOD_ID ('smart_send_shipping'), see #106.
+			do_action( 'woocommerce_smart_send_shipping_shipping_add_rate', $this, $rate );
 		}
 
 		public function is_available( $package ) {
@@ -501,7 +503,8 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 				}
 			}
 
-			return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', $is_available, $package, $this );
+			// $this->id is always SS_SHIPPING_METHOD_ID ('smart_send_shipping'), see #106.
+			return apply_filters( 'woocommerce_shipping_smart_send_shipping_is_available', $is_available, $package, $this );
 		}
 
 		/**

--- a/smart-send-logistics/admin/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/admin/class-ss-shipping-wc-method.php
@@ -68,8 +68,9 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			// Set title so can be viewed in zone screen
 			$this->title = $this->get_option( 'title' );
 
-			// $this->id is always SS_SHIPPING_METHOD_ID ('smart_send_shipping'), see #106.
-			add_action( 'woocommerce_update_options_shipping_smart_send_shipping', array( $this, 'process_admin_options' ) );
+			// Built from the constant (never $this->id) so the hook name can't drift
+			// out of sync with it if SS_SHIPPING_METHOD_ID's value ever changes - see #106.
+			add_action( 'woocommerce_update_options_shipping_' . SS_SHIPPING_METHOD_ID, array( $this, 'process_admin_options' ) );
 			// Admin script
 			add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
 		}
@@ -420,8 +421,9 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			 *            $method->add_rate( $new_rate );
 			 *        }.
 			 */
-			// $this->id is always SS_SHIPPING_METHOD_ID ('smart_send_shipping'), see #106.
-			do_action( 'woocommerce_smart_send_shipping_shipping_add_rate', $this, $rate );
+			// Built from the constant (never $this->id) so the hook name can't drift
+			// out of sync with it if SS_SHIPPING_METHOD_ID's value ever changes - see #106.
+			do_action( 'woocommerce_' . SS_SHIPPING_METHOD_ID . '_shipping_add_rate', $this, $rate );
 		}
 
 		public function is_available( $package ) {
@@ -503,8 +505,9 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 				}
 			}
 
-			// $this->id is always SS_SHIPPING_METHOD_ID ('smart_send_shipping'), see #106.
-			return apply_filters( 'woocommerce_shipping_smart_send_shipping_is_available', $is_available, $package, $this );
+			// Built from the constant (never $this->id) so the hook name can't drift
+			// out of sync with it if SS_SHIPPING_METHOD_ID's value ever changes - see #106.
+			return apply_filters( 'woocommerce_shipping_' . SS_SHIPPING_METHOD_ID . '_is_available', $is_available, $package, $this );
 		}
 
 		/**

--- a/tests/Integration/BulkActionsHookRegistrationTest.php
+++ b/tests/Integration/BulkActionsHookRegistrationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Characterization tests for SS_Shipping_Order_Bulk_Actions::register_bulk_order_actions().
+ *
+ * The bulk "Generate Labels" / "Generate Return Labels" actions are wired
+ * onto one of two screens depending on whether HPOS (the custom orders
+ * table) is enabled, toggled through the woocommerce_custom_orders_table_enabled
+ * option (see #106): the hook names are literal per branch rather than built
+ * by string interpolation, so this asserts each branch registers the
+ * expected literal hook name.
+ */
+
+/**
+ * Re-register the bulk actions against the live SS_Shipping_Order_Bulk_Actions
+ * component (fetched via reflection, since it has no public getter) while a
+ * given HPOS option value is in effect, mirroring what happens once at
+ * plugin bootstrap.
+ */
+function register_bulk_actions_with_hpos(bool $hpos): void
+{
+    with_option('woocommerce_custom_orders_table_enabled', $hpos ? 'yes' : 'no');
+
+    $order_integration = SS_SHIPPING_WC()->get_ss_shipping_wc_order();
+
+    $reflection = new ReflectionProperty(SS_Shipping_WC_Order::class, 'bulk_actions');
+    $bulk_actions = $reflection->getValue($order_integration);
+
+    $bulk_actions->register_bulk_order_actions($order_integration);
+}
+
+it('registers the HPOS orders-screen bulk action hooks when HPOS is enabled', function () {
+    register_bulk_actions_with_hpos(true);
+
+    expect(has_filter('bulk_actions-woocommerce_page_wc-orders', [SS_SHIPPING_WC()->get_ss_shipping_wc_order(), 'add_bulk_order_actions']))->not->toBeFalse()
+        ->and(has_filter('handle_bulk_actions-woocommerce_page_wc-orders', [SS_SHIPPING_WC()->get_ss_shipping_wc_order(), 'handle_bulk_order_actions']))->not->toBeFalse();
+});
+
+it('registers the legacy orders-screen bulk action hooks when HPOS is disabled', function () {
+    register_bulk_actions_with_hpos(false);
+
+    expect(has_filter('bulk_actions-edit-shop_order', [SS_SHIPPING_WC()->get_ss_shipping_wc_order(), 'add_bulk_order_actions']))->not->toBeFalse()
+        ->and(has_filter('handle_bulk_actions-edit-shop_order', [SS_SHIPPING_WC()->get_ss_shipping_wc_order(), 'handle_bulk_order_actions']))->not->toBeFalse();
+});


### PR DESCRIPTION
## What happened

PR #120 was opened with base `chore/issue-108-constants-audit` (correct at the time — #106's stack was built on top of #108's still-open branch). #118 (the #108 constants-audit PR) merged into `develop` normally, but its branch `chore/issue-108-constants-audit` was never deleted, so GitHub never auto-retargeted #120's base to `develop` the way it does when a base branch is deleted.

When #120 was merged, it merged `chore/issue-106-dynamic-hooks` into the **stale, un-deleted `chore/issue-108-constants-audit` branch** — not into `develop`. #120 shows as "Merged" on GitHub, but none of its commits (nor the drift-safety follow-up commit pushed after review) ever reached `develop`.

## What this PR does

Lands the missing commits — `chore/issue-106-dynamic-hooks`'s original work (issue #106) plus the `SS_SHIPPING_METHOD_ID`-derivation follow-up requested in review — into `develop`. #108's own content (already in `develop` via #118) is a common ancestor, so this is a clean merge of just the new work.

Refs #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)