### PR TITLE
Fix naming-convention outliers, document the WP/PSR split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Single-entry WordPress plugin. `smart-send-logistics/smart-send-logistics.php` d
 
 4. **PSR-style API client** in `includes/lib/Smartsend/` — namespace `Smartsend`, classes `Api` (endpoint methods, extends `Client`) and `Client` (HTTP via `wp_remote_*` against `https://app.smartsend.io/api/v1/`), plus `Models/` value objects (`Shipment`, `Agent`, and their sub-models). This layer is deliberately WordPress-light; keep API concerns here rather than in the `SS_Shipping_*` classes.
 
+Naming convention follows this same split: `SS_Shipping_*` (WordPress-style) code uses snake_case methods; the `Smartsend\` PSR-style lib uses camelCase — a call chain crossing the boundary (e.g. `SS_SHIPPING_WC()->get_api_handle()->bookings()->findByAgentNo()`) is expected to mix both, not a bug to fix.
+
 ## Logging policy
 
 Two decoupled surfaces with distinct audiences — place every log/notice call deliberately on one of them (see issue #92):

--- a/smart-send-logistics/admin/class-ss-shipping-order-meta-box.php
+++ b/smart-send-logistics/admin/class-ss-shipping-order-meta-box.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta_Box' ) ) :
 			echo '<p>' . sprintf(
 				/* translators: %0.2f: total order weight in kg. */
 				esc_html__( 'Weight: %0.2f kg', 'smart-send-logistics' ),
-				floatval( $this->getOrderWeight( $order ) )
+				floatval( $this->get_order_weight( $order ) )
 			) . '</p>';
 
 			// Display Agent No. field if pickup-point shipping method selected.
@@ -250,8 +250,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta_Box' ) ) :
 		 * @param WC_Order $order The order.
 		 * @return float weight in kg
 		 */
-		// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- pre-existing method name, kept for backwards compatibility.
-		protected function getOrderWeight( $order ) {
+		protected function get_order_weight( $order ) {
 			$weight_total = 0;
 
 			// Get order item specific data.

--- a/smart-send-logistics/public/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/public/class-ss-shipping-frontend.php
@@ -463,7 +463,7 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 		 */
 		public function display_ss_shipping_agent( $order ) {
 
-			$order_id                = $this->getOrderId( $order );
+			$order_id                = $this->get_order_id( $order );
 			$ordered_pickup_point_no = SS_SHIPPING_WC()->get_ss_shipping_wc_order()->get_ss_shipping_order_agent_no( $order_id );
 
 			if ( $ordered_pickup_point_no ) {
@@ -481,8 +481,7 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 			}
 		}
 
-		// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- pre-existing method name, kept for backwards compatibility.
-		protected function getOrderId( $order ) {
+		protected function get_order_id( $order ) {
 			// WC 3.0 code!
 			if ( defined( 'WOOCOMMERCE_VERSION' ) && version_compare( WOOCOMMERCE_VERSION, '3.0', '>=' ) ) {
 				return $order->get_id();


### PR DESCRIPTION
## Summary
- `SS_Shipping_Order_Meta_Box::getOrderWeight()` → `get_order_weight()`, `SS_Shipping_Frontend::getOrderId()` → `get_order_id()` — both protected, single internal caller each, no filter/action exposes them, so the existing "kept for backwards compatibility" phpcs-ignore was unwarranted.
- Added one line to CLAUDE.md documenting that `SS_Shipping_*` code uses snake_case and the `Smartsend\` PSR lib uses camelCase, and that a call chain crossing that boundary (e.g. `SS_SHIPPING_WC()->get_api_handle()->bookings()->findByAgentNo()`) is expected to mix both.

## Test plan
- [x] `composer test:integration` — 179 passed
- [x] `vendor/bin/phpcs` — no new violations on touched lines