### PR TITLE
Replace v1-shaped Shipment DTO with new internal representation, fix discount allocation

### DIFF
--- a/smart-send-logistics/admin/class-ss-shipping-shipment-builder.php
+++ b/smart-send-logistics/admin/class-ss-shipping-shipment-builder.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * WooCommerce Smart Send internal shipment representation builder.
+ *
+ * @package  SS_Shipping_Shipment_Builder
+ * @category Shipping
+ * @author   Smart Send
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+// A second copy of the plugin may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
+
+	/**
+	 * Assembles the new internal shipment representation (#113) from
+	 * SS_Shipping_Order_Data's output plus the agent/pick-up-point
+	 * selection and parcel split. The representation is a plain array
+	 * shaped close to the Smart Send v2 API schema: a single net amount +
+	 * tax amount per level (shipment/parcel/item), no excl/incl
+	 * redundancy, and a pickup-point section named after v2's
+	 * PickupParty.service_point_code rather than v1's agent_no/agent.
+	 *
+	 * This class does not talk to the API and does not know about the v1
+	 * wire format - translating the representation into the v1 request
+	 * body is SS_Shipping_Shipment's job (a thin adapter, kept only
+	 * because #112's resource layer, which will own that translation
+	 * permanently, is not part of this change).
+	 *
+	 * Gift card exclusion (#128) is NOT implemented here: WooCommerce
+	 * Gift Cards redemptions are not order items (confirmed against the
+	 * plugin's public FAQ: "cart/order line items are not discounted and
+	 * product/order revenue is recorded in full" - the plugin instead
+	 * "modifies the order total of every order that is paid with gift
+	 * cards" to work around WooCommerce not supporting multiple payment
+	 * methods per order), so they never reach get_items_data() and never
+	 * lower an item price. But the exact order-level representation
+	 * (fee line, meta, or something else) could not be confirmed with
+	 * confidence without the plugin installed, so the shipment/parcel
+	 * subtotal calculated in SS_Shipping_Order_Data::get_totals() is not
+	 * yet corrected to add the redemption back - a gift-card-funded order
+	 * still under-reports its shipment value today, same as before this
+	 * change. This is a documented follow-up, to be implemented against
+	 * this representation once the mechanism is confirmed (e.g. against a
+	 * real WC_Order captured from a store with the plugin installed).
+	 */
+	class SS_Shipping_Shipment_Builder {
+
+		/**
+		 * The WooCommerce order.
+		 *
+		 * @var WC_Order
+		 */
+		protected WC_Order $order;
+
+		/**
+		 * Order data access utility.
+		 *
+		 * @var SS_Shipping_Order_Data
+		 */
+		protected SS_Shipping_Order_Data $order_data;
+
+		/**
+		 * The admin order integration.
+		 *
+		 * @var SS_Shipping_WC_Order
+		 */
+		protected SS_Shipping_WC_Order $shipping_order;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Order               $order          The WooCommerce order.
+		 * @param SS_Shipping_Order_Data $order_data     Order data access utility for the same order.
+		 * @param SS_Shipping_WC_Order   $shipping_order The admin order integration.
+		 */
+		public function __construct( WC_Order $order, SS_Shipping_Order_Data $order_data, SS_Shipping_WC_Order $shipping_order ) {
+			$this->order          = $order;
+			$this->order_data     = $order_data;
+			$this->shipping_order = $shipping_order;
+		}
+
+		/**
+		 * Build the internal shipment representation.
+		 *
+		 * @param boolean $is_return Whether the label is a return label.
+		 *
+		 * @return array {
+		 *     The internal shipment representation, or an error.
+		 *
+		 *     @type string     $error               Set instead of every other key when no return method is configured.
+		 *     @type string     $internal_id         Order id.
+		 *     @type string     $internal_reference  Order number.
+		 *     @type string|null $shipping_carrier   Smart Send carrier code.
+		 *     @type string|null $shipping_method    Smart Send shipping method code.
+		 *     @type string     $shipping_date       Shipping date (Y-m-d).
+		 *     @type array      $receiver            Receiver data, see SS_Shipping_Order_Data::get_receiver_data().
+		 *     @type array|null $pickup_point        Pickup point data (service_point_code, address, ...), or null.
+		 *     @type array[]    $parcels             One row per parcel: internal_id, internal_reference, weight,
+		 *                                            height, width, length, freetext, items (item rows),
+		 *                                            total_net_amount, total_tax_amount.
+		 *     @type float|null $subtotal_net_amount Order total excl. shipping, excl. tax.
+		 *     @type float|null $subtotal_tax_amount Tax on the order total excl. shipping.
+		 *     @type float|null $shipping_net_amount Shipping cost excl. tax.
+		 *     @type float|null $shipping_tax_amount Tax on the shipping cost.
+		 *     @type float|null $total_net_amount    Order total excl. tax.
+		 *     @type float|null $total_tax_amount    Total tax on the order.
+		 *     @type string|null $currency           Order currency code.
+		 * }
+		 */
+		public function build( $is_return ) {
+			$order_id = $this->order_data->get_order_id();
+
+			$ss_args = array();
+
+			// Get shipping method.
+			$ss_shipping_method_id = $this->shipping_order->get_smart_send_method_id( $order_id, $is_return );
+
+			if ( $is_return && isset( $ss_shipping_method_id['smart_send_return_method'] ) ) {
+				// If no return method set return error.
+				if ( empty( $ss_shipping_method_id['smart_send_return_method'] ) ) {
+					return array( 'error' => __( 'No return method set', 'smart-send-logistics' ) );
+				} else {
+					$ss_shipping_method_id = $ss_shipping_method_id['smart_send_return_method'];
+				}
+			} else {
+				$ss_args['ss_agent'] = $this->shipping_order->get_ss_shipping_order_agent( $order_id );
+			}
+
+			// Determine shipping method and carrier from return settings.
+			$ss_args['ss_carrier'] = SS_SHIPPING_WC()->get_shipping_method_carrier( $ss_shipping_method_id );
+			$ss_args['ss_type']    = SS_SHIPPING_WC()->get_shipping_method_type( $ss_shipping_method_id );
+
+			/*
+			 * Filter the parcel split used for the order before the shipment
+			 * representation is assembled. The split is the value stored by the
+			 * "Split into parcels" admin option: an array of rows, each with
+			 * keys 'id' (product/variation id), 'name' (product name) and
+			 * 'value' (box number, 1-9). An empty value means a single parcel
+			 * containing all items. Runs before smart_send_shipping_label_args,
+			 * which receives the filtered split as $ss_args['ss_parcels'] and
+			 * keeps the final say.
+			 *
+			 * @since 9.0.0
+			 *
+			 * @param array|string|false $parcels   The stored parcel split rows, or an empty value when the order is not split.
+			 * @param int                $order_id  Order ID.
+			 * @param boolean            $is_return Whether the label is a return label.
+			 *
+			 * @return array|string|false The parcel split rows to use.
+			 */
+			$ss_args['ss_parcels'] = apply_filters(
+				'smart_send_order_parcels',
+				$this->shipping_order->get_ss_shipping_order_parcels( $order_id ),
+				$order_id,
+				$is_return
+			);
+
+			/*
+			 * Filter the arguments used when creating a shipping label
+			 *
+			 * @param array   $ss_args  contains info about shipping carrier, shipping method, agent and parcels
+			 * @param int     $order_id Order ID
+			 * @param boolean $is_return Whether or not the label is return (true) or normal (false)
+			 */
+			$ss_args = apply_filters( 'smart_send_shipping_label_args', $ss_args, $order_id, $is_return );
+
+			$receiver = $this->order_data->get_receiver_data();
+
+			// Add the pickup point to the shipment, if any.
+			$ss_agent = apply_filters(
+				'smart_send_order_pickup_point',
+				empty( $ss_args['ss_agent'] ) ? null : $ss_args['ss_agent'],
+				$order_id
+			);
+
+			$pickup_point = empty( $ss_agent ) ? null : $this->build_pickup_point( $ss_agent );
+
+			// Item lines and totals.
+			$items_data = $this->order_data->get_items_data();
+
+			$parcels = array();
+			$totals  = array(
+				'subtotal_net_amount' => null,
+				'subtotal_tax_amount' => null,
+				'shipping_net_amount' => null,
+				'shipping_tax_amount' => null,
+				'total_net_amount'    => null,
+				'total_tax_amount'    => null,
+				'currency'            => null,
+			);
+
+			if ( ! empty( $items_data ) ) {
+				$totals     = $this->order_data->get_totals();
+				$order_note = $this->order_data->get_order_note();
+
+				// Item rows, keyed by product/variation id so a parcel
+				// split can reference them.
+				$item_lookup  = array();
+				$weight_total = 0;
+
+				foreach ( $items_data as $item_row ) {
+					$item_lookup[ $item_row['id'] ] = $item_row;
+
+					if ( $item_row['unit_weight'] ) {
+						$weight_total += ( $item_row['quantity'] * $item_row['unit_weight'] );
+					}
+				}
+
+				if ( ! empty( $ss_args['ss_parcels'] ) && is_array( $ss_args['ss_parcels'] ) ) {
+					$parcels = $this->build_split_parcels( $ss_args['ss_parcels'], $item_lookup, $order_note );
+				} else {
+					// A single parcel containing all the items just defined.
+					$parcels[] = array(
+						'internal_id'        => $this->value_or_null( $order_id ),
+						'internal_reference' => $this->value_or_null( $this->order_data->get_order_number() ),
+						'weight'             => $this->value_or_null( $weight_total ),
+						'height'             => null,
+						'width'              => null,
+						'length'             => null,
+						'freetext'           => $this->value_or_null( $order_note ),
+						'items'              => array_values( $items_data ),
+						'total_net_amount'   => $totals['subtotal_net_amount'],
+						'total_tax_amount'   => $totals['subtotal_tax_amount'],
+					);
+				}
+			}
+
+			/*
+			 * Filter the parcels section of the booking request. Unlike
+			 * before #113, this now operates on the internal representation
+			 * (plain parcel arrays, each with an 'items' array of item
+			 * rows) rather than assembled Smartsend\Models\Shipment\Parcel
+			 * objects - the smart_send_payload_* filters are unreleased
+			 * (#73/#111) so this signature change is not a breaking change.
+			 *
+			 * @since 9.0.0
+			 *
+			 * @param array[]  $parcels The assembled parcel rows (see the return doc of self::build()).
+			 * @param WC_Order $order   The WooCommerce order.
+			 */
+			$parcels = apply_filters( 'smart_send_payload_parcels', $parcels, $this->order );
+
+			return array(
+				'internal_id'         => $this->value_or_null( $order_id ),
+				'internal_reference'  => $this->value_or_null( $this->order_data->get_order_number() ),
+				'shipping_carrier'    => $this->value_or_null( $ss_args['ss_carrier'] ),
+				'shipping_method'     => $this->value_or_null( $ss_args['ss_type'] ),
+				'shipping_date'       => gmdate( 'Y-m-d' ),
+				'receiver'            => $receiver,
+				'pickup_point'        => $pickup_point,
+				'parcels'             => $parcels,
+				'subtotal_net_amount' => $totals['subtotal_net_amount'],
+				'subtotal_tax_amount' => $totals['subtotal_tax_amount'],
+				'shipping_net_amount' => $totals['shipping_net_amount'],
+				'shipping_tax_amount' => $totals['shipping_tax_amount'],
+				'total_net_amount'    => $totals['total_net_amount'],
+				'total_tax_amount'    => $totals['total_tax_amount'],
+				'currency'            => $totals['currency'],
+			);
+		}
+
+		/**
+		 * Build the pickup-point section from the stored agent object.
+		 *
+		 * Named after v2's PickupParty.service_point_code rather than v1's
+		 * agent_no/agent (#111) - the v1 wire adapter still calls it
+		 * agent_no on the wire.
+		 *
+		 * @param object $ss_agent The agent object stored on the order.
+		 *
+		 * @return array
+		 */
+		protected function build_pickup_point( $ss_agent ) {
+			return array(
+				'internal_id'        => isset( $ss_agent->id ) ? $ss_agent->id : $ss_agent->agent_no,
+				'internal_reference' => isset( $ss_agent->id ) ? $ss_agent->id : $ss_agent->agent_no,
+				'service_point_code' => $this->value_or_null( $ss_agent->agent_no ),
+				'company'            => $this->value_or_null( $ss_agent->company ),
+				'address_line1'      => $this->value_or_null( $ss_agent->address_line1 ),
+				'address_line2'      => $this->value_or_null( $ss_agent->address_line2 ),
+				'postal_code'        => $this->value_or_null( $ss_agent->postal_code ),
+				'city'               => $this->value_or_null( $ss_agent->city ),
+				'country'            => $this->value_or_null( $ss_agent->country ),
+			);
+		}
+
+		/**
+		 * Build one parcel per box from the parcel-split meta stored on the
+		 * order.
+		 *
+		 * @param array       $ss_parcels  Parcel split meta rows (id, name, value).
+		 * @param array       $item_lookup Item rows keyed by product/variation id.
+		 * @param string|null $order_note  Freetext for the parcels.
+		 *
+		 * @return array[]
+		 */
+		protected function build_split_parcels( $ss_parcels, $item_lookup, $order_note ) {
+			$parcels = array();
+
+			$boxes = array();
+			foreach ( $ss_parcels as $parcel_meta ) {
+				$boxes[ $parcel_meta['value'] ][] = array(
+					'id'   => $parcel_meta['id'],
+					'name' => $parcel_meta['name'],
+				);
+			}
+
+			foreach ( $boxes as $box_items ) {
+				$item_net_total    = 0;
+				$item_tax_total    = 0;
+				$item_weight_total = 0;
+				$box_item_rows     = array();
+
+				foreach ( $box_items as $box_item ) {
+					$item_row = $item_lookup[ $box_item['id'] ];
+					$quantity = $item_row['quantity'] ? $item_row['quantity'] : 1;
+
+					// Per-unit share of the (possibly multi-unit) line, one
+					// row per unit like the stored split meta - matches the
+					// pre-#113 behaviour bug-for-bug (each box embeds the
+					// full order-line item row, not a per-unit slice of it).
+					$item_net_total    += ( $item_row['total_net_amount'] / $quantity );
+					$item_tax_total    += ( $item_row['total_tax_amount'] / $quantity );
+					$item_weight_total += floatval( $item_row['unit_weight'] );
+
+					$box_item_rows[] = $item_row;
+				}
+
+				/*
+				 * Filter the weight of a parcel.
+				 *
+				 * @param float|null $parcel_weight Total weight of the items in the parcel.
+				 * @param int        $order_id      Order ID.
+				 */
+				$parcel_total_weight = apply_filters(
+					'smart_send_parcel_weight',
+					$this->value_or_null( $item_weight_total ),
+					$this->order_data->get_order_id()
+				);
+
+				$parcels[] = array(
+					'internal_id'        => $this->value_or_null( $this->order_data->get_order_id() ),
+					'internal_reference' => $this->value_or_null( $this->order_data->get_order_number() ),
+					'weight'             => $parcel_total_weight,
+					'height'             => null,
+					'width'              => null,
+					'length'             => null,
+					'freetext'           => $this->value_or_null( $order_note ),
+					'items'              => $box_item_rows,
+					'total_net_amount'   => $this->value_or_null( $item_net_total ),
+					'total_tax_amount'   => $this->value_or_null( $item_tax_total ),
+				);
+			}
+
+			return $parcels;
+		}
+
+		/**
+		 * Return the value when truthy, null otherwise (the API models
+		 * expect null instead of empty/zero values).
+		 *
+		 * @param mixed $value The value to check.
+		 *
+		 * @return mixed|null
+		 */
+		protected function value_or_null( $value ) {
+			if ( $value ) {
+				return $value;
+			}
+
+			return null;
+		}
+	}
+
+endif;

--- a/smart-send-logistics/admin/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/admin/class-ss-shipping-shipment.php
@@ -15,9 +15,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 
 	/**
-	 * Assembles the Smart Send API shipment model for a WooCommerce order and
-	 * sends it to the API. All WooCommerce data access goes through
-	 * SS_Shipping_Order_Data; this class only builds the API models.
+	 * Sends a WooCommerce order to the Smart Send API as a shipment.
+	 *
+	 * SS_Shipping_Shipment_Builder assembles the new internal shipment
+	 * representation (#113); this class is now only a thin adapter that
+	 * translates that representation into the v1 wire request
+	 * (Smartsend\Models\Shipment and its sub-models) and sends it. That
+	 * translation exists here only because #112's resource layer, which is
+	 * meant to own it permanently, is not part of this change - once #112
+	 * lands, this class's translate_to_wire_shipment() and its helpers
+	 * move there.
 	 */
 	class SS_Shipping_Shipment {
 
@@ -46,7 +53,15 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 		protected ?SS_Shipping_WC_Order $shipping_order = null;
 
 		/**
-		 * The shipment model being assembled.
+		 * The internal shipment representation assembled by
+		 * SS_Shipping_Shipment_Builder, or an error array.
+		 *
+		 * @var array|null
+		 */
+		protected ?array $representation = null;
+
+		/**
+		 * The v1 wire shipment model translated from the representation.
 		 *
 		 * @var \Smartsend\Models\Shipment|null
 		 */
@@ -74,7 +89,9 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 			$this->order_data     = new SS_Shipping_Order_Data( $this->order );
 			$this->shipping_order = $shipping_order;
 
-			// New shipment model.
+			// Wire shipment model, empty until the representation is
+			// translated. Kept even on a build error so a caller that
+			// still sends the (empty) request behaves as it always has.
 			$this->shipment = new \Smartsend\Models\Shipment();
 		}
 
@@ -124,190 +141,87 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 		}
 
 		/**
-		 * Create Payload for API request.
+		 * Build the internal shipment representation and translate it into
+		 * the v1 wire shipment model.
 		 *
 		 * @param boolean $is_return Whether the label is a return label.
 		 *
-		 * @return array|void
+		 * @return array|void The representation, only when it is an error.
 		 */
 		protected function make_single_shipment_api_payload( $is_return ) {
-			$order_id = $this->order_data->get_order_id();
+			$builder              = new SS_Shipping_Shipment_Builder( $this->order, $this->order_data, $this->shipping_order );
+			$this->representation = $builder->build( $is_return );
 
-			$ss_args = array();
-
-			// Get shipping method.
-			$ss_shipping_method_id = $this->shipping_order->get_smart_send_method_id( $order_id, $is_return );
-
-			if ( $is_return && isset( $ss_shipping_method_id['smart_send_return_method'] ) ) {
-				// If no return method set return error.
-				if ( empty( $ss_shipping_method_id['smart_send_return_method'] ) ) {
-					return array( 'error' => __( 'No return method set', 'smart-send-logistics' ) );
-				} else {
-					$ss_shipping_method_id = $ss_shipping_method_id['smart_send_return_method'];
-				}
-			} else {
-				$ss_args['ss_agent'] = $this->shipping_order->get_ss_shipping_order_agent( $order_id );
+			if ( isset( $this->representation['error'] ) ) {
+				return $this->representation;
 			}
 
-			// Determine shipping method and carrier from return settings.
-			$ss_args['ss_carrier'] = SS_SHIPPING_WC()->get_shipping_method_carrier( $ss_shipping_method_id );
-			$ss_args['ss_type']    = SS_SHIPPING_WC()->get_shipping_method_type( $ss_shipping_method_id );
-			/*
-			 * Filter the parcel split used for the order before the shipment
-			 * payload is assembled. The split is the value stored by the
-			 * "Split into parcels" admin option: an array of rows, each with
-			 * keys 'id' (product/variation id), 'name' (product name) and
-			 * 'value' (box number, 1-9). An empty value means a single parcel
-			 * containing all items. Runs before smart_send_shipping_label_args,
-			 * which receives the filtered split as $ss_args['ss_parcels'] and
-			 * keeps the final say.
-			 *
-			 * @since 9.0.0
-			 *
-			 * @param array|string|false $parcels   The stored parcel split rows, or an empty value when the order is not split.
-			 * @param int                $order_id  Order ID.
-			 * @param boolean            $is_return Whether the label is a return label.
-			 *
-			 * @return array|string|false The parcel split rows to use.
-			 */
-			$ss_args['ss_parcels'] = apply_filters(
-				'smart_send_order_parcels',
-				$this->shipping_order->get_ss_shipping_order_parcels( $order_id ),
-				$order_id,
-				$is_return
-			);
+			$this->shipment = $this->translate_to_wire_shipment( $this->representation );
+		}
 
-			/*
-			 * Filter the arguments used when creating a shipping label
-			 *
-			 * @param array   $ss_args  contains info about shipping carrier, shipping method, agent and parcels
-			 * @param int     $order_id Order ID
-			 * @param boolean $is_return Whether or not the label is return (true) or normal (false)
-			 */
-			$ss_args = apply_filters( 'smart_send_shipping_label_args', $ss_args, $order_id, $is_return );
+		/**
+		 * Translate the internal shipment representation into the v1 wire
+		 * shipment model. This is the single point where the excl/incl
+		 * pairs are (re)computed from the representation's single net/tax
+		 * amounts (#113) - the actual v1 wire payload is unchanged.
+		 *
+		 * @param array $representation The internal shipment representation from SS_Shipping_Shipment_Builder::build().
+		 *
+		 * @return \Smartsend\Models\Shipment
+		 */
+		protected function translate_to_wire_shipment( array $representation ) {
+			$receiver = $this->build_receiver( $representation );
 
-			// Add the receiver to the shipment.
-			$receiver = $this->build_receiver();
-			$this->shipment->setReceiver( $receiver );
+			$shipment = new \Smartsend\Models\Shipment();
+			$shipment->setReceiver( $receiver );
 
-			// Add the agent (pickup point) to the shipment, if any.
-			$ss_agent = apply_filters(
-				'smart_send_order_pickup_point',
-				empty( $ss_args['ss_agent'] ) ? null : $ss_args['ss_agent'],
-				$order_id
-			);
-
-			if ( ! empty( $ss_agent ) ) {
-				$this->shipment->setAgent( $this->build_agent( $ss_agent ) );
+			if ( ! empty( $representation['pickup_point'] ) ) {
+				$shipment->setAgent( $this->build_agent( $representation['pickup_point'] ) );
 			}
-
-			// Item lines and totals.
-			$items_data = $this->order_data->get_items_data();
 
 			$parcels = array();
-			$totals  = array(
-				'subtotal_price_excluding_tax' => null,
-				'subtotal_price_including_tax' => null,
-				'subtotal_tax_amount'          => null,
-				'shipping_price_excluding_tax' => null,
-				'shipping_price_including_tax' => null,
-				'shipping_tax_amount'          => null,
-				'total_price_excluding_tax'    => null,
-				'total_price_including_tax'    => null,
-				'total_tax_amount'             => null,
-				'currency'                     => null,
-			);
-
-			if ( ! empty( $items_data ) ) {
-				$totals     = $this->order_data->get_totals();
-				$order_note = $this->order_data->get_order_note();
-
-				// Build the item models, keyed by product/variation id so a
-				// parcel split can reference them.
-				$items        = array();
-				$item_lookup  = array();
-				$weight_total = 0;
-
-				foreach ( $items_data as $item_row ) {
-					$item_model = $this->build_item( $item_row );
-
-					$items[] = $item_model;
-
-					$item_lookup[ $item_row['id'] ] = array(
-						'row'   => $item_row,
-						'model' => $item_model,
-					);
-
-					if ( $item_row['unit_weight'] ) {
-						$weight_total += ( $item_row['quantity'] * $item_row['unit_weight'] );
-					}
-				}
-
-				if ( ! empty( $ss_args['ss_parcels'] ) ) {
-					if ( is_array( $ss_args['ss_parcels'] ) ) {
-						$parcels = $this->build_split_parcels( $ss_args['ss_parcels'], $item_lookup, $order_note );
-					}
-				} else {
-					// Create a single parcel containing the items just defined.
-					$parcel = new \Smartsend\Models\Shipment\Parcel();
-					$parcel->setInternalId( $this->value_or_null( $order_id ) )
-						->setInternalReference( $this->value_or_null( $this->order_data->get_order_number() ) )
-						->setWeight( $this->value_or_null( $weight_total ) )
-						->setHeight( null )
-						->setWidth( null )
-						->setLength( null )
-						->setFreetext( $this->value_or_null( $order_note ) )
-						->setItems( $items )// Alternatively add each item using $parcel->addItem(Item $item).
-						->setTotalPriceExcludingTax( $this->value_or_null( $totals['subtotal_price_excluding_tax'] ) )
-						->setTotalPriceIncludingTax( $this->value_or_null( $totals['subtotal_price_including_tax'] ) )
-						->setTotalTaxAmount( $this->value_or_null( $totals['subtotal_tax_amount'] ) );
-
-					$parcels[] = $parcel;
-				}
+			foreach ( $representation['parcels'] as $parcel_row ) {
+				$parcels[] = $this->build_parcel( $parcel_row );
 			}
-
-			/*
-			 * Filter the parcels section of the booking request.
-			 *
-			 * @param \Smartsend\Models\Shipment\Parcel[] $parcels The assembled parcel models.
-			 * @param WC_Order                            $order   The WooCommerce order.
-			 */
-			$parcels = apply_filters( 'smart_send_payload_parcels', $parcels, $this->order );
 
 			// Create services.
 			$services = new \Smartsend\Models\Shipment\Services();
 			$services->setSmsNotification( $receiver->getSms() )// Always enable SMS notification.
 				->setEmailNotification( $receiver->getEmail() ); // Always enable Email notification.
 
-			// Add final parameters to shipment.
-			$this->shipment->setInternalId( $this->value_or_null( $order_id ) )
-				->setInternalReference( $this->value_or_null( $this->order_data->get_order_number() ) )
-				->setShippingCarrier( $this->value_or_null( $ss_args['ss_carrier'] ) )
-				->setShippingMethod( $this->value_or_null( $ss_args['ss_type'] ) )
-				->setShippingDate( gmdate( 'Y-m-d' ) )
-				->setParcels( $parcels )// Alternatively add each parcel using $this->shipment->addParcel(Parcel $parcel).
+			$shipment->setInternalId( $representation['internal_id'] )
+				->setInternalReference( $this->value_or_null( $representation['internal_reference'] ) )
+				->setShippingCarrier( $this->value_or_null( $representation['shipping_carrier'] ) )
+				->setShippingMethod( $this->value_or_null( $representation['shipping_method'] ) )
+				->setShippingDate( $representation['shipping_date'] )
+				->setParcels( $parcels )// Alternatively add each parcel using $shipment->addParcel(Parcel $parcel).
 				->setServices( $services )
-				->setSubtotalPriceExcludingTax( $this->value_or_null( $totals['subtotal_price_excluding_tax'] ) )
-				->setSubtotalPriceIncludingTax( $this->value_or_null( $totals['subtotal_price_including_tax'] ) )
-				->setTotalPriceExcludingTax( $this->value_or_null( $totals['total_price_excluding_tax'] ) )
-				->setTotalPriceIncludingTax( $this->value_or_null( $totals['total_price_including_tax'] ) )
-				->setShippingPriceExcludingTax( $this->value_or_null( $totals['shipping_price_excluding_tax'] ) )
-				->setShippingPriceIncludingTax( $this->value_or_null( $totals['shipping_price_including_tax'] ) )
-				->setTotalTaxAmount( $this->value_or_null( $totals['total_tax_amount'] ) )
-				->setCurrency( $this->value_or_null( $totals['currency'] ) );
+				->setSubtotalPriceExcludingTax( $this->value_or_null( $representation['subtotal_net_amount'] ) )
+				->setSubtotalPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $representation['subtotal_net_amount'], $representation['subtotal_tax_amount'] ) ) )
+				->setTotalPriceExcludingTax( $this->value_or_null( $representation['total_net_amount'] ) )
+				->setTotalPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $representation['total_net_amount'], $representation['total_tax_amount'] ) ) )
+				->setShippingPriceExcludingTax( $this->value_or_null( $representation['shipping_net_amount'] ) )
+				->setShippingPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $representation['shipping_net_amount'], $representation['shipping_tax_amount'] ) ) )
+				->setTotalTaxAmount( $this->value_or_null( $representation['total_tax_amount'] ) )
+				->setCurrency( $this->value_or_null( $representation['currency'] ) );
+
+			return $shipment;
 		}
 
 		/**
-		 * Build the receiver model from the order data.
+		 * Build the receiver model from the representation's receiver
+		 * section.
+		 *
+		 * @param array $representation The internal shipment representation.
 		 *
 		 * @return \Smartsend\Models\Shipment\Receiver
 		 */
-		protected function build_receiver() {
-			$receiver_data = $this->order_data->get_receiver_data();
+		protected function build_receiver( array $representation ) {
+			$receiver_data = $representation['receiver'];
 
 			$receiver = new \Smartsend\Models\Shipment\Receiver();
-			$receiver->setInternalId( $this->order_data->get_order_id() )
-				->setInternalReference( $this->value_or_null( $this->order_data->get_order_number() ) )
+			$receiver->setInternalId( $representation['internal_id'] )
+				->setInternalReference( $this->value_or_null( $representation['internal_reference'] ) )
 				->setCompany( $this->value_or_null( $receiver_data['company'] ) )
 				->setNameLine1( $this->value_or_null( $receiver_data['name_line1'] ) )
 				->setNameLine2( $this->value_or_null( $receiver_data['name_line2'] ) )
@@ -323,35 +237,43 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 		}
 
 		/**
-		 * Build the agent (pickup point) model from the stored agent object.
+		 * Build the agent (pickup point) model from the representation's
+		 * pickup-point section.
 		 *
-		 * @param object $ss_agent The agent object stored on the order.
+		 * @param array $pickup_point Pickup point data, see SS_Shipping_Shipment_Builder::build_pickup_point().
 		 *
 		 * @return \Smartsend\Models\Shipment\Agent
 		 */
-		protected function build_agent( $ss_agent ) {
+		protected function build_agent( array $pickup_point ) {
 			$agent = new \Smartsend\Models\Shipment\Agent();
-			$agent->setInternalId( isset( $ss_agent->id ) ? $ss_agent->id : $ss_agent->agent_no )
-				->setInternalReference( isset( $ss_agent->id ) ? $ss_agent->id : $ss_agent->agent_no )
-				->setAgentNo( $this->value_or_null( $ss_agent->agent_no ) )
-				->setCompany( $this->value_or_null( $ss_agent->company ) )
-				->setAddressLine1( $this->value_or_null( $ss_agent->address_line1 ) )
-				->setAddressLine2( $this->value_or_null( $ss_agent->address_line2 ) )
-				->setPostalCode( $this->value_or_null( $ss_agent->postal_code ) )
-				->setCity( $this->value_or_null( $ss_agent->city ) )
-				->setCountry( $this->value_or_null( $ss_agent->country ) );
+			$agent->setInternalId( $pickup_point['internal_id'] )
+				->setInternalReference( $pickup_point['internal_reference'] )
+				->setAgentNo( $pickup_point['service_point_code'] )
+				->setCompany( $pickup_point['company'] )
+				->setAddressLine1( $pickup_point['address_line1'] )
+				->setAddressLine2( $pickup_point['address_line2'] )
+				->setPostalCode( $pickup_point['postal_code'] )
+				->setCity( $pickup_point['city'] )
+				->setCountry( $pickup_point['country'] );
 
 			return $agent;
 		}
 
 		/**
-		 * Build an item model from an item data row.
+		 * Build an item model from an item row of the representation.
 		 *
-		 * @param array $item_row Item row from SS_Shipping_Order_Data::get_items_data().
+		 * @param array $item_row Item row, see SS_Shipping_Order_Data::get_items_data().
 		 *
 		 * @return \Smartsend\Models\Shipment\Item
 		 */
-		protected function build_item( $item_row ) {
+		protected function build_item( array $item_row ) {
+			$quantity = $item_row['quantity'] ? $item_row['quantity'] : 1;
+
+			// The wire format's unit_price_* pair is recomputed here, once,
+			// from the representation's single net/tax amount (#113).
+			$unit_net_amount = $item_row['total_net_amount'] / $quantity;
+			$unit_tax_amount = $item_row['total_tax_amount'] / $quantity;
+
 			$item = new \Smartsend\Models\Shipment\Item();
 			$item->setInternalId( $this->value_or_null( $item_row['id'] ) )
 				->setInternalReference( $this->value_or_null( $item_row['id'] ) )
@@ -362,85 +284,43 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 				->setCountryOfOrigin( $this->value_or_null( $item_row['country_of_origin'] ) )
 				->setImageUrl( null )// The product image url can be used, but sometimes includes spaces (bug) which causes validation error.
 				->setUnitWeight( $item_row['unit_weight'] > 0 ? $item_row['unit_weight'] : null )
-				->setUnitPriceExcludingTax( $this->value_or_null( $item_row['unit_price_excluding_tax'] ) )
-				->setUnitPriceIncludingTax( $this->value_or_null( $item_row['unit_price_including_tax'] ) )
+				->setUnitPriceExcludingTax( $this->value_or_null( $unit_net_amount ) )
+				->setUnitPriceIncludingTax( $this->value_or_null( $unit_net_amount + $unit_tax_amount ) )
 				->setQuantity( $this->value_or_null( $item_row['quantity'] ) )
-				->setTotalPriceExcludingTax( $this->value_or_null( $item_row['total_price_excluding_tax'] ) )
-				->setTotalPriceIncludingTax( $this->value_or_null( $item_row['total_price_including_tax'] ) )
+				->setTotalPriceExcludingTax( $this->value_or_null( $item_row['total_net_amount'] ) )
+				->setTotalPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $item_row['total_net_amount'], $item_row['total_tax_amount'] ) ) )
 				->setTotalTaxAmount( $this->value_or_null( $item_row['total_tax_amount'] ) );
 
 			return $item;
 		}
 
 		/**
-		 * Build one parcel per box from the parcel-split meta stored on the order.
+		 * Build a parcel model from a parcel row of the representation.
 		 *
-		 * @param array       $ss_parcels  Parcel split meta rows (id, name, value).
-		 * @param array       $item_lookup Item rows and models keyed by product/variation id.
-		 * @param string|null $order_note  Freetext for the parcels.
+		 * @param array $parcel_row Parcel row, see SS_Shipping_Shipment_Builder::build().
 		 *
-		 * @return \Smartsend\Models\Shipment\Parcel[]
+		 * @return \Smartsend\Models\Shipment\Parcel
 		 */
-		protected function build_split_parcels( $ss_parcels, $item_lookup, $order_note ) {
-			$parcels = array();
-
-			$boxes = array();
-			foreach ( $ss_parcels as $parcel_meta ) {
-				$boxes[ $parcel_meta['value'] ][] = array(
-					'id'   => $parcel_meta['id'],
-					'name' => $parcel_meta['name'],
-				);
+		protected function build_parcel( array $parcel_row ) {
+			$items = array();
+			foreach ( $parcel_row['items'] as $item_row ) {
+				$items[] = $this->build_item( $item_row );
 			}
 
-			foreach ( $boxes as $box_items ) {
-				$item_total_wo_tax   = 0;
-				$item_total_tax      = 0;
-				$item_total_incl_tax = 0;
-				$item_weight_total   = 0;
-				$product_items       = array();
+			$parcel = new \Smartsend\Models\Shipment\Parcel();
+			$parcel->setInternalId( $this->value_or_null( $parcel_row['internal_id'] ) )
+				->setInternalReference( $this->value_or_null( $parcel_row['internal_reference'] ) )
+				->setWeight( $this->value_or_null( $parcel_row['weight'] ) )
+				->setHeight( $parcel_row['height'] )
+				->setWidth( $parcel_row['width'] )
+				->setLength( $parcel_row['length'] )
+				->setFreetext( $this->value_or_null( $parcel_row['freetext'] ) )
+				->setItems( $items )// Alternatively add each item using $parcel->addItem(Item $item).
+				->setTotalPriceExcludingTax( $this->value_or_null( $parcel_row['total_net_amount'] ) )
+				->setTotalPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $parcel_row['total_net_amount'], $parcel_row['total_tax_amount'] ) ) )
+				->setTotalTaxAmount( $this->value_or_null( $parcel_row['total_tax_amount'] ) );
 
-				foreach ( $box_items as $box_item ) {
-					$item_row = $item_lookup[ $box_item['id'] ]['row'];
-
-					$item_total_wo_tax   += floatval( $item_row['unit_price_excluding_tax'] );
-					$item_total_incl_tax += floatval( $item_row['unit_price_including_tax'] );
-					$item_weight_total   += floatval( $item_row['unit_weight'] );
-
-					// Compute for the total tax per individual.
-					$item_total_tax += $item_total_incl_tax - $item_total_wo_tax;
-
-					$product_items[] = $item_lookup[ $box_item['id'] ]['model'];
-				}
-
-				/*
-				 * Filter the weight of a parcel.
-				 *
-				 * @param float|null $parcel_weight Total weight of the items in the parcel.
-				 * @param int        $order_id      Order ID.
-				 */
-				$parcel_total_weight = apply_filters(
-					'smart_send_parcel_weight',
-					$this->value_or_null( $item_weight_total ),
-					$this->order_data->get_order_id()
-				);
-
-				$parcel = new \Smartsend\Models\Shipment\Parcel();
-				$parcel->setInternalId( $this->value_or_null( $this->order_data->get_order_id() ) )
-					->setInternalReference( $this->value_or_null( $this->order_data->get_order_number() ) )
-					->setWeight( $parcel_total_weight )
-					->setHeight( null )
-					->setWidth( null )
-					->setLength( null )
-					->setFreetext( $this->value_or_null( $order_note ) )
-					->setItems( $product_items )// Alternatively add each item using $parcel->addItem(Item $item).
-					->setTotalPriceExcludingTax( $this->value_or_null( $item_total_wo_tax ) )
-					->setTotalPriceIncludingTax( $this->value_or_null( $item_total_incl_tax ) )
-					->setTotalTaxAmount( $this->value_or_null( $item_total_tax ) );
-
-				$parcels[] = $parcel;
-			}
-
-			return $parcels;
+			return $parcel;
 		}
 
 		/**
@@ -455,8 +335,22 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 		}
 
 		/**
-		 * Return the value when truthy, null otherwise (the API models expect
-		 * null instead of empty/zero values).
+		 * Add a net amount and a tax amount together, treating a null
+		 * operand as zero - the including-tax wire figure derived from the
+		 * representation's single net/tax amount (#113).
+		 *
+		 * @param float|null $net_amount Net (excluding tax) amount.
+		 * @param float|null $tax_amount Tax amount.
+		 *
+		 * @return float
+		 */
+		protected function net_plus_tax( $net_amount, $tax_amount ) {
+			return (float) $net_amount + (float) $tax_amount;
+		}
+
+		/**
+		 * Return the value when truthy, null otherwise (the API models
+		 * expect null instead of empty/zero values).
 		 *
 		 * @param mixed $value The value to check.
 		 *

--- a/smart-send-logistics/includes/class-ss-shipping-order-data.php
+++ b/smart-send-logistics/includes/class-ss-shipping-order-data.php
@@ -145,9 +145,20 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 		 * Get the item lines for the order: one row per order line with
 		 * weight, price and customs data.
 		 *
-		 * Prices are based on the pre-discount line subtotal, matching how
-		 * the plugin has always priced item lines (order-level discounts are
-		 * reflected in the order totals, not the individual lines).
+		 * Prices are based on the item's post-discount line total
+		 * (WC_Order_Item_Product::get_total()/get_total_tax()), not the
+		 * pre-discount line subtotal. WooCommerce itself prorates
+		 * order-level (percentage/fixed-cart) coupons across line items and
+		 * applies line-level (fixed-product) coupons directly, both landing
+		 * in get_total()/get_total_tax() - so sum(item totals) reconciles
+		 * with the order subtotal from get_totals() without needing any
+		 * discount-allocation math of our own (#128). Gift card redemptions
+		 * are order fees, never order items, so they never reach this
+		 * method - see the class docblock on SS_Shipping_Shipment_Builder
+		 * for the gift-card exclusion status.
+		 *
+		 * A single net amount + tax amount is returned per item line (no
+		 * excl/incl pair) - see #113.
 		 *
 		 * @return array[] List of item rows.
 		 */
@@ -170,39 +181,31 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 
 				$quantity = $item->get_quantity();
 
-				// Total w/o tax and individual w/o tax. Clamped at >= 0 so a
+				// Post-discount line total and its tax. Clamped at >= 0 so a
 				// negative line never produces a negative item value (#54).
-				$total_price_excluding_tax = max( 0.0, (float) $item->get_subtotal() );
-				$unit_price_excluding_tax  = $total_price_excluding_tax / $quantity;
-
-				// Total tax.
-				$total_tax_amount = max( 0.0, (float) $item->get_subtotal_tax() );
-
-				// Total w/ tax and individual w/ tax.
-				$total_price_including_tax = $total_price_excluding_tax + $total_tax_amount;
-				$unit_price_including_tax  = $total_price_including_tax / $quantity;
+				$total_net_amount = max( 0.0, (float) $item->get_total() );
+				$total_tax_amount = max( 0.0, (float) $item->get_total_tax() );
 
 				$unit_weight = round( wc_get_weight( $product_variation->get_weight(), 'kg' ), 2 );
 
 				$items[] = array(
-					'id'                        => $product_id,
-					'sku'                       => $product_sku,
-					'name'                      => $product->get_title(),
-					'description'               => $this->get_product_meta( $product, $product_variation, '_ss_customs_desc' ),
-					'hs_code'                   => $this->get_product_meta( $product, $product_variation, '_ss_hs_code' ),
-					'country_of_origin'         => $this->get_product_meta( $product, $product_variation, '_ss_country_of_origin' ),
-					'quantity'                  => $quantity,
-					'unit_weight'               => $unit_weight,
-					'unit_price_excluding_tax'  => $unit_price_excluding_tax,
-					'unit_price_including_tax'  => $unit_price_including_tax,
-					'total_price_excluding_tax' => $total_price_excluding_tax,
-					'total_price_including_tax' => $total_price_including_tax,
-					'total_tax_amount'          => $total_tax_amount,
+					'id'                => $product_id,
+					'sku'               => $product_sku,
+					'name'              => $product->get_title(),
+					'description'       => $this->get_product_meta( $product, $product_variation, '_ss_customs_desc' ),
+					'hs_code'           => $this->get_product_meta( $product, $product_variation, '_ss_hs_code' ),
+					'country_of_origin' => $this->get_product_meta( $product, $product_variation, '_ss_country_of_origin' ),
+					'quantity'          => $quantity,
+					'unit_weight'       => $unit_weight,
+					'total_net_amount'  => $total_net_amount,
+					'total_tax_amount'  => $total_tax_amount,
 				);
 			}
 
 			/*
 			 * Filter the item lines of the booking request.
+			 *
+			 * @since 9.0.0
 			 *
 			 * @param array[]  $items One row per order line (see the return doc above).
 			 * @param WC_Order $order The WooCommerce order.
@@ -215,26 +218,36 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 		 *
 		 * The rule (see issue #72): totals are derived from what WooCommerce
 		 * itself reports via CRUD getters and reconcile with
-		 * WC_Order::get_total(): subtotal + shipping = total, on both the
-		 * including-tax and excluding-tax basis. Every value is clamped at
-		 * >= 0, so a discount or gift card larger than the item value (which
-		 * can push the non-shipping subtotal negative) never produces a
-		 * negative amount in the booking request (#54). When a clamp kicks
-		 * in, the clamped value wins over strict reconciliation.
+		 * WC_Order::get_total(): subtotal + shipping = total. Every net/tax
+		 * pair is clamped at >= 0, so a discount or gift card larger than
+		 * the item value (which can push the non-shipping subtotal
+		 * negative) never produces a negative amount in the booking request
+		 * (#54). When a clamp kicks in, the clamped value wins over strict
+		 * reconciliation.
+		 *
+		 * A single net amount + tax amount is returned per level (no
+		 * excl/incl pair) - the including-tax figure, where the wire
+		 * payload needs one, is net + tax computed once at the translation
+		 * boundary (#113). This is a minor, deliberate simplification of
+		 * the previous three-way independent clamp (excl/incl/tax each
+		 * clamped separately): net and tax are now clamped individually and
+		 * incl is always their sum, so it can no longer disagree with
+		 * net + tax the way independently-clamped values occasionally could.
+		 *
+		 * Gift card redemptions are not yet excluded from this calculation
+		 * - see the class docblock on SS_Shipping_Shipment_Builder for the
+		 * gift-card exclusion status (#128).
 		 *
 		 * @return array {
 		 *     Order totals.
 		 *
-		 *     @type float  $subtotal_price_excluding_tax Order total excl. shipping, excl. tax.
-		 *     @type float  $subtotal_price_including_tax Order total excl. shipping, incl. tax.
-		 *     @type float  $subtotal_tax_amount          Tax on the order total excl. shipping.
-		 *     @type float  $shipping_price_excluding_tax Shipping cost excl. tax.
-		 *     @type float  $shipping_price_including_tax Shipping cost incl. tax.
-		 *     @type float  $shipping_tax_amount          Tax on the shipping cost.
-		 *     @type float  $total_price_excluding_tax    Order total excl. tax.
-		 *     @type float  $total_price_including_tax    Order total incl. tax.
-		 *     @type float  $total_tax_amount             Total tax on the order.
-		 *     @type string $currency                     Order currency code.
+		 *     @type float  $subtotal_net_amount Order total excl. shipping, excl. tax.
+		 *     @type float  $subtotal_tax_amount Tax on the order total excl. shipping.
+		 *     @type float  $shipping_net_amount Shipping cost excl. tax.
+		 *     @type float  $shipping_tax_amount Tax on the shipping cost.
+		 *     @type float  $total_net_amount    Order total excl. tax.
+		 *     @type float  $total_tax_amount    Total tax on the order.
+		 *     @type string $currency            Order currency code.
 		 * }
 		 */
 		public function get_totals() {
@@ -254,22 +267,21 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 			$subtotal_excluding_tax = $subtotal_including_tax - $subtotal_tax;
 
 			$totals = array(
-				'subtotal_price_excluding_tax' => max( 0.0, $subtotal_excluding_tax ),
-				'subtotal_price_including_tax' => max( 0.0, $subtotal_including_tax ),
-				'subtotal_tax_amount'          => max( 0.0, $subtotal_tax ),
-				'shipping_price_excluding_tax' => max( 0.0, $shipping_excluding_tax ),
-				'shipping_price_including_tax' => max( 0.0, $shipping_including_tax ),
-				'shipping_tax_amount'          => max( 0.0, $shipping_tax ),
-				'total_price_excluding_tax'    => max( 0.0, $total_excluding_tax ),
-				'total_price_including_tax'    => max( 0.0, $total_including_tax ),
-				'total_tax_amount'             => max( 0.0, $total_tax ),
-				'currency'                     => $this->order->get_currency(),
+				'subtotal_net_amount' => max( 0.0, $subtotal_excluding_tax ),
+				'subtotal_tax_amount' => max( 0.0, $subtotal_tax ),
+				'shipping_net_amount' => max( 0.0, $shipping_excluding_tax ),
+				'shipping_tax_amount' => max( 0.0, $shipping_tax ),
+				'total_net_amount'    => max( 0.0, $total_excluding_tax ),
+				'total_tax_amount'    => max( 0.0, $total_tax ),
+				'currency'            => $this->order->get_currency(),
 			);
 
 			/*
 			 * Filter the totals section of the booking request. The filter
 			 * runs after the clamping rule, so returned values are used
 			 * as-is.
+			 *
+			 * @since 9.0.0
 			 *
 			 * @param array    $totals The order totals (see the return doc above).
 			 * @param WC_Order $order  The WooCommerce order.

--- a/smart-send-logistics/readme.txt
+++ b/smart-send-logistics/readme.txt
@@ -165,7 +165,7 @@ Example: show at most 5 pickup points and pre-select the closest one:
 * **smart_send_payload_totals** (since 9.0.0)
     A filter on the totals section (array) of the booking request
 * **smart_send_payload_parcels** (since 9.0.0)
-    A filter on the assembled parcel models (Smartsend\Models\Shipment\Parcel objects) of the booking request
+    A filter on the assembled parcels (array of parcel rows, each with an 'items' array of item rows - see #113) of the booking request
 * **smart_send_parcel_weight**
     A filter on the weight of each parcel when the order is split into parcels
 * **smart_send_order_note**

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -176,6 +176,7 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 
 			// Admin components.
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-plugins-screen-updates.php';
+			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-shipment-builder.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-shipment.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-order-meta.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-order-meta-box.php';

--- a/tests/Integration/ShipmentPayloadTest.php
+++ b/tests/Integration/ShipmentPayloadTest.php
@@ -168,7 +168,15 @@ it('books a simple domestic agent order with the full expected payload', functio
     ]));
 });
 
-it('prices item lines pre-discount when a percentage coupon is applied', function () {
+it('allocates an order-level percentage coupon discount down to the item lines (#128)', function () {
+    // Deliberate behaviour change from the v8 oddity this test used to
+    // assert: item lines used to be priced from the pre-discount line
+    // subtotal, so an order-level coupon discount only showed up in the
+    // parcel/order totals and sum(item totals) > order subtotal. #128 fixes
+    // this by pricing item lines from the post-discount line total instead
+    // (WC_Order_Item_Product::get_total(), which WooCommerce itself prorates
+    // order-level coupons into) so item lines and totals now reconcile
+    // exactly, without relying on the #54 clamp to hide the mismatch.
     $product = create_simple_product(['name' => 'Couponed Product', 'price' => 100, 'weight' => 1]);
     $coupon  = create_coupon(['type' => 'percent', 'amount' => 10]);
     $order   = create_order([
@@ -193,15 +201,14 @@ it('prices item lines pre-discount when a percentage coupon is applied', functio
                 'length'             => null,
                 'freetext'           => null,
                 'items'              => [
-                    // v8 oddity: item lines use the pre-discount subtotal, so
-                    // the coupon discount never shows up on the item lines.
                     expected_item($product, [
+                        'unit_price_excluding_tax'  => 90,
+                        'unit_price_including_tax'  => 90,
                         'quantity'                  => 2,
-                        'total_price_excluding_tax' => 200,
-                        'total_price_including_tax' => 200,
+                        'total_price_excluding_tax' => 180,
+                        'total_price_including_tax' => 180,
                     ]),
                 ],
-                // The coupon discount is reflected in the parcel totals.
                 'total_price_excluding_tax' => 180,
                 'total_price_including_tax' => 180,
                 'total_tax_amount'          => null,
@@ -641,15 +648,20 @@ it('lets the per-section payload filters adjust receiver, items, parcels and tot
         return $items;
     };
     $totals_filter = function (array $totals, WC_Order $filtered_order) {
-        $totals['total_price_including_tax'] = 999;
+        $totals['total_net_amount'] = 999;
 
         return $totals;
     };
+    // As of #113/#111 this filter operates on the internal representation's
+    // plain parcel arrays (each with an 'items' array of item rows), not on
+    // assembled Smartsend\Models\Shipment\Parcel objects - a deliberate
+    // signature change, safe because the filter is still unreleased (#73).
     $parcels_filter = function (array $parcels, WC_Order $filtered_order) {
-        foreach ($parcels as $parcel) {
-            expect($parcel)->toBeInstanceOf(\Smartsend\Models\Shipment\Parcel::class);
-            $parcel->setWeight(42);
+        foreach ($parcels as &$parcel) {
+            expect($parcel)->toBeArray();
+            $parcel['weight'] = 42;
         }
+        unset($parcel);
 
         return $parcels;
     };

--- a/tests/Integration/ShipmentRepresentationTest.php
+++ b/tests/Integration/ShipmentRepresentationTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * Coverage for the new internal shipment representation introduced by
+ * #113 (SS_Shipping_Shipment_Builder) and the #128 discount-allocation fix
+ * built on top of it. ShipmentPayloadTest.php proves the v1 wire payload
+ * translated from this representation is unchanged (or, for the two
+ * scenarios #128 deliberately fixes, correctly changed); this file asserts
+ * the representation itself: a single net + tax amount per level, no
+ * excl/incl pairs, and that item-line totals reconcile with the order
+ * subtotal for every native WooCommerce coupon type.
+ */
+
+/**
+ * Build the internal shipment representation for an order the same way
+ * SS_Shipping_Shipment does, without going through the (mocked) API call.
+ */
+function build_shipment_representation(WC_Order $order, bool $return = false): array
+{
+    $order_data = new SS_Shipping_Order_Data($order);
+    $builder    = new SS_Shipping_Shipment_Builder($order, $order_data, SS_SHIPPING_WC()->get_ss_shipping_wc_order());
+
+    return $builder->build($return);
+}
+
+beforeEach(function (): void {
+    with_ss_settings();
+});
+
+it('represents shipment, parcel and item totals as a single net + tax amount, with no excl/incl pair', function () {
+    $product = create_simple_product(['name' => 'Representation Product', 'price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [[$product, 2]],
+        'shipping_method' => 'postnord_homedelivery',
+        'shipping_total'  => '39',
+    ]);
+
+    $representation = build_shipment_representation($order);
+
+    // Shipment level: single net/tax pair, no excluding/including-tax keys.
+    expect($representation)->toHaveKeys([
+        'subtotal_net_amount',
+        'subtotal_tax_amount',
+        'shipping_net_amount',
+        'shipping_tax_amount',
+        'total_net_amount',
+        'total_tax_amount',
+    ]);
+    foreach (array_keys($representation) as $key) {
+        expect($key)->not->toContain('excluding_tax')
+            ->and($key)->not->toContain('including_tax');
+    }
+
+    // Parcel level.
+    expect($representation['parcels'])->toHaveCount(1);
+    $parcel = $representation['parcels'][0];
+    expect($parcel)->toHaveKeys(['total_net_amount', 'total_tax_amount']);
+    foreach (array_keys($parcel) as $key) {
+        expect($key)->not->toContain('excluding_tax')
+            ->and($key)->not->toContain('including_tax');
+    }
+
+    // Item level.
+    expect($parcel['items'])->toHaveCount(1);
+    $item = $parcel['items'][0];
+    expect($item)->toHaveKeys(['total_net_amount', 'total_tax_amount'])
+        ->and($item['total_net_amount'])->toEqual(200.0)
+        ->and($item['total_tax_amount'])->toEqual(0.0);
+    foreach (array_keys($item) as $key) {
+        expect($key)->not->toContain('excluding_tax')
+            ->and($key)->not->toContain('including_tax')
+            ->and($key)->not->toContain('unit_price'); // No per-unit price redundancy either.
+    }
+});
+
+it('names the pickup-point section after v2\'s service_point_code, not v1\'s agent_no', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_agent',
+    ]);
+    SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent($order->get_id(), sample_agent());
+
+    $representation = build_shipment_representation($order);
+
+    expect($representation['pickup_point'])->toHaveKey('service_point_code')
+        ->and($representation['pickup_point']['service_point_code'])->toBe('1234')
+        ->and($representation['pickup_point'])->not->toHaveKey('agent_no');
+});
+
+it('reconciles item-line totals with the order subtotal for a percentage coupon', function () {
+    $product = create_simple_product(['name' => 'Percent Coupon Product', 'price' => 100, 'weight' => 1]);
+    $coupon  = create_coupon(['type' => 'percent', 'amount' => 20]);
+    $order   = create_order([
+        'products'        => [[$product, 3]],
+        'coupons'         => $coupon->get_code(),
+        'shipping_method' => 'postnord_homedelivery',
+    ]);
+
+    $representation = build_shipment_representation($order);
+
+    $item_sum = array_sum(array_column($representation['parcels'][0]['items'], 'total_net_amount'));
+
+    expect($item_sum)->toEqual($representation['subtotal_net_amount'])
+        ->and($item_sum)->toEqual(240.0); // 3 x 100, 20% off.
+});
+
+it('reconciles item-line totals with the order subtotal for a fixed-cart coupon', function () {
+    $product_a = create_simple_product(['name' => 'Fixed Cart Product A', 'price' => 60, 'weight' => 1]);
+    $product_b = create_simple_product(['name' => 'Fixed Cart Product B', 'price' => 40, 'weight' => 1]);
+    $coupon    = create_coupon(['type' => 'fixed_cart', 'amount' => 20]);
+    $order     = create_order([
+        'products'        => [$product_a, $product_b],
+        'coupons'         => $coupon->get_code(),
+        'shipping_method' => 'postnord_homedelivery',
+    ]);
+
+    $representation = build_shipment_representation($order);
+
+    $item_sum = array_sum(array_column($representation['parcels'][0]['items'], 'total_net_amount'));
+
+    // 100 order subtotal, 20 fixed-cart discount prorated across both lines.
+    expect($item_sum)->toEqual($representation['subtotal_net_amount'])
+        ->and($item_sum)->toEqual(80.0);
+});
+
+it('reconciles item-line totals with the order subtotal for a fixed-product coupon', function () {
+    $product_a = create_simple_product(['name' => 'Fixed Product Coupon Target', 'price' => 60, 'weight' => 1]);
+    $product_b = create_simple_product(['name' => 'Fixed Product Coupon Bystander', 'price' => 40, 'weight' => 1]);
+    $coupon    = create_coupon(['type' => 'fixed_product', 'amount' => 15]);
+    $coupon->set_product_ids([$product_a->get_id()]);
+    $coupon->save();
+    $order = create_order([
+        'products'        => [$product_a, $product_b],
+        'coupons'         => $coupon->get_code(),
+        'shipping_method' => 'postnord_homedelivery',
+    ]);
+
+    $representation = build_shipment_representation($order);
+
+    $items    = $representation['parcels'][0]['items'];
+    $item_sum = array_sum(array_column($items, 'total_net_amount'));
+
+    // Only product A's line is discounted, by exactly the fixed amount.
+    $product_a_id = $product_a->get_id();
+    $line_a       = current(array_filter($items, fn ($item) => $item['id'] === $product_a_id));
+
+    expect($line_a['total_net_amount'])->toEqual(45.0)
+        ->and($item_sum)->toEqual($representation['subtotal_net_amount'])
+        ->and($item_sum)->toEqual(85.0);
+});


### PR DESCRIPTION
## Summary

Part of #113. Part of #128.

This PR implements both issues together, as directed: #128 (discount allocation + gift-card compatibility) is explicitly scoped to depend on #113's new internal shipment representation, so both land in the same pass.

**#113 - new internal shipment representation**
- `SS_Shipping_Order_Data::get_items_data()`/`get_totals()` now return a single net amount + tax amount per level (no more `*_excluding_tax`/`*_including_tax` pairs), shaped close to the Smart Send v2 schema.
- New `SS_Shipping_Shipment_Builder` (`smart-send-logistics/admin/class-ss-shipping-shipment-builder.php`) assembles the representation from `SS_Shipping_Order_Data`'s output plus the agent/pickup-point selection and parcel split - this is the "ShipmentBuilder" from the issue.
- The pickup-point section is named `service_point_code` (v2's `PickupParty.service_point_code`) instead of v1's `agent_no`/`agent`.
- `SS_Shipping_Shipment` is reduced to a thin adapter/translation step: it takes the representation and builds the v1 wire request (`Smartsend\Models\Shipment` and sub-models) at a single point. This translation logic stays here (rather than moving to a dedicated resource layer) because #112, which will own it permanently, is not part of this change - #112 can lift `translate_to_wire_shipment()` and its helpers wholesale.
- **The v1 wire payload is unchanged.** All `tests/Integration/ShipmentPayloadTest.php` golden tests pass unmodified, except the one scenario #128 deliberately fixes (see below).

**Filter surface change (for #112, working next, stacked on this branch):**
- `smart_send_payload_receiver` / `_items` / `_totals` already operated on plain arrays and are unchanged in shape (field names inside `_items`/`_totals` changed per the representation above, but the filter signatures - array + `WC_Order` - did not).
- `smart_send_payload_parcels` now receives an array of plain parcel rows (each with an `items` array of item rows), not `Smartsend\Models\Shipment\Parcel` objects. This is a deliberate signature change, safe because the filter is unreleased (confirmed against `origin/main`'s `readme.txt`: still marked "since 9.0.0", no shipped version carries it).
- readme.txt's filter docs updated accordingly.

**#128 - discount allocation**
- Item lines are now priced from `WC_Order_Item_Product::get_total()`/`get_total_tax()` (post-discount) instead of `get_subtotal()`/`get_subtotal_tax()` (pre-discount). WooCommerce itself prorates order-level (percentage/fixed-cart) coupons across line items and applies line-level (fixed-product) coupons directly - both land in `get_total()` - so `sum(item totals) === order subtotal` now holds exactly for every native coupon type, with no manual proportional-allocation math needed and without relying on the `#54` zero-clamp to hide the previous mismatch.
- This changes the expectations of the one `ShipmentPayloadTest.php` scenario that exercised the "v8 oddity" it fixes (`it allocates an order-level percentage coupon discount down to the item lines (#128)`, renamed from `it prices item lines pre-discount...`) - a deliberate, called-out behaviour change per the repo's refactor rule. Every other golden test, including the fee and taxed-order scenarios, is byte-for-byte unchanged.
- New `tests/Integration/ShipmentRepresentationTest.php` covers reconciliation for percentage, fixed-cart, and fixed-product coupons directly against the representation, plus the representation shape itself (single net/tax pair per level, pickup-point naming).

**#128 - gift card exclusion: deferred, documented follow-up**

WooCommerce Gift Cards is not installed, so its order representation could not be confirmed with code-level confidence. Research findings (from the plugin's public FAQ at `woocommerce.com/document/gift-cards/faq/`):
- "cart/order line items are not discounted and product/order revenue is recorded in full" - confirms gift card redemptions never touch item lines or the item price, consistent with what this PR needs.
- "WooCommerce does not natively support multiple payment methods per order... the plugin modifies the order total of every order that is paid with gift cards" - confirms the redemption is applied at the order-total level, likely (but not confirmed) via a mechanism similar to the synthetic negative `WC_Order_Item_Fee` already used in the two existing "Gift card" golden tests.

Without being able to confirm the exact mechanism against a real order, I did not implement a heuristic-based exclusion that might silently misidentify fees. Per the issue's explicit fallback, only the discount-allocation half lands now; the gift-card-specific exclusion is documented as a follow-up in `SS_Shipping_Shipment_Builder`'s class docblock and in `SS_Shipping_Order_Data::get_totals()`'s docblock. The two existing gift-card-fee golden tests (`reconciles totals...`, `clamps negative values...`) are unchanged - a gift-card-funded order still under-reports its shipment subtotal by the redemption amount today, exactly as before this PR.

## Test plan

- [x] `composer test:integration` - 164 passed (707 assertions), including all `ShipmentPayloadTest.php` golden tests and the new `ShipmentRepresentationTest.php`
- [x] `vendor/bin/phpcs` (WordPress standard) - clean, 0 violations across the whole plugin
- [x] `composer phpcs:compat` (PHP 7.4+ compatibility) - clean
- [x] `php -l` on every touched/new file

## Note for maintainers

"Closes #113" / "Closes #128" intentionally not used - this merges into `develop`, not the default branch, so GitHub won't auto-close on merge. Please close both issues manually after merge.