### PR TITLE
Fix: weight table now takes precedence over free shipping

### DIFF
--- a/smart-send-logistics/admin/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/admin/class-ss-shipping-wc-method.php
@@ -256,8 +256,34 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			// Set tax status based on selection otherwise always taxed
 			$this->tax_status = $this->get_option( 'tax_status' );
 
-			// Check if free shipping, otherwise claculate based on weight and evaluate formulas
-			if ( $this->is_free_shipping( $package ) ) {
+			// The weight table defines which cart weights the method is available for at
+			// all - an empty table means every weight is valid. Free shipping is only
+			// ever applied on top of an otherwise-available rate: it never overrules the
+			// weight table (see issue #16 - this reorders the v8 behaviour, which let the
+			// flat-rate threshold skip the weight table entirely).
+			$cart_weight     = WC()->cart->get_cart_contents_weight();
+			$weight_costs    = $this->get_option( 'cost_weight', array() );
+			$weight_unit     = get_option( 'woocommerce_weight_unit' );
+			$weight_in_table = $this->is_weight_within_table( $cart_weight, $weight_costs );
+
+			if ( ! $weight_in_table ) {
+				SS_Shipping_Logger::debug(
+					sprintf( 'Smart Send "%1$s": no rate added - cart weight %2$s %3$s did not match any weight table row.', $rate['label'], $cart_weight, $weight_unit ),
+					array(
+						'rate_id'     => $rate['id'],
+						'cart_weight' => $cart_weight,
+					)
+				);
+				SS_Shipping_Checkout_Debug::add_notice(
+					sprintf(
+						/* translators: 1: shipping rate label, 2: cart weight, 3: weight unit. */
+						__( 'Smart Send "%1$s": no rate added - cart weight %2$s %3$s did not match any weight table row.', 'smart-send-logistics' ),
+						$rate['label'],
+						$cart_weight,
+						$weight_unit
+					)
+				);
+			} elseif ( $this->is_free_shipping( $package ) ) {
 
 				$rate['cost'] = $this->get_option( 'flatfee_cost' );
 				$this->add_rate( $rate );
@@ -278,10 +304,6 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 				);
 
 			} else {
-				$cart_weight  = WC()->cart->get_cart_contents_weight();
-				$weight_costs = $this->get_option( 'cost_weight', array() );
-
-				$weight_unit  = get_option( 'woocommerce_weight_unit' );
 				$rate_added   = false;
 				$matched_rows = array();
 
@@ -513,6 +535,38 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			// Built from the constant (never $this->id) so the hook name can't drift
 			// out of sync with it if SS_SHIPPING_METHOD_ID's value ever changes - see #106.
 			return apply_filters( 'woocommerce_shipping_' . SS_SHIPPING_METHOD_ID . '_is_available', $is_available, $package, $this );
+		}
+
+		/**
+		 * Whether the cart weight falls inside a configured weight table row.
+		 *
+		 * The weight table defines which weights the method is available for at
+		 * all - an empty table means every weight is valid (see issue #16).
+		 *
+		 * @param float $cart_weight  The cart's total weight.
+		 * @param array $weight_costs The configured weight table rows.
+		 * @return bool
+		 */
+		protected function is_weight_within_table( $cart_weight, $weight_costs ) {
+			if ( empty( $weight_costs ) ) {
+				return true;
+			}
+
+			foreach ( $weight_costs as $weight_cost ) {
+				// If min weight is set and the cart weight is below it, this row does not apply.
+				if ( ! empty( $weight_cost['ss_min_weight'] ) && ( $cart_weight < $weight_cost['ss_min_weight'] ) ) {
+					continue;
+				}
+
+				// If max weight is set and the cart weight is at or above it, this row does not apply.
+				if ( ! empty( $weight_cost['ss_max_weight'] ) && ( $cart_weight >= $weight_cost['ss_max_weight'] ) ) {
+					continue;
+				}
+
+				return true;
+			}
+
+			return false;
 		}
 
 		/**

--- a/smart-send-logistics/readme.txt
+++ b/smart-send-logistics/readme.txt
@@ -281,6 +281,9 @@ This box appears when a "Select Pickup Point" shipping method is selected, but n
 
 == Changelog ==
 
+= 9.0.0 =
+* Breaking change: the weight table now defines which cart weights the Smart Send shipping method is available for at all. Free shipping (the flat-rate threshold) only zeroes the price of an otherwise-available rate and can no longer make the method available for a cart weight outside the configured weight table - see the "9.0.0" entry under Upgrade Notice
+
 = 8.2.0 =
 * Tested with WordPress 7.0
 * Tested with WooCommerce 11.0
@@ -622,6 +625,11 @@ This box appears when a "Select Pickup Point" shipping method is selected, but n
 * Initial release for Wordpress.org
 
 == Upgrade Notice ==
+
+= 9.0.0 =
+9.0 is the v9 major release and carries breaking changes for sites that rely on Smart Send hooks or filters, or on the pre-9.0 free-shipping behaviour. Note: 9.0.0 has not been released yet as of this writing; this entry is maintained on develop ahead of the actual release. Review before upgrading from 8.x:
+
+* The weight table now defines which cart weights the shipping method is available for at all. Previously, meeting the free-shipping (flat-rate) threshold made the method available and free regardless of the weight table, even for a cart weight the table did not cover. Now, free shipping only zeroes the price of a rate the weight table already allows - a cart weight outside every configured weight-table row means the method is not offered, no matter the subtotal. An empty weight table still means every weight is valid. Sites relying on free shipping to override the weight table should either widen the weight table or use the `woocommerce_shipping_smart_send_shipping_is_available` filter to restore the old behaviour.
 
 = 8.0 =
 8.0 is a major update. Shipping methods moved to WooCommerce Shipping Zones and must be setup again after upgrading. Make a full site backup, and [review update best practices](https://docs.woocommerce.com/document/how-to-update-your-site) before upgrading.

--- a/tests/Integration/RateCalculationTest.php
+++ b/tests/Integration/RateCalculationTest.php
@@ -3,8 +3,14 @@
 /*
  * Characterization tests for SS_Shipping_WC_Method rate calculation: the
  * weight-bracket table, the free-shipping rules and the availability
- * options. These capture the CURRENT v8 semantics; #16 will change the
- * free-shipping behaviour deliberately and must update these tests.
+ * options.
+ *
+ * v9 (#16): the weight table now defines which cart weights the method is
+ * available for at all - free shipping only zeroes the price of an
+ * otherwise-available rate, it can no longer overrule the weight table (a
+ * behaviour change from v8, where the flat-rate threshold skipped the
+ * weight table entirely). See the "weight table takes precedence over free
+ * shipping" block below.
  */
 
 /**
@@ -206,6 +212,74 @@ it('grants free shipping for a valid free-shipping coupon when required', functi
         'requires'     => 'coupon',
         'flatfee_cost' => '0',
         'cost_weight'  => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(0.0);
+});
+
+// v9 (#16): the weight table takes precedence over free shipping - free
+// shipping only ever zeroes the price of a rate the weight table already
+// allows; it can no longer make the method available for a weight the table
+// excludes.
+
+it('uses the weight table price when the free-shipping threshold is not met', function () {
+    $product = create_simple_product(['price' => 300, 'weight' => 0.4]);
+    $package = cart_package([$product]);
+
+    $method = create_ss_method([
+        'requires'     => 'min_amount',
+        'min_amount'   => '500',
+        'flatfee_cost' => '0',
+        'cost_weight'  => [['ss_min_weight' => '0', 'ss_max_weight' => '1', 'ss_cost_weight' => '49']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(49.0);
+});
+
+it('grants free shipping when the threshold is met and the weight falls inside the table', function () {
+    $product = create_simple_product(['price' => 600, 'weight' => 0.4]);
+    $package = cart_package([$product]);
+
+    $method = create_ss_method([
+        'requires'     => 'min_amount',
+        'min_amount'   => '500',
+        'flatfee_cost' => '0',
+        'cost_weight'  => [['ss_min_weight' => '0', 'ss_max_weight' => '1', 'ss_cost_weight' => '49']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(1)
+        ->and((float) current($method->rates)->get_cost())->toBe(0.0);
+});
+
+it('does not offer the method at all when the weight exceeds the table, even if the free-shipping threshold is met', function () {
+    $product = create_simple_product(['price' => 600, 'weight' => 2]);
+    $package = cart_package([$product]);
+
+    $method = create_ss_method([
+        'requires'     => 'min_amount',
+        'min_amount'   => '500',
+        'flatfee_cost' => '0',
+        'cost_weight'  => [['ss_min_weight' => '0', 'ss_max_weight' => '1', 'ss_cost_weight' => '49']],
+    ]);
+    $method->calculate_shipping($package);
+
+    expect($method->rates)->toHaveCount(0);
+});
+
+it('treats an empty weight table as valid for every weight, so free shipping still applies', function () {
+    $product = create_simple_product(['price' => 600, 'weight' => 25]);
+    $package = cart_package([$product]);
+
+    $method = create_ss_method([
+        'requires'     => 'min_amount',
+        'min_amount'   => '500',
+        'flatfee_cost' => '0',
+        'cost_weight'  => [],
     ]);
     $method->calculate_shipping($package);
 


### PR DESCRIPTION
## Summary

Closes #16 (won't auto-close since this merges into `develop`, not the default branch - the orchestrator will close #16 manually after merge).

- Reorders `SS_Shipping_WC_Method::calculate_shipping()` so the weight table decides availability first; free shipping now only zeroes the price of an otherwise-available rate. It can no longer make the method available for a cart weight the weight table excludes.
- An empty weight table still means every weight is valid (per the issue's decided behaviour).
- This is a deliberate v9 breaking change (v9 permits breaking changes). Documented in `smart-send-logistics/readme.txt` under both `== Changelog ==` (new `9.0.0` entry) and `== Upgrade Notice ==` (new `9.0.0` entry explaining the behaviour change and the `woocommerce_shipping_smart_send_shipping_is_available` filter workaround for merchants who relied on the old behaviour).

## Test plan

Added four integration tests to `tests/Integration/RateCalculationTest.php` covering the exact scenarios from the issue:
- [x] Subtotal below threshold, weight inside the table → weight-table price
- [x] Subtotal above threshold, weight inside the table → free shipping (0)
- [x] Subtotal above threshold, weight outside the table → method not offered at all
- [x] Empty weight table (no rows) → treated as valid for every weight, free shipping still applies

`composer test:integration` — 163 passed (610 assertions).
`vendor/bin/phpcs --standard=WordPress smart-send-logistics` — no new violations on touched lines (pre-existing violations elsewhere in the file are unrelated to this change; there is no baseline file in this repo currently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)