### PR TITLE
Split the API client into a Resource-based layer (#112)

### DIFF
--- a/smart-send-logistics/admin/class-ss-shipping-order-bulk-actions.php
+++ b/smart-send-logistics/admin/class-ss-shipping-order-bulk-actions.php
@@ -283,7 +283,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Bulk_Actions' ) ) :
 			} elseif ( count( $array_shipment_ids ) > 1 ) {
 				// If more than one smart send shipment label created, then create combo labels.
 				// Create combined label with successful shipments
-				$combined_shipments = SS_SHIPPING_WC()->get_api_handle()->combineLabelsForShipments(
+				$combined_shipments = SS_SHIPPING_WC()->get_api_handle()->bookings()->combine(
 					wp_list_pluck(
 						$array_shipment_ids,
 						'shipment_id'

--- a/smart-send-logistics/admin/class-ss-shipping-order-meta.php
+++ b/smart-send-logistics/admin/class-ss-shipping-order-meta.php
@@ -184,7 +184,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 				if ( ! empty( $shipping_method_carrier ) && ! empty( $shipping_address['country'] ) ) {
 
 					// API call to get agent info by agent no.
-					if ( SS_SHIPPING_WC()->get_api_handle()->getAgentByAgentNo( $shipping_method_carrier, $shipping_address['country'], $ss_shipping_agent_no ) ) {
+					if ( SS_SHIPPING_WC()->get_api_handle()->pickupPoints()->findByAgentNo( $shipping_method_carrier, $shipping_address['country'], $ss_shipping_agent_no ) ) {
 
 						SS_Shipping_Logger::info(
 							'Pickup point changed on order',

--- a/smart-send-logistics/admin/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/admin/class-ss-shipping-shipment.php
@@ -18,13 +18,12 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 	 * Sends a WooCommerce order to the Smart Send API as a shipment.
 	 *
 	 * SS_Shipping_Shipment_Builder assembles the new internal shipment
-	 * representation (#113); this class is now only a thin adapter that
+	 * representation (#113); \Smartsend\Resources\BookingResource (#112)
 	 * translates that representation into the v1 wire request
-	 * (Smartsend\Models\Shipment and its sub-models) and sends it. That
-	 * translation exists here only because #112's resource layer, which is
-	 * meant to own it permanently, is not part of this change - once #112
-	 * lands, this class's translate_to_wire_shipment() and its helpers
-	 * move there.
+	 * (Smartsend\Models\Shipment and its sub-models) and sends it. This
+	 * class is now only the order-level orchestrator: build the
+	 * representation, hand it to the booking resource, and expose the
+	 * result to callers (SS_Shipping_Label_Creator).
 	 */
 	class SS_Shipping_Shipment {
 
@@ -142,7 +141,9 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 
 		/**
 		 * Build the internal shipment representation and translate it into
-		 * the v1 wire shipment model.
+		 * the v1 wire shipment model. The translation itself is
+		 * \Smartsend\Resources\BookingResource::fromRepresentation() (#112)
+		 * - the single point where the v1 wire payload is built.
 		 *
 		 * @param boolean $is_return Whether the label is a return label.
 		 *
@@ -156,171 +157,7 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 				return $this->representation;
 			}
 
-			$this->shipment = $this->translate_to_wire_shipment( $this->representation );
-		}
-
-		/**
-		 * Translate the internal shipment representation into the v1 wire
-		 * shipment model. This is the single point where the excl/incl
-		 * pairs are (re)computed from the representation's single net/tax
-		 * amounts (#113) - the actual v1 wire payload is unchanged.
-		 *
-		 * @param array $representation The internal shipment representation from SS_Shipping_Shipment_Builder::build().
-		 *
-		 * @return \Smartsend\Models\Shipment
-		 */
-		protected function translate_to_wire_shipment( array $representation ) {
-			$receiver = $this->build_receiver( $representation );
-
-			$shipment = new \Smartsend\Models\Shipment();
-			$shipment->setReceiver( $receiver );
-
-			if ( ! empty( $representation['pickup_point'] ) ) {
-				$shipment->setAgent( $this->build_agent( $representation['pickup_point'] ) );
-			}
-
-			$parcels = array();
-			foreach ( $representation['parcels'] as $parcel_row ) {
-				$parcels[] = $this->build_parcel( $parcel_row );
-			}
-
-			// Create services.
-			$services = new \Smartsend\Models\Shipment\Services();
-			$services->setSmsNotification( $receiver->getSms() )// Always enable SMS notification.
-				->setEmailNotification( $receiver->getEmail() ); // Always enable Email notification.
-
-			$shipment->setInternalId( $representation['internal_id'] )
-				->setInternalReference( $this->value_or_null( $representation['internal_reference'] ) )
-				->setShippingCarrier( $this->value_or_null( $representation['shipping_carrier'] ) )
-				->setShippingMethod( $this->value_or_null( $representation['shipping_method'] ) )
-				->setShippingDate( $representation['shipping_date'] )
-				->setParcels( $parcels )// Alternatively add each parcel using $shipment->addParcel(Parcel $parcel).
-				->setServices( $services )
-				->setSubtotalPriceExcludingTax( $this->value_or_null( $representation['subtotal_net_amount'] ) )
-				->setSubtotalPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $representation['subtotal_net_amount'], $representation['subtotal_tax_amount'] ) ) )
-				->setTotalPriceExcludingTax( $this->value_or_null( $representation['total_net_amount'] ) )
-				->setTotalPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $representation['total_net_amount'], $representation['total_tax_amount'] ) ) )
-				->setShippingPriceExcludingTax( $this->value_or_null( $representation['shipping_net_amount'] ) )
-				->setShippingPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $representation['shipping_net_amount'], $representation['shipping_tax_amount'] ) ) )
-				->setTotalTaxAmount( $this->value_or_null( $representation['total_tax_amount'] ) )
-				->setCurrency( $this->value_or_null( $representation['currency'] ) );
-
-			return $shipment;
-		}
-
-		/**
-		 * Build the receiver model from the representation's receiver
-		 * section.
-		 *
-		 * @param array $representation The internal shipment representation.
-		 *
-		 * @return \Smartsend\Models\Shipment\Receiver
-		 */
-		protected function build_receiver( array $representation ) {
-			$receiver_data = $representation['receiver'];
-
-			$receiver = new \Smartsend\Models\Shipment\Receiver();
-			$receiver->setInternalId( $representation['internal_id'] )
-				->setInternalReference( $this->value_or_null( $representation['internal_reference'] ) )
-				->setCompany( $this->value_or_null( $receiver_data['company'] ) )
-				->setNameLine1( $this->value_or_null( $receiver_data['name_line1'] ) )
-				->setNameLine2( $this->value_or_null( $receiver_data['name_line2'] ) )
-				->setAddressLine1( $this->value_or_null( $receiver_data['address_line1'] ) )
-				->setAddressLine2( $this->value_or_null( $receiver_data['address_line2'] ) )
-				->setPostalCode( $this->value_or_null( $receiver_data['postal_code'] ) )
-				->setCity( $this->value_or_null( $receiver_data['city'] ) )
-				->setCountry( $this->value_or_null( $receiver_data['country'] ) )
-				->setSms( $this->value_or_null( $receiver_data['phone'] ) )
-				->setEmail( $this->value_or_null( $receiver_data['email'] ) );
-
-			return $receiver;
-		}
-
-		/**
-		 * Build the agent (pickup point) model from the representation's
-		 * pickup-point section.
-		 *
-		 * @param array $pickup_point Pickup point data, see SS_Shipping_Shipment_Builder::build_pickup_point().
-		 *
-		 * @return \Smartsend\Models\Shipment\Agent
-		 */
-		protected function build_agent( array $pickup_point ) {
-			$agent = new \Smartsend\Models\Shipment\Agent();
-			$agent->setInternalId( $pickup_point['internal_id'] )
-				->setInternalReference( $pickup_point['internal_reference'] )
-				->setAgentNo( $pickup_point['service_point_code'] )
-				->setCompany( $pickup_point['company'] )
-				->setAddressLine1( $pickup_point['address_line1'] )
-				->setAddressLine2( $pickup_point['address_line2'] )
-				->setPostalCode( $pickup_point['postal_code'] )
-				->setCity( $pickup_point['city'] )
-				->setCountry( $pickup_point['country'] );
-
-			return $agent;
-		}
-
-		/**
-		 * Build an item model from an item row of the representation.
-		 *
-		 * @param array $item_row Item row, see SS_Shipping_Order_Data::get_items_data().
-		 *
-		 * @return \Smartsend\Models\Shipment\Item
-		 */
-		protected function build_item( array $item_row ) {
-			$quantity = $item_row['quantity'] ? $item_row['quantity'] : 1;
-
-			// The wire format's unit_price_* pair is recomputed here, once,
-			// from the representation's single net/tax amount (#113).
-			$unit_net_amount = $item_row['total_net_amount'] / $quantity;
-			$unit_tax_amount = $item_row['total_tax_amount'] / $quantity;
-
-			$item = new \Smartsend\Models\Shipment\Item();
-			$item->setInternalId( $this->value_or_null( $item_row['id'] ) )
-				->setInternalReference( $this->value_or_null( $item_row['id'] ) )
-				->setSku( $this->value_or_null( $item_row['sku'] ) )
-				->setName( $this->value_or_null( $item_row['name'] ) )
-				->setDescription( $this->value_or_null( $item_row['description'] ) )// The product description can be used, but is often too long (255).
-				->setHsCode( $this->value_or_null( $item_row['hs_code'] ) )
-				->setCountryOfOrigin( $this->value_or_null( $item_row['country_of_origin'] ) )
-				->setImageUrl( null )// The product image url can be used, but sometimes includes spaces (bug) which causes validation error.
-				->setUnitWeight( $item_row['unit_weight'] > 0 ? $item_row['unit_weight'] : null )
-				->setUnitPriceExcludingTax( $this->value_or_null( $unit_net_amount ) )
-				->setUnitPriceIncludingTax( $this->value_or_null( $unit_net_amount + $unit_tax_amount ) )
-				->setQuantity( $this->value_or_null( $item_row['quantity'] ) )
-				->setTotalPriceExcludingTax( $this->value_or_null( $item_row['total_net_amount'] ) )
-				->setTotalPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $item_row['total_net_amount'], $item_row['total_tax_amount'] ) ) )
-				->setTotalTaxAmount( $this->value_or_null( $item_row['total_tax_amount'] ) );
-
-			return $item;
-		}
-
-		/**
-		 * Build a parcel model from a parcel row of the representation.
-		 *
-		 * @param array $parcel_row Parcel row, see SS_Shipping_Shipment_Builder::build().
-		 *
-		 * @return \Smartsend\Models\Shipment\Parcel
-		 */
-		protected function build_parcel( array $parcel_row ) {
-			$items = array();
-			foreach ( $parcel_row['items'] as $item_row ) {
-				$items[] = $this->build_item( $item_row );
-			}
-
-			$parcel = new \Smartsend\Models\Shipment\Parcel();
-			$parcel->setInternalId( $this->value_or_null( $parcel_row['internal_id'] ) )
-				->setInternalReference( $this->value_or_null( $parcel_row['internal_reference'] ) )
-				->setWeight( $this->value_or_null( $parcel_row['weight'] ) )
-				->setHeight( $parcel_row['height'] )
-				->setWidth( $parcel_row['width'] )
-				->setLength( $parcel_row['length'] )
-				->setFreetext( $this->value_or_null( $parcel_row['freetext'] ) )
-				->setItems( $items )// Alternatively add each item using $parcel->addItem(Item $item).
-				->setTotalPriceExcludingTax( $this->value_or_null( $parcel_row['total_net_amount'] ) )
-				->setTotalPriceIncludingTax( $this->value_or_null( $this->net_plus_tax( $parcel_row['total_net_amount'], $parcel_row['total_tax_amount'] ) ) )
-				->setTotalTaxAmount( $this->value_or_null( $parcel_row['total_tax_amount'] ) );
-
-			return $parcel;
+			$this->shipment = SS_SHIPPING_WC()->get_api_handle()->bookings()->fromRepresentation( $this->representation );
 		}
 
 		/**
@@ -331,37 +168,7 @@ if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 		protected function make_single_shipment_api_request() {
 			// Make API Request. The request and response (incl. HTTP status
 			// code and endpoint) are logged by the client's request logger.
-			SS_SHIPPING_WC()->get_api_handle()->createShipmentAndLabels( $this->shipment );
-		}
-
-		/**
-		 * Add a net amount and a tax amount together, treating a null
-		 * operand as zero - the including-tax wire figure derived from the
-		 * representation's single net/tax amount (#113).
-		 *
-		 * @param float|null $net_amount Net (excluding tax) amount.
-		 * @param float|null $tax_amount Tax amount.
-		 *
-		 * @return float
-		 */
-		protected function net_plus_tax( $net_amount, $tax_amount ) {
-			return (float) $net_amount + (float) $tax_amount;
-		}
-
-		/**
-		 * Return the value when truthy, null otherwise (the API models
-		 * expect null instead of empty/zero values).
-		 *
-		 * @param mixed $value The value to check.
-		 *
-		 * @return mixed|null
-		 */
-		protected function value_or_null( $value ) {
-			if ( $value ) {
-				return $value;
-			}
-
-			return null;
+			SS_SHIPPING_WC()->get_api_handle()->bookings()->create( $this->shipment );
 		}
 	}
 

--- a/smart-send-logistics/includes/lib/Smartsend/Api.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Api.php
@@ -3,392 +3,63 @@
 namespace Smartsend;
 
 require_once 'Client.php';
-require_once 'Models/Agent.php';
-require_once 'Models/Shipment.php';
+require_once 'Resources/BookingResource.php';
+require_once 'Resources/PickupPointResource.php';
 
-use Smartsend\Models\Agent;
-use Smartsend\Models\Shipment;
+use Smartsend\Resources\BookingResource;
+use Smartsend\Resources\PickupPointResource;
 
+/**
+ * The Smart Send API client: the transport (inherited from Client) plus
+ * accessors for the API's resource groups (#112) - each resource is
+ * responsible for one API concern (booking/labels, pick-up point lookup)
+ * and is the single point where its v1 wire payload is built. Response
+ * state (isSuccessful()/getData()/getError()/...) stays on this instance
+ * (inherited from Client), since every resource call goes through it.
+ */
 class Api extends Client
 {
-    // User API
+    /** @var BookingResource|null */
+    private $bookings;
 
+    /** @var PickupPointResource|null */
+    private $pickup_points;
+
+    /**
+     * Confirm the API token is valid and fetch the connected account.
+     *
+     * @return  object|true|false
+     */
     public function getAuthenticatedUser()
     {
         return $this->httpGet('');
     }
 
-    // Agent API
-    const AGENT_TIMEOUT = 4;
-
     /**
-     * Get the timeout used when fetching agents
+     * Shipment/label booking calls.
      *
-     * If no results are returned within the timespan, then cURL timeouts.
-     * This prevents customers from waiting at checkout until the PHP script timeouts.
-     *
-     * @return float timeout in seconds
+     * @return  BookingResource
      */
-    private function getAgentTimeout()
+    public function bookings(): BookingResource
     {
-        /*
-         * Filter the timeout used when searching for agents
-         *
-         * @param int | timeout in seconds
-         */
-        return apply_filters( 'smart_send_pickup_point_timeout', self::AGENT_TIMEOUT);
-    }
-
-    public function getAgent($id)
-    {
-        return $this->httpGet(
-            $method = 'agents/',
-            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-        );
-    }
-
-    public function getAgentByAgentNo($carrier, $country, $agent_no)
-    {
-        return $this->httpGet(
-            $method = 'agents/carrier/'.$carrier.'/country/'.$country.'/agentno/'.$agent_no,
-            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-        );
-    }
-
-    public function findFirstAgent($criteria)
-    {
-        throw new \Exception('Feature not yet implemented');
-    }
-
-    public function updateAgent($id, Agent $agent)
-    {
-        return $this->httpPut('agents/'.$id, array(), array(), $agent);
-    }
-
-    public function deleteAgent($id)
-    {
-        return $this->httpDelete('agents/'.$id);
-    }
-
-    public function createAgent(Agent $agent)
-    {
-        return $this->httpPost('agents/', array(), array(), $agent);
-    }
-
-    /*
-     * Find  agents located in country
-     *
-     * @param string $carrier is the carrier code for which carrier to find agents
-     * @param string $country is the country code of the country in which the agents should be located
-     *
-     * return array of agent objects
-     */
-    public function getAgentsByCountry($carrier, $country)
-    {
-        return $this->httpGet(
-            $method = 'agents/carrier/'.$carrier.'/country/'.$country,
-            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-        );
-    }
-
-    /*
-     * Find  agents located in postal code (exact match)
-     *
-     * @param string $carrier is the carrier for which to find agents
-     * @param string $country is the country in which the agents should be located
-     * @param string $postal_code is the postal code to search for close agents from
-     *
-     * return array of agent objects
-     */
-    public function getAgentsByPostalCode($carrier, $country, $postal_code)
-    {
-        return $this->httpGet(
-            $method = 'agents/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code,
-            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-        );
-    }
-
-    /*
-     * Find  agents located on street (exact match)
-     *
-     * @param string $carrier is the carrier for which to find agents
-     * @param string $country is the country in which the agents should be located
-     * @param string $postal_code is the postal code which the agents should be located
-     * @param string $street is the street name on which the agents should be located
-     *
-     * return array of agent objects
-     */
-    public function getAgentsByAddress($carrier, $country, $postal_code, $street)
-    {
-        return $this->httpGet(
-            $method = 'agents/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code.'/street/'.$street,
-            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-        );
-    }
-
-    /*
-     * Get agents located within an area
-     *
-     * @param string $carrier is the carrier for which to find agents
-     * @param string $country optionally country in which the agents should be located
-     * @param string $min_latitude Agents will be located an a latitude larger than this value
-     * @param string $max_latitude Agents will be located an a latitude lower than this value
-     * @param string $min_longitude Agents will be located an a longitude larger than this value
-     * @param string $max_longitude Agents will be located an a longitude lower than this value
-     *
-     * return array of agent objects
-     */
-    public function getAgentsInArea($carrier, $country=null, $min_latitude, $max_latitude,$min_longitude, $max_longitude)
-    {
-        if ($country) {
-            $method = 'agents/carrier/'.$carrier.'/country/'.$country
-                .'/area/latitude/min/'.$min_latitude.'/max/'.$max_latitude
-                .'/longitude/min/'.$min_longitude.'/max/'.$max_longitude;
-        } else {
-            $method = 'agents/carrier/'.$carrier
-                .'/area/latitude/min/'.$min_latitude.'/max/'.$max_latitude
-                .'/longitude/min/'.$min_longitude.'/max/'.$max_longitude;
+        if (!$this->bookings) {
+            $this->bookings = new BookingResource($this);
         }
 
-        return $this->httpGet($method, $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout());
+        return $this->bookings;
     }
 
-    /*
-     * Find closest agents by postal code (not necessarily with exact match)
+    /**
+     * Pick-up point lookup calls.
      *
-     * @param string $carrier is the carrier for which to find agents
-     * @param string $country is the country in which the agents should be located
-     * @param string $postal_code is the postal code to search for close agents from
-     *
-     * return array of agent objects
+     * @return  PickupPointResource
      */
-    public function findClosestAgentByPostalCode($carrier, $country, $postal_code)
+    public function pickupPoints(): PickupPointResource
     {
-        return $this->httpGet(
-            $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code,
-            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-        );
-    }
-
-    /*
-     * Find closest agents by address (not necessarily with exact match)
-     *
-     * @param string $carrier is the carrier for which to find agents
-     * @param string $country is the country in which the agents should be located
-     * @param string $postal_code is the postal code to search for close agents from
-     * @param string $city is the city to search for close agents from
-     * @param string $street is the street name to search for close agents from
-     *
-     * return array of agent objects
-     */
-    public function findClosestAgentByAddress($carrier, $country, $postal_code, $city=null, $street)
-    {
-        $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code;
-        if ($city) {
-            $method .= '/city/'.$city;
+        if (!$this->pickup_points) {
+            $this->pickup_points = new PickupPointResource($this);
         }
 
-        $method .= '/street/'.$street;
-        return $this->httpGet(
-            $method,
-            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-        );
-    }
-
-    /*
-     * Find closest agents by GPS coordinates
-     *
-     * @param string $carrier is the carrier for which to find agents
-     * @param string $country is the country in which the agents should be located
-     * @param string $latitude is the latitude of the GPS coordinates to search for close agents from
-     * @param string $longitude is the longitude of the GPS coordinates to search for close agents from
-     *
-     * return array of agent objects
-     */
-    public function findClosestAgentByGpsCoordinates($carrier, $country, $latitude, $longitude)
-    {
-        return $this->httpGet(
-            $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/coordinates/latitude/'.$latitude.'/longitude/'.$longitude,
-            $args = array(), $headers = array(), $body = null, $timeout = $this->getAgentTimeout()
-        );
-    }
-
-// Shipment API
-
-    public function getShipment($id)
-    {
-        return $this->httpGet('shipments/'.$id);
-    }
-
-    public function findShipments()
-    {
-        return $this->httpGet('shipments');
-    }
-
-    public function createShipment(Shipment $shipment)
-    {
-        return $this->httpPost('shipments', array(), array(), $shipment);
-    }
-
-    public function updateShipment($id, Shipment $shipment)
-    {
-        return $this->httpPut('shipments'.$id, array(), array(), $shipment);
-    }
-
-    public function deleteShipment($id)
-    {
-        return $this->httpDelete('shipments/'.$id);
-    }
-
-// Label API
-    public function getLabels($shipment_id, $parcel_id=null)
-    {
-        if ($parcel_id) {
-            return $this->httpGet('shipments/'.$shipment_id.'/parcels/'.$parcel_id.'/label');
-        } else {
-            return $this->httpGet('shipments/'.$shipment_id.'/labels');
-        }
-    }
-
-    public function getPdfLabels($shipment_id, $parcel_id=null)
-    {
-        if ($parcel_id) {
-            return $this->httpGet('shipments/'.$shipment_id.'/parcels/'.$parcel_id.'/label/pdf');
-        } else {
-            return $this->httpGet('shipments/'.$shipment_id.'/labels/pdf');
-        }
-    }
-
-    public function findLabel()
-    {
-        return $this->httpGet('shipments');
-    }
-
-    public function createLabels($shipment_id)
-    {
-        return $this->httpPost('shipments/'.$shipment_id.'/labels');
-    }
-
-    public function createShipmentAndLabels($shipment)
-    {
-        return $this->httpPost('shipments/labels', array(), array(), $shipment);
-    }
-
-    public function combineLabelsForShipments($shipments=array())
-    {
-        $request = array(
-            'shipments' => array()
-        );
-        foreach ($shipments as $shipment) {
-            $request["shipments"][] = array("shipment_id" => $shipment);
-        }
-
-        return $this->httpPost('shipments/labels/combine', array(), array(), $request);
-    }
-
-
-// General part
-
-
-    /**
-     * Does API response contain link to next page of results
-     * @return  boolean
-     */
-    public function hasNextLink()
-    {
-        $links = $this->getLinks();
-        return (!empty($links->next));
-    }
-
-    /**
-     * Get API response contain link to next page of results
-     * @return  boolean
-     */
-    public function getNextLink()
-    {
-        return $this->getLinks()->next;
-    }
-
-    /**
-     * Does API response contain link to previous page of results
-     * @return  boolean
-     */
-    public function hasPreviousLink()
-    {
-        $links = $this->getLinks();
-        return (!empty($links->previous));
-    }
-
-    /**
-     * Get API response contain link to previous page of results
-     * @return  boolean
-     */
-    public function getPreviousLink()
-    {
-        return $this->getLinks()->previous;
-    }
-
-    /**
-     * Does API response contain link to last page of results
-     * @return  boolean
-     */
-    public function hasLastLink()
-    {
-        $links = $this->getLinks();
-        return (!empty($links->last));
-    }
-
-    /**
-     * Get API response contain link to last page of results
-     * @return  boolean
-     */
-    public function getLastLink()
-    {
-        return $this->getLinks()->last;
-    }
-
-    /**
-     * Get API response next page
-     * @return  object
-     * @throws \Exception
-     */
-    public function next()
-    {
-        return $this->httpGet($this->stripEndpointFromLink($this->getNextLink()));
-    }
-
-    /**
-     * Get API response previous page
-     * @return  object
-     * @throws \Exception
-     */
-    public function previous()
-    {
-        return $this->httpGet($this->stripEndpointFromLink($this->getPreviousLink()));
-    }
-
-    /**
-     * Get API response last page
-     * @return  object
-     * @throws \Exception
-     */
-    public function last()
-    {
-        return $this->httpGet($this->stripEndpointFromLink($this->getLastLink()));
-    }
-
-    /**
-     * Remove the URL endpont from a link
-     * @url  string
-     * @return  string
-     */
-    private function stripEndpointFromLink($url) 
-    {
-        $api_endpoint = $this->getApiEndpoint();
-        if (substr($url, 0, strlen($api_endpoint)) == $api_endpoint) {
-            return substr($url, strlen($api_endpoint));
-        } else {
-            return $url;
-        }
+        return $this->pickup_points;
     }
 }

--- a/smart-send-logistics/includes/lib/Smartsend/Client.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Client.php
@@ -464,6 +464,13 @@ class Client
 		    'timeout'    => $timeout,
 		    'httpversion' => '1.1',
             'sslverify'  => apply_filters('smart_send_sslverify', true),
+            // Equivalent to using wp_safe_remote_*(): the endpoint is
+            // filterable at runtime (smart_send_api_endpoint), so reject
+            // requests that resolve to a private/internal IP range (SSRF
+            // hardening). Independent of sslverify above and does not
+            // affect the mocked pre_http_request tests, which short-circuit
+            // before this check runs.
+            'reject_unsafe_urls' => true,
 	    ));
 
         // execute request

--- a/smart-send-logistics/includes/lib/Smartsend/Resources/BookingResource.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Resources/BookingResource.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Smartsend\Resources;
+
+require_once __DIR__ . '/../Client.php';
+require_once __DIR__ . '/../Models/Shipment.php';
+
+use Smartsend\Client;
+use Smartsend\Models\Shipment;
+use Smartsend\Models\Shipment\Agent as ShipmentAgent;
+use Smartsend\Models\Shipment\Item;
+use Smartsend\Models\Shipment\Parcel;
+use Smartsend\Models\Shipment\Receiver;
+use Smartsend\Models\Shipment\Services;
+
+/**
+ * Books a shipment (and its labels) with the Smart Send API.
+ *
+ * This is the single point where the internal shipment representation
+ * assembled by SS_Shipping_Shipment_Builder (#113) is translated into the
+ * v1 wire request (Smartsend\Models\Shipment and its sub-models) - the
+ * excl/incl price pairs the v1 API expects are (re)computed here, once,
+ * from the representation's single net/tax amounts. A future v2 client
+ * would replace fromRepresentation() with a v2-shaped translation; nothing
+ * above this resource (SS_Shipping_Shipment, SS_Shipping_Shipment_Builder,
+ * SS_Shipping_Order_Data) would need to change (#111).
+ */
+class BookingResource
+{
+    /** @var Client */
+    protected $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Book a shipment and create its labels in a single call.
+     *
+     * @param   Shipment $shipment The v1 wire shipment, see self::fromRepresentation().
+     * @return  object|true|false
+     */
+    public function create(Shipment $shipment)
+    {
+        return $this->client->httpPost('shipments/labels', array(), array(), $shipment);
+    }
+
+    /**
+     * Combine the labels of multiple already-booked shipments into a
+     * single PDF.
+     *
+     * @param   string[] $shipment_ids
+     * @return  object|true|false
+     */
+    public function combine(array $shipment_ids)
+    {
+        $request = array(
+            'shipments' => array(),
+        );
+
+        foreach ($shipment_ids as $shipment_id) {
+            $request['shipments'][] = array('shipment_id' => $shipment_id);
+        }
+
+        return $this->client->httpPost('shipments/labels/combine', array(), array(), $request);
+    }
+
+    /**
+     * Translate the internal shipment representation into the v1 wire
+     * shipment model.
+     *
+     * @param   array $representation The internal shipment representation from SS_Shipping_Shipment_Builder::build().
+     * @return  Shipment
+     */
+    public function fromRepresentation(array $representation): Shipment
+    {
+        $receiver = $this->buildReceiver($representation);
+
+        $shipment = new Shipment();
+        $shipment->setReceiver($receiver);
+
+        if (!empty($representation['pickup_point'])) {
+            $shipment->setAgent($this->buildAgent($representation['pickup_point']));
+        }
+
+        $parcels = array();
+        foreach ($representation['parcels'] as $parcel_row) {
+            $parcels[] = $this->buildParcel($parcel_row);
+        }
+
+        // Create services.
+        $services = new Services();
+        $services->setSmsNotification($receiver->getSms()) // Always enable SMS notification.
+            ->setEmailNotification($receiver->getEmail()); // Always enable Email notification.
+
+        $shipment->setInternalId($representation['internal_id'])
+            ->setInternalReference($this->valueOrNull($representation['internal_reference']))
+            ->setShippingCarrier($this->valueOrNull($representation['shipping_carrier']))
+            ->setShippingMethod($this->valueOrNull($representation['shipping_method']))
+            ->setShippingDate($representation['shipping_date'])
+            ->setParcels($parcels) // Alternatively add each parcel using $shipment->addParcel(Parcel $parcel).
+            ->setServices($services)
+            ->setSubtotalPriceExcludingTax($this->valueOrNull($representation['subtotal_net_amount']))
+            ->setSubtotalPriceIncludingTax($this->valueOrNull($this->netPlusTax($representation['subtotal_net_amount'], $representation['subtotal_tax_amount'])))
+            ->setTotalPriceExcludingTax($this->valueOrNull($representation['total_net_amount']))
+            ->setTotalPriceIncludingTax($this->valueOrNull($this->netPlusTax($representation['total_net_amount'], $representation['total_tax_amount'])))
+            ->setShippingPriceExcludingTax($this->valueOrNull($representation['shipping_net_amount']))
+            ->setShippingPriceIncludingTax($this->valueOrNull($this->netPlusTax($representation['shipping_net_amount'], $representation['shipping_tax_amount'])))
+            ->setTotalTaxAmount($this->valueOrNull($representation['total_tax_amount']))
+            ->setCurrency($this->valueOrNull($representation['currency']));
+
+        return $shipment;
+    }
+
+    /**
+     * Build the receiver model from the representation's receiver section.
+     *
+     * @param   array $representation The internal shipment representation.
+     * @return  Receiver
+     */
+    protected function buildReceiver(array $representation): Receiver
+    {
+        $receiver_data = $representation['receiver'];
+
+        $receiver = new Receiver();
+        $receiver->setInternalId($representation['internal_id'])
+            ->setInternalReference($this->valueOrNull($representation['internal_reference']))
+            ->setCompany($this->valueOrNull($receiver_data['company']))
+            ->setNameLine1($this->valueOrNull($receiver_data['name_line1']))
+            ->setNameLine2($this->valueOrNull($receiver_data['name_line2']))
+            ->setAddressLine1($this->valueOrNull($receiver_data['address_line1']))
+            ->setAddressLine2($this->valueOrNull($receiver_data['address_line2']))
+            ->setPostalCode($this->valueOrNull($receiver_data['postal_code']))
+            ->setCity($this->valueOrNull($receiver_data['city']))
+            ->setCountry($this->valueOrNull($receiver_data['country']))
+            ->setSms($this->valueOrNull($receiver_data['phone']))
+            ->setEmail($this->valueOrNull($receiver_data['email']));
+
+        return $receiver;
+    }
+
+    /**
+     * Build the agent (pickup point) model from the representation's
+     * pickup-point section.
+     *
+     * @param   array $pickup_point Pickup point data, see SS_Shipping_Shipment_Builder::build_pickup_point().
+     * @return  ShipmentAgent
+     */
+    protected function buildAgent(array $pickup_point): ShipmentAgent
+    {
+        $agent = new ShipmentAgent();
+        $agent->setInternalId($pickup_point['internal_id'])
+            ->setInternalReference($pickup_point['internal_reference'])
+            ->setAgentNo($pickup_point['service_point_code'])
+            ->setCompany($pickup_point['company'])
+            ->setAddressLine1($pickup_point['address_line1'])
+            ->setAddressLine2($pickup_point['address_line2'])
+            ->setPostalCode($pickup_point['postal_code'])
+            ->setCity($pickup_point['city'])
+            ->setCountry($pickup_point['country']);
+
+        return $agent;
+    }
+
+    /**
+     * Build an item model from an item row of the representation.
+     *
+     * @param   array $item_row Item row, see SS_Shipping_Order_Data::get_items_data().
+     * @return  Item
+     */
+    protected function buildItem(array $item_row): Item
+    {
+        $quantity = $item_row['quantity'] ? $item_row['quantity'] : 1;
+
+        // The wire format's unit_price_* pair is recomputed here, once,
+        // from the representation's single net/tax amount (#113).
+        $unit_net_amount = $item_row['total_net_amount'] / $quantity;
+        $unit_tax_amount = $item_row['total_tax_amount'] / $quantity;
+
+        $item = new Item();
+        $item->setInternalId($this->valueOrNull($item_row['id']))
+            ->setInternalReference($this->valueOrNull($item_row['id']))
+            ->setSku($this->valueOrNull($item_row['sku']))
+            ->setName($this->valueOrNull($item_row['name']))
+            ->setDescription($this->valueOrNull($item_row['description'])) // The product description can be used, but is often too long (255).
+            ->setHsCode($this->valueOrNull($item_row['hs_code']))
+            ->setCountryOfOrigin($this->valueOrNull($item_row['country_of_origin']))
+            ->setImageUrl(null) // The product image url can be used, but sometimes includes spaces (bug) which causes validation error.
+            ->setUnitWeight($item_row['unit_weight'] > 0 ? $item_row['unit_weight'] : null)
+            ->setUnitPriceExcludingTax($this->valueOrNull($unit_net_amount))
+            ->setUnitPriceIncludingTax($this->valueOrNull($unit_net_amount + $unit_tax_amount))
+            ->setQuantity($this->valueOrNull($item_row['quantity']))
+            ->setTotalPriceExcludingTax($this->valueOrNull($item_row['total_net_amount']))
+            ->setTotalPriceIncludingTax($this->valueOrNull($this->netPlusTax($item_row['total_net_amount'], $item_row['total_tax_amount'])))
+            ->setTotalTaxAmount($this->valueOrNull($item_row['total_tax_amount']));
+
+        return $item;
+    }
+
+    /**
+     * Build a parcel model from a parcel row of the representation.
+     *
+     * @param   array $parcel_row Parcel row, see SS_Shipping_Shipment_Builder::build().
+     * @return  Parcel
+     */
+    protected function buildParcel(array $parcel_row): Parcel
+    {
+        $items = array();
+        foreach ($parcel_row['items'] as $item_row) {
+            $items[] = $this->buildItem($item_row);
+        }
+
+        $parcel = new Parcel();
+        $parcel->setInternalId($this->valueOrNull($parcel_row['internal_id']))
+            ->setInternalReference($this->valueOrNull($parcel_row['internal_reference']))
+            ->setWeight($this->valueOrNull($parcel_row['weight']))
+            ->setHeight($parcel_row['height'])
+            ->setWidth($parcel_row['width'])
+            ->setLength($parcel_row['length'])
+            ->setFreetext($this->valueOrNull($parcel_row['freetext']))
+            ->setItems($items) // Alternatively add each item using $parcel->addItem(Item $item).
+            ->setTotalPriceExcludingTax($this->valueOrNull($parcel_row['total_net_amount']))
+            ->setTotalPriceIncludingTax($this->valueOrNull($this->netPlusTax($parcel_row['total_net_amount'], $parcel_row['total_tax_amount'])))
+            ->setTotalTaxAmount($this->valueOrNull($parcel_row['total_tax_amount']));
+
+        return $parcel;
+    }
+
+    /**
+     * Add a net amount and a tax amount together, treating a null operand
+     * as zero - the including-tax wire figure derived from the
+     * representation's single net/tax amount (#113).
+     *
+     * @param   float|null $net_amount Net (excluding tax) amount.
+     * @param   float|null $tax_amount Tax amount.
+     * @return  float
+     */
+    protected function netPlusTax($net_amount, $tax_amount)
+    {
+        return (float) $net_amount + (float) $tax_amount;
+    }
+
+    /**
+     * Return the value when truthy, null otherwise (the API models expect
+     * null instead of empty/zero values).
+     *
+     * @param   mixed $value The value to check.
+     * @return  mixed|null
+     */
+    protected function valueOrNull($value)
+    {
+        if ($value) {
+            return $value;
+        }
+
+        return null;
+    }
+}

--- a/smart-send-logistics/includes/lib/Smartsend/Resources/PickupPointResource.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Resources/PickupPointResource.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Smartsend\Resources;
+
+require_once __DIR__ . '/../Client.php';
+
+use Smartsend\Client;
+
+/**
+ * Looks up carrier pick-up points ("agents").
+ */
+class PickupPointResource
+{
+    const AGENT_TIMEOUT = 4;
+
+    /** @var Client */
+    protected $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Get the timeout used when looking up pick-up points.
+     *
+     * If no results are returned within the timespan, then the request
+     * times out. This prevents customers from waiting at checkout until
+     * the PHP script times out.
+     *
+     * @return  float Timeout in seconds.
+     */
+    protected function getTimeout()
+    {
+        /*
+         * Filter the timeout used when searching for pick-up points.
+         *
+         * @param int $timeout Timeout in seconds.
+         */
+        return apply_filters('smart_send_pickup_point_timeout', self::AGENT_TIMEOUT);
+    }
+
+    /**
+     * Look up a single pick-up point by its agent number.
+     *
+     * @param   string $carrier  Carrier code (e.g. 'postnord').
+     * @param   string $country  ISO3166-A2 country code.
+     * @param   string $agent_no The pick-up point's agent number.
+     * @return  object|true|false
+     */
+    public function findByAgentNo($carrier, $country, $agent_no)
+    {
+        return $this->client->httpGet(
+            'agents/carrier/'.$carrier.'/country/'.$country.'/agentno/'.$agent_no,
+            array(),
+            array(),
+            null,
+            $this->getTimeout()
+        );
+    }
+
+    /**
+     * Find the pick-up points closest to an address (not necessarily an
+     * exact match).
+     *
+     * @param   string      $carrier     Carrier code (e.g. 'postnord').
+     * @param   string      $country     ISO3166-A2 country code.
+     * @param   string      $postal_code Postal code to search near.
+     * @param   string|null $city        City to search near.
+     * @param   string      $street      Street address to search near.
+     * @return  object|true|false
+     */
+    public function findClosestByAddress($carrier, $country, $postal_code, $city, $street)
+    {
+        $method = 'agents/closest/carrier/'.$carrier.'/country/'.$country.'/postalcode/'.$postal_code;
+
+        if ($city) {
+            $method .= '/city/'.$city;
+        }
+
+        $method .= '/street/'.$street;
+
+        return $this->client->httpGet($method, array(), array(), null, $this->getTimeout());
+    }
+}

--- a/smart-send-logistics/public/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/public/class-ss-shipping-frontend.php
@@ -204,7 +204,7 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 
 			// The request and response (incl. HTTP status code and endpoint)
 			// are logged by the client's request logger.
-			if ( SS_SHIPPING_WC()->get_api_handle()->findClosestAgentByAddress( $carrier, $search_params['country'], $search_params['postal_code'], $search_params['city'], $search_params['street'] ) ) {
+			if ( SS_SHIPPING_WC()->get_api_handle()->pickupPoints()->findClosestByAddress( $carrier, $search_params['country'], $search_params['postal_code'], $search_params['city'], $search_params['street'] ) ) {
 
 				$ss_pickup_points = SS_SHIPPING_WC()->get_api_handle()->getData();
 

--- a/tests/Integration/LoggerTest.php
+++ b/tests/Integration/LoggerTest.php
@@ -252,7 +252,7 @@ it('includes the request body of POST requests in the context', function () {
     $spy = spy_on_logger();
     mock_smart_send_api();
 
-    create_logging_api_client()->combineLabelsForShipments(['shipment-1', 'shipment-2']);
+    create_logging_api_client()->bookings()->combine(['shipment-1', 'shipment-2']);
 
     expect($spy->entries)->toHaveCount(1);
     expect($spy->entries[0]['message'])->toStartWith('POST ');

--- a/tests/Integration/ResourceLayerTest.php
+++ b/tests/Integration/ResourceLayerTest.php
@@ -1,0 +1,285 @@
+<?php
+
+/*
+ * Tests for the #112 Client/Resource split of the Smart Send API client:
+ * Smartsend\Api now exposes focused resource accessors (bookings(),
+ * pickupPoints()) instead of one monolithic method-per-endpoint surface.
+ * Each resource method is exercised here directly (success + the existing
+ * error taxonomy from #38/#85 surfacing through the shared Client state),
+ * proving the split preserved both the wire format and the error handling
+ * - complementary to the wire-format golden tests in ShipmentPayloadTest
+ * and the transport error-mapping tests in HttpClientErrorTest.
+ */
+
+use Smartsend\Api;
+use Smartsend\Models\Error;
+use Smartsend\Models\Shipment;
+use Smartsend\Resources\BookingResource;
+use Smartsend\Resources\PickupPointResource;
+
+/**
+ * A minimal but fully-shaped internal shipment representation, the shape
+ * SS_Shipping_Shipment_Builder::build() returns. See ShipmentPayloadTest for
+ * the exhaustive, order-driven coverage of every field.
+ */
+function sample_representation(array $overrides = []): array
+{
+    return array_replace_recursive([
+        'internal_id'         => '123',
+        'internal_reference'  => '123',
+        'shipping_carrier'    => 'postnord',
+        'shipping_method'     => 'agent',
+        'shipping_date'       => date('Y-m-d'),
+        'receiver'            => [
+            'company'       => null,
+            'name_line1'    => 'Test',
+            'name_line2'    => 'Customer',
+            'address_line1' => 'Islands Brygge 39',
+            'address_line2' => null,
+            'postal_code'   => '2300',
+            'city'          => 'Copenhagen',
+            'country'       => 'DK',
+            'phone'         => '+4512345678',
+            'email'         => 'integration-test@smartsend.io',
+        ],
+        'pickup_point'        => null,
+        'parcels'             => [
+            [
+                'internal_id'        => '123',
+                'internal_reference' => '123',
+                'weight'             => 1.5,
+                'height'             => null,
+                'width'              => null,
+                'length'             => null,
+                'freetext'           => null,
+                'items'              => [
+                    [
+                        'id'                => '456',
+                        'sku'               => 'SKU-1',
+                        'name'              => 'Sample Product',
+                        'description'       => null,
+                        'hs_code'           => null,
+                        'country_of_origin' => null,
+                        'unit_weight'       => 1.5,
+                        'quantity'          => 1,
+                        'total_net_amount'  => 100,
+                        'total_tax_amount'  => null,
+                    ],
+                ],
+                'total_net_amount' => 100,
+                'total_tax_amount' => null,
+            ],
+        ],
+        'subtotal_net_amount' => 100,
+        'subtotal_tax_amount' => null,
+        'shipping_net_amount' => 39,
+        'shipping_tax_amount' => null,
+        'total_net_amount'    => 139,
+        'total_tax_amount'    => null,
+        'currency'            => 'DKK',
+    ], $overrides);
+}
+
+function pickup_point_api_data(): array
+{
+    return [
+        'id'            => 7,
+        'agent_no'      => '1234',
+        'company'       => 'Corner Shop',
+        'address_line1' => 'Main Street 1',
+        'address_line2' => null,
+        'postal_code'   => '2300',
+        'city'          => 'Copenhagen',
+        'country'       => 'DK',
+        'distance'      => 0.5,
+    ];
+}
+
+beforeEach(function (): void {
+    with_ss_settings();
+});
+
+it('accepts a Shipment through the client without needing a resource accessor for the response state', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    $capture = mock_smart_send_api();
+
+    $resource = $api->bookings();
+    expect($resource)->toBeInstanceOf(BookingResource::class)
+        // The accessor is memoized: the same instance is returned every call.
+        ->and($api->bookings())->toBe($resource);
+
+    $shipment = $resource->fromRepresentation(sample_representation());
+    expect($resource->create($shipment))->toBeTrue();
+    expect($api->isSuccessful())->toBeTrue();
+
+    $request = end($capture->requests);
+    expect($request['url'])->toContain('shipments/labels');
+    expect($request['url'])->not->toContain('shipments/labels/combine');
+});
+
+it('surfaces the existing error taxonomy through BookingResource::create()', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    mock_smart_send_api(function () {
+        return ss_api_response(422, ss_api_error_body('The receiver postal code is invalid.'));
+    });
+
+    $shipment = $api->bookings()->fromRepresentation(sample_representation());
+    $result   = $api->bookings()->create($shipment);
+
+    expect($result)->toBeFalse();
+    expect($api->isSuccessful())->toBeFalse();
+
+    $error = $api->getError();
+    expect($error)->toBeInstanceOf(Error::class);
+    expect($error->code)->toBe('ValidationException');
+    expect($error->message)->toBe('The receiver postal code is invalid.');
+});
+
+it('builds the v1 wire Shipment model from the internal representation (BookingResource::fromRepresentation)', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+
+    $shipment = $api->bookings()->fromRepresentation(sample_representation());
+
+    expect($shipment)->toBeInstanceOf(Shipment::class);
+
+    $payload = json_decode(json_encode($shipment), true);
+    expect($payload['internal_id'])->toBe('123');
+    expect($payload['shipping_carrier'])->toBe('postnord');
+    expect($payload['receiver']['name_line1'])->toBe('Test');
+    expect($payload['parcels'][0]['items'][0]['sku'])->toBe('SKU-1');
+    expect($payload['subtotal_price_excluding_tax'])->toBe(100);
+    expect($payload['total_price_excluding_tax'])->toBe(139);
+});
+
+it('combines labels for multiple shipments into a single request body', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    $capture = mock_smart_send_api();
+
+    $result = $api->bookings()->combine(['shipment-1', 'shipment-2']);
+
+    expect($result)->toBeTrue();
+    $request = end($capture->requests);
+    expect($request['url'])->toContain('shipments/labels/combine');
+
+    $body = json_decode($request['body'], true);
+    expect($body)->toBe([
+        'shipments' => [
+            ['shipment_id' => 'shipment-1'],
+            ['shipment_id' => 'shipment-2'],
+        ],
+    ]);
+});
+
+it('surfaces the existing error taxonomy through BookingResource::combine()', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    mock_smart_send_api(function () {
+        return ss_api_response(404, ss_api_error_body('One or more shipments could not be found.'));
+    });
+
+    expect($api->bookings()->combine(['unknown-shipment']))->toBeFalse();
+    expect($api->getError()->message)->toBe('One or more shipments could not be found.');
+});
+
+it('looks up a pickup point by agent number', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    $capture = mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => pickup_point_api_data()]);
+    });
+
+    $resource = $api->pickupPoints();
+    expect($resource)->toBeInstanceOf(PickupPointResource::class)
+        ->and($api->pickupPoints())->toBe($resource);
+
+    $result = $resource->findByAgentNo('postnord', 'DK', '1234');
+
+    expect($result)->toBeTrue();
+    expect($api->isSuccessful())->toBeTrue();
+    expect($api->getData()->agent_no)->toBe('1234');
+
+    $request = end($capture->requests);
+    expect($request['url'])->toContain('agents/carrier/postnord/country/DK/agentno/1234');
+});
+
+it('surfaces the existing error taxonomy through PickupPointResource::findByAgentNo()', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    mock_smart_send_api(function () {
+        return ss_api_response(404, ss_api_error_body('Agent number not found.'));
+    });
+
+    $result = $api->pickupPoints()->findByAgentNo('postnord', 'DK', '9999');
+
+    expect($result)->toBeFalse();
+    expect($api->getError())->toBeInstanceOf(Error::class);
+    expect($api->getError()->message)->toBe('Agent number not found.');
+});
+
+it('finds the closest pickup points to an address, including the city segment', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    $capture = mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [pickup_point_api_data()]]);
+    });
+
+    $result = $api->pickupPoints()->findClosestByAddress('postnord', 'DK', '2300', 'Copenhagen', 'Islands Brygge 39');
+
+    expect($result)->toBeTrue();
+    expect($api->getData())->toHaveCount(1);
+
+    $request = end($capture->requests);
+    expect($request['url'])->toContain('agents/closest/carrier/postnord/country/DK/postalcode/2300/city/Copenhagen/street/Islands Brygge 39');
+});
+
+it('omits the city segment from the closest-address lookup when no city is given', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    $capture = mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [pickup_point_api_data()]]);
+    });
+
+    $api->pickupPoints()->findClosestByAddress('postnord', 'DK', '2300', null, 'Islands Brygge 39');
+
+    $request = end($capture->requests);
+    expect($request['url'])->toContain('agents/closest/carrier/postnord/country/DK/postalcode/2300/street/Islands Brygge 39');
+    expect($request['url'])->not->toContain('/city/');
+});
+
+it('surfaces the existing error taxonomy through PickupPointResource::findClosestByAddress()', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    mock_smart_send_api(function () {
+        return new WP_Error('http_request_failed', 'cURL error 28: Operation timed out after 4000 milliseconds');
+    });
+
+    $result = $api->pickupPoints()->findClosestByAddress('postnord', 'DK', '2300', 'Copenhagen', 'Islands Brygge 39');
+
+    expect($result)->toBeFalse();
+    expect($api->getError()->code)->toBe('transport-timeout');
+});
+
+it('applies the pickup point lookup timeout to both pickup point resource calls', function () {
+    $api = new Api('secret-token-123', 'example.test', true);
+    $capture = mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => pickup_point_api_data()]);
+    });
+
+    with_smart_send_pickup_point_timeout_filter(2.5);
+
+    $api->pickupPoints()->findByAgentNo('postnord', 'DK', '1234');
+
+    $request = end($capture->requests);
+    expect($request['timeout'])->toBe(2.5);
+});
+
+/**
+ * Add a smart_send_pickup_point_timeout filter callback, removed after the
+ * test.
+ */
+function with_smart_send_pickup_point_timeout_filter(float $timeout): void
+{
+    $callback = function () use ($timeout) {
+        return $timeout;
+    };
+
+    add_filter('smart_send_pickup_point_timeout', $callback);
+
+    remember_cleanup_callback(function () use ($callback): void {
+        remove_filter('smart_send_pickup_point_timeout', $callback);
+    });
+}


### PR DESCRIPTION
## Summary

Stacked PR - part of #111 (umbrella), on top of #130 (#113/#128, not yet merged). **This PR targets `feature/issue-113-shipment-representation`, not `develop`.** Once #130 merges it should be retargeted to `develop`.

Implements #112: splits `includes/lib/Smartsend/Api.php` (one monolithic class, one method per endpoint) into a Client/Resource layer.

- **`Client.php`**: unchanged transport/error taxonomy/logging seam, except one line - `wp_remote_request()` now passes `'reject_unsafe_urls' => true`, the same SSRF hardening `wp_safe_remote_*()` applies (relevant since `smart_send_api_endpoint` makes the endpoint filterable). Verified this does not affect the `smart_send_sslverify` filter or the `pre_http_request`-mocked test suite (that filter short-circuits before the new check runs).
- **`Resources/BookingResource.php`** (new): shipment/label booking (`create()`, `combine()`), and `fromRepresentation()` - the single point where #113's internal shipment representation is translated into the v1 wire `Smartsend\Models\Shipment`. This logic moved here from `SS_Shipping_Shipment::translate_to_wire_shipment()` and its `build_receiver()`/`build_agent()`/`build_item()`/`build_parcel()` helpers.
- **`Resources/PickupPointResource.php`** (new): agent-number and closest-address pick-up point lookups (`findByAgentNo()`, `findClosestByAddress()`).
- **`Api.php`**: now just `Client` + `getAuthenticatedUser()` (connection test, kept inline - `HttpClientErrorTest`/`LoggerTest` construct `Api` directly and call it) + memoized `bookings()`/`pickupPoints()` resource accessors. Response state (`isSuccessful()`/`getData()`/`getError()`/...) stays on the `Client`/`Api` instance, since every resource call goes back through it - this keeps every existing `SS_SHIPPING_WC()->get_api_handle()->isSuccessful()`-style call site working unchanged.
- Dropped the pagination helpers (`next()`/`previous()`/`last()`, `hasNextLink()`/...) and the agent CRUD/search methods (`getAgent()`, `createAgent()`, `getAgentsInArea()`, ...) that had no caller anywhere outside `Api.php` itself - dead weight from the old monolithic surface, not part of any `smart_send_*` extension point.

### `SS_Shipping_Shipment`'s role

Shrinks from 368 to 175 lines. It's now purely the order-level orchestrator: build the internal representation via `SS_Shipping_Shipment_Builder`, hand it to `BookingResource::fromRepresentation()`/`::create()`, expose the result (`get_shipping_data()`, `get_error_msg()`, `get_shipment()`) to `SS_Shipping_Label_Creator`. All v1 wire-translation logic is gone from this class - it now lives permanently in `BookingResource`, matching #113's stated intent ("kept only because #112's resource layer... is not part of this change").

### Call sites updated

- `class-ss-shipping-order-meta.php`, `public/class-ss-shipping-frontend.php`: `getAgentByAgentNo()`/`findClosestAgentByAddress()` → `pickupPoints()->findByAgentNo()`/`->findClosestByAddress()`.
- `class-ss-shipping-order-bulk-actions.php`: `combineLabelsForShipments()` → `bookings()->combine()`.
- `tests/Integration/LoggerTest.php`: one call site updated to the new `bookings()->combine()` shape (not a golden/wire test).

### Not done: `SmartSendFake` canned-response testing layer

Explicitly optional per the issue. Skipped - the existing `mock_smart_send_api()` helper in `tests/Integration/Helpers.php` already fakes at the same `pre_http_request` boundary the reference implementation's `SmartSendFake` targets, and my new resource-level tests reuse it directly. Adding a declarative wrapper on top would grow this diff without a concrete pain point driving it yet.

## Test plan

- [x] `composer test:integration` - 175 passed (was 164; added `tests/Integration/ResourceLayerTest.php` with one success + one error-taxonomy case per resource method, +1 test for the pickup-point timeout filter still applying)
- [x] `tests/Integration/ShipmentPayloadTest.php` (golden payload tests) pass **unmodified**
- [x] `tests/Integration/HttpClientErrorTest.php` (transport/error-taxonomy tests, constructs `Api` directly) passes **unmodified**
- [x] `vendor/bin/phpcs` (WordPress standard) - 0 violations
- [x] `composer phpcs:compat` (PHP 7.4+) - 0 violations
- [x] No baseline file present; verified fresh against every touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)