### PR TITLE
Restructure Phase 5 booking classes: naming + typed shipment representation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,14 +46,18 @@ Single-entry WordPress plugin. `smart-send-logistics/smart-send-logistics.php` d
 1. **Admin classes** in `admin/`:
    - `SS_Shipping_WC_Method` — the shipping method, extends `WC_Shipping_Flat_Rate`; rate calculation (`calculate_shipping`, `is_available`, `is_free_shipping`) and the two protected rate reporters (log + checkout debug bar). WooCommerce's settings framework dispatches `validate_*_field`/`generate_*_html` on this instance, so it keeps thin wrappers that delegate to its components: `SS_Shipping_Method_Settings` (form field definitions + validation), `SS_Shipping_Method_Form_Renderer` (custom field type rendering), `SS_Shipping_Method_Catalog` (per-carrier method lists and code→name lookup).
    - `SS_Shipping_WC_Order` — the admin order integration facade; its public surface is the stable API reached via `SS_SHIPPING_WC()->get_ss_shipping_wc_order()`. It wires hooks and delegates to: `SS_Shipping_Order_Meta` (order meta access: method id, pick-up point agent, parcel split, shipment ids), `SS_Shipping_Order_Meta_Box` (order screen meta box), `SS_Shipping_Label_Creator` (AJAX `wp_ajax_ss_shipping_generate_label` + label creation flow), `SS_Shipping_Order_Bulk_Actions` (bulk label generation incl. combined PDF). Supports both legacy post-based orders and HPOS (the plugin declares HPOS compatibility). WooCommerce Subscriptions integration stays on the facade.
-   - `SS_Shipping_Shipment` — builds the shipment payload from a WC order and sends it to the API.
+   - `SS_Shipping_Booking_Service` — the order-level booking orchestrator: `book_outbound()`/`book_return()` build a shipment representation via `SS_Shipping_Shipment_Builder`, hand it to `Smartsend\Resources\BookingResource`, and wrap the outcome in a `SS_Shipping_Booking`.
+   - `SS_Shipping_Shipment_Builder` — assembles the internal shipment representation (a typed `SS_Shipping_Shipment` value object) from `SS_Shipping_Order_Reader`'s output plus the agent/pick-up-point selection and parcel split; `build_outbound()`/`build_return()`.
+   - `SS_Shipping_Shipment` — the internal shipment representation itself: a typed, WP-side value object (order/receiver/pickup-point/parcels/totals), zero WordPress dependencies.
+   - `SS_Shipping_Booking` — wraps the outcome of a booking attempt (success flag, error message, raw API response data, translated v1 wire shipment).
+   - `SS_Shipping_Booking_Exception` — thrown internally by `SS_Shipping_Shipment_Builder::build_return()` when no return method is configured; caught by `SS_Shipping_Booking_Service` and converted into a failed `SS_Shipping_Booking`.
    - `SS_Shipping_WC_Product` — per-product shipping meta.
    - `SS_Plugins_Screen_Updates` — upgrade notices on the plugins screen.
 
 2. **Frontend classes** in `public/`:
    - `SS_Shipping_Frontend` — checkout-side pick-up point selection display.
 
-3. **Shared classes** in `includes/`: `SS_Shipping_Logger` (WC log; `debug` level gated on the "Debug Log" setting), `SS_Shipping_Checkout_Debug` (checkout shipping debug bar), `SS_Shipping_Admin_Notices` (flash notices store), `SS_Shipping_Order_Data` (order → payload data extraction).
+3. **Shared classes** in `includes/`: `SS_Shipping_Logger` (WC log; `debug` level gated on the "Debug Log" setting), `SS_Shipping_Checkout_Debug` (checkout shipping debug bar), `SS_Shipping_Admin_Notices` (flash notices store), `SS_Shipping_Order_Reader` (order → payload data extraction).
 
 4. **PSR-style API client** in `includes/lib/Smartsend/` — namespace `Smartsend`, classes `Api` (endpoint methods, extends `Client`) and `Client` (HTTP via `wp_remote_*` against `https://app.smartsend.io/api/v1/`), plus `Models/` value objects (`Shipment`, `Agent`, and their sub-models). This layer is deliberately WordPress-light; keep API concerns here rather than in the `SS_Shipping_*` classes.
 

--- a/smart-send-logistics/admin/class-ss-shipping-booking-exception.php
+++ b/smart-send-logistics/admin/class-ss-shipping-booking-exception.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * WooCommerce Smart Send booking exception.
+ *
+ * @package  SS_Shipping_Booking_Exception
+ * @category Shipping
+ * @author   Smart Send
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+// A second copy of the plugin may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_Booking_Exception' ) ) :
+
+	/**
+	 * Thrown by SS_Shipping_Shipment_Builder when it cannot produce a valid
+	 * SS_Shipping_Shipment (e.g. no return method configured).
+	 *
+	 * Message-only: SS_Shipping_Booking_Service catches this internally and
+	 * converts it into a failed SS_Shipping_Booking - it never propagates
+	 * to SS_Shipping_Booking_Service's own callers.
+	 */
+	class SS_Shipping_Booking_Exception extends \Exception {}
+
+endif;

--- a/smart-send-logistics/admin/class-ss-shipping-booking-service.php
+++ b/smart-send-logistics/admin/class-ss-shipping-booking-service.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * WooCommerce Smart Send booking service.
+ *
+ * @package  SS_Shipping_Booking_Service
+ * @category Shipping
+ * @author   Smart Send
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+// A second copy of the plugin may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_Booking_Service' ) ) :
+
+	/**
+	 * Books a WooCommerce order with the Smart Send API.
+	 *
+	 * SS_Shipping_Shipment_Builder assembles the internal shipment
+	 * representation (#113); \Smartsend\Resources\BookingResource (#112)
+	 * translates that representation into the v1 wire request
+	 * (Smartsend\Models\Shipment and its sub-models) and sends it. This
+	 * class is the order-level orchestrator: build the representation, hand
+	 * it to the booking resource, and expose the result to callers
+	 * (SS_Shipping_Label_Creator) as a SS_Shipping_Booking.
+	 *
+	 * Outbound and return bookings are two separate entry points -
+	 * book_outbound() and book_return() - rather than a single method
+	 * taking an is_return boolean; see SS_Shipping_Shipment_Builder's
+	 * class docblock for why. Neither method ever throws: a config error
+	 * (e.g. no return method configured, raised internally by
+	 * SS_Shipping_Shipment_Builder as a SS_Shipping_Booking_Exception) or
+	 * an API-level error are both reported the same way, as a failed
+	 * SS_Shipping_Booking - callers only need to check is_successful().
+	 */
+	class SS_Shipping_Booking_Service {
+
+		/**
+		 * The WooCommerce order.
+		 *
+		 * @var WC_Order
+		 */
+		protected WC_Order $order;
+
+		/**
+		 * Order data access utility.
+		 *
+		 * @var SS_Shipping_Order_Reader
+		 */
+		protected SS_Shipping_Order_Reader $order_reader;
+
+		/**
+		 * The admin order integration.
+		 *
+		 * @var SS_Shipping_WC_Order
+		 */
+		protected SS_Shipping_WC_Order $shipping_order;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param WC_Order             $order          The WooCommerce order to book a shipment for.
+		 * @param SS_Shipping_WC_Order $shipping_order The admin order integration.
+		 */
+		public function __construct( WC_Order $order, SS_Shipping_WC_Order $shipping_order ) {
+			$this->order          = $order;
+			$this->order_reader   = new SS_Shipping_Order_Reader( $order );
+			$this->shipping_order = $shipping_order;
+		}
+
+		/**
+		 * Book an outbound (normal) shipping label.
+		 *
+		 * @return SS_Shipping_Booking
+		 */
+		public function book_outbound(): SS_Shipping_Booking {
+			$builder = new SS_Shipping_Shipment_Builder( $this->order, $this->order_reader, $this->shipping_order );
+
+			try {
+				$shipment = $builder->build_outbound();
+			} catch ( SS_Shipping_Booking_Exception $e ) {
+				return new SS_Shipping_Booking( false, $e->getMessage(), null, null );
+			}
+
+			return $this->send( $shipment );
+		}
+
+		/**
+		 * Book a return shipping label.
+		 *
+		 * @return SS_Shipping_Booking
+		 */
+		public function book_return(): SS_Shipping_Booking {
+			$builder = new SS_Shipping_Shipment_Builder( $this->order, $this->order_reader, $this->shipping_order );
+
+			try {
+				$shipment = $builder->build_return();
+			} catch ( SS_Shipping_Booking_Exception $e ) {
+				return new SS_Shipping_Booking( false, $e->getMessage(), null, null );
+			}
+
+			return $this->send( $shipment );
+		}
+
+		/**
+		 * Translate the shipment representation into the v1 wire model and
+		 * send it to the Smart Send API, wrapping the outcome into a
+		 * SS_Shipping_Booking. Shared by book_outbound() and book_return()
+		 * - the part of booking that never differs between the two.
+		 *
+		 * @param SS_Shipping_Shipment $shipment The shipment representation to book.
+		 *
+		 * @return SS_Shipping_Booking
+		 */
+		protected function send( SS_Shipping_Shipment $shipment ): SS_Shipping_Booking {
+			$api = SS_SHIPPING_WC()->get_api_handle();
+
+			$wire_shipment = $api->bookings()->fromShipment( $shipment );
+
+			// Make API Request. The request and response (incl. HTTP status
+			// code and endpoint) are logged by the client's request logger.
+			$api->bookings()->create( $wire_shipment );
+
+			if ( $api->isSuccessful() ) {
+				return new SS_Shipping_Booking( true, null, $api->getData(), $wire_shipment );
+			}
+
+			return new SS_Shipping_Booking( false, $api->getErrorString(), null, $wire_shipment );
+		}
+	}
+
+endif;

--- a/smart-send-logistics/admin/class-ss-shipping-booking.php
+++ b/smart-send-logistics/admin/class-ss-shipping-booking.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * WooCommerce Smart Send booking outcome.
+ *
+ * @package  SS_Shipping_Booking
+ * @category Shipping
+ * @author   Smart Send
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+// A second copy of the plugin may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_Booking' ) ) :
+
+	/**
+	 * Wraps the outcome of a SS_Shipping_Booking_Service::book_outbound()/
+	 * book_return() attempt: either the raw API response data (unchanged
+	 * pass-through of Smartsend\Client::getData()'s dynamic stdClass shape -
+	 * remodelling that shape is out of scope here, see #112) and the
+	 * translated v1 wire shipment model, or an error message when the
+	 * booking failed (config error or API error).
+	 */
+	class SS_Shipping_Booking {
+
+		/**
+		 * Whether the booking succeeded.
+		 *
+		 * @var boolean
+		 */
+		protected bool $successful;
+
+		/**
+		 * The error message, set only when the booking failed.
+		 *
+		 * @var string|null
+		 */
+		protected ?string $error_message;
+
+		/**
+		 * The raw API response data, set only when the booking succeeded.
+		 *
+		 * @var object|null
+		 */
+		protected ?object $data;
+
+		/**
+		 * The v1 wire shipment model translated from the
+		 * SS_Shipping_Shipment representation, or null when no shipment
+		 * could be built (e.g. no return method configured).
+		 *
+		 * @var \Smartsend\Models\Shipment|null
+		 */
+		protected ?\Smartsend\Models\Shipment $wire_shipment;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param boolean                          $successful    Whether the booking succeeded.
+		 * @param string|null                      $error_message The error message, set only when the booking failed.
+		 * @param object|null                      $data          The raw API response data, set only when the booking succeeded.
+		 * @param \Smartsend\Models\Shipment|null   $wire_shipment The v1 wire shipment model, if one was built.
+		 */
+		public function __construct( bool $successful, ?string $error_message, ?object $data, ?\Smartsend\Models\Shipment $wire_shipment ) {
+			$this->successful    = $successful;
+			$this->error_message = $error_message;
+			$this->data          = $data;
+			$this->wire_shipment = $wire_shipment;
+		}
+
+		/**
+		 * Whether the booking succeeded.
+		 *
+		 * @return boolean
+		 */
+		public function is_successful(): bool {
+			return $this->successful;
+		}
+
+		/**
+		 * Get the error message, if the booking failed.
+		 *
+		 * @return string|null
+		 */
+		public function get_error_message(): ?string {
+			return $this->error_message;
+		}
+
+		/**
+		 * Get the raw API response data, if the booking succeeded.
+		 *
+		 * Same dynamic stdClass shape Smartsend\Client::getData() returns
+		 * today: shipment_id, pdf->base_64_encoded, pdf->link, carrier_name,
+		 * parcels[]->tracking_code/tracking_link, woocommerce, etc.
+		 *
+		 * @return object|null
+		 */
+		public function get_data(): ?object {
+			return $this->data;
+		}
+
+		/**
+		 * Get the v1 wire shipment model translated from the shipment
+		 * representation, if one was built.
+		 *
+		 * @return \Smartsend\Models\Shipment|null
+		 */
+		public function get_wire_shipment(): ?\Smartsend\Models\Shipment {
+			return $this->wire_shipment;
+		}
+	}
+
+endif;

--- a/smart-send-logistics/admin/class-ss-shipping-label-creator.php
+++ b/smart-send-logistics/admin/class-ss-shipping-label-creator.php
@@ -8,9 +8,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Smart Send label creation.
  *
  * Owns the AJAX label-generation endpoint and the full create-label flow
- * for a single order: calling the API via SS_Shipping_Shipment, storing
- * the shipment id, writing the order note, pushing tracking info and
- * saving the PDF file.
+ * for a single order: calling the API via SS_Shipping_Booking_Service,
+ * storing the shipment id, writing the order note, pushing tracking info
+ * and saving the PDF file.
  *
  * @package  SS_Shipping_Label_Creator
  * @category Shipping
@@ -25,7 +25,7 @@ if ( ! class_exists( 'SS_Shipping_Label_Creator' ) ) :
 		protected string $label_prefix = 'smart-send-label-';
 
 		/**
-		 * The order integration facade (passed on to SS_Shipping_Shipment).
+		 * The order integration facade (passed on to SS_Shipping_Booking_Service).
 		 *
 		 * @var SS_Shipping_WC_Order
 		 */
@@ -137,12 +137,13 @@ if ( ! class_exists( 'SS_Shipping_Label_Creator' ) ) :
 				);
 			}
 
-			$ss_order_api = new SS_Shipping_Shipment( $order, $this->order_integration );
+			$booking_service = new SS_Shipping_Booking_Service( $order, $this->order_integration );
+			$booking         = $return ? $booking_service->book_return() : $booking_service->book_outbound();
 
-			if ( $ss_order_api->make_single_shipment_api_call( $return ) ) {
+			if ( $booking->is_successful() ) {
 
 				//The request was successful, lets update WooCommerce
-				$response = $ss_order_api->get_shipping_data();
+				$response = $booking->get_data();
 
 				if ( SS_SHIPPING_WC()->get_setting_save_shipping_labels_in_uploads() ) {
 					try {
@@ -236,11 +237,11 @@ if ( ! class_exists( 'SS_Shipping_Label_Creator' ) ) :
 				// return the success data
 				return array(
 					'success'  => $response,
-					'shipment' => $ss_order_api->get_shipment(),
+					'shipment' => $booking->get_wire_shipment(),
 				);
 			} else {
 				// Something failed. Let's return them, so the error can be shown to the user
-				return array( 'error' => $ss_order_api->get_error_msg() );
+				return array( 'error' => $booking->get_error_message() );
 			}
 		}
 

--- a/smart-send-logistics/admin/class-ss-shipping-shipment-builder.php
+++ b/smart-send-logistics/admin/class-ss-shipping-shipment-builder.php
@@ -15,19 +15,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 
 	/**
-	 * Assembles the new internal shipment representation (#113) from
-	 * SS_Shipping_Order_Data's output plus the agent/pick-up-point
-	 * selection and parcel split. The representation is a plain array
-	 * shaped close to the Smart Send v2 API schema: a single net amount +
-	 * tax amount per level (shipment/parcel/item), no excl/incl
-	 * redundancy, and a pickup-point section named after v2's
+	 * Assembles the internal shipment representation (#113), a typed
+	 * SS_Shipping_Shipment value object, from SS_Shipping_Order_Reader's
+	 * output plus the agent/pick-up-point selection and parcel split. The
+	 * representation is shaped close to the Smart Send v2 API schema: a
+	 * single net amount + tax amount per level (shipment/parcel/item), no
+	 * excl/incl redundancy, and a pickup-point section named after v2's
 	 * PickupParty.service_point_code rather than v1's agent_no/agent.
 	 *
 	 * This class does not talk to the API and does not know about the v1
 	 * wire format - translating the representation into the v1 request
-	 * body is SS_Shipping_Shipment's job (a thin adapter, kept only
-	 * because #112's resource layer, which will own that translation
-	 * permanently, is not part of this change).
+	 * body is \Smartsend\Resources\BookingResource::fromShipment()'s job
+	 * (#112).
+	 *
+	 * Outbound and return bookings are two separate entry points -
+	 * build_outbound() and build_return() - rather than a single build()
+	 * taking an is_return boolean: they are expected to grow different
+	 * do_action() calls and different business logic over time, and a
+	 * boolean flag silently branching inside one method would hide that.
+	 * Both share assemble_shipment() for the parts that don't differ
+	 * (item/parcel/totals assembly) - only the shipping-method/agent
+	 * selection differs between the two.
+	 *
+	 * build_return() throws SS_Shipping_Booking_Exception when it cannot
+	 * produce a valid shipment (no return method configured) - it is
+	 * SS_Shipping_Booking_Service's job to catch that and convert it into
+	 * a failed SS_Shipping_Booking; this class never returns an error
+	 * array/value.
 	 *
 	 * Gift card exclusion (#128) is NOT implemented here: WooCommerce
 	 * Gift Cards redemptions are not order items (confirmed against the
@@ -39,7 +53,7 @@ if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 	 * lower an item price. But the exact order-level representation
 	 * (fee line, meta, or something else) could not be confirmed with
 	 * confidence without the plugin installed, so the shipment/parcel
-	 * subtotal calculated in SS_Shipping_Order_Data::get_totals() is not
+	 * subtotal calculated in SS_Shipping_Order_Reader::get_totals() is not
 	 * yet corrected to add the redemption back - a gift-card-funded order
 	 * still under-reports its shipment value today, same as before this
 	 * change. This is a documented follow-up, to be implemented against
@@ -58,9 +72,9 @@ if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 		/**
 		 * Order data access utility.
 		 *
-		 * @var SS_Shipping_Order_Data
+		 * @var SS_Shipping_Order_Reader
 		 */
-		protected SS_Shipping_Order_Data $order_data;
+		protected SS_Shipping_Order_Reader $order_reader;
 
 		/**
 		 * The admin order integration.
@@ -72,64 +86,93 @@ if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 		/**
 		 * Constructor.
 		 *
-		 * @param WC_Order               $order          The WooCommerce order.
-		 * @param SS_Shipping_Order_Data $order_data     Order data access utility for the same order.
-		 * @param SS_Shipping_WC_Order   $shipping_order The admin order integration.
+		 * @param WC_Order                 $order          The WooCommerce order.
+		 * @param SS_Shipping_Order_Reader $order_reader   Order data access utility for the same order.
+		 * @param SS_Shipping_WC_Order     $shipping_order The admin order integration.
 		 */
-		public function __construct( WC_Order $order, SS_Shipping_Order_Data $order_data, SS_Shipping_WC_Order $shipping_order ) {
+		public function __construct( WC_Order $order, SS_Shipping_Order_Reader $order_reader, SS_Shipping_WC_Order $shipping_order ) {
 			$this->order          = $order;
-			$this->order_data     = $order_data;
+			$this->order_reader   = $order_reader;
 			$this->shipping_order = $shipping_order;
 		}
 
 		/**
-		 * Build the internal shipment representation.
+		 * Build the internal shipment representation for an outbound
+		 * (normal) shipping label: the shipping method/carrier comes from
+		 * the order's Smart Send shipping method, and a pick-up point
+		 * (agent) is selected when one is stored on the order.
 		 *
-		 * @param boolean $is_return Whether the label is a return label.
-		 *
-		 * @return array {
-		 *     The internal shipment representation, or an error.
-		 *
-		 *     @type string     $error               Set instead of every other key when no return method is configured.
-		 *     @type string     $internal_id         Order id.
-		 *     @type string     $internal_reference  Order number.
-		 *     @type string|null $shipping_carrier   Smart Send carrier code.
-		 *     @type string|null $shipping_method    Smart Send shipping method code.
-		 *     @type string     $shipping_date       Shipping date (Y-m-d).
-		 *     @type array      $receiver            Receiver data, see SS_Shipping_Order_Data::get_receiver_data().
-		 *     @type array|null $pickup_point        Pickup point data (service_point_code, address, ...), or null.
-		 *     @type array[]    $parcels             One row per parcel: internal_id, internal_reference, weight,
-		 *                                            height, width, length, freetext, items (item rows),
-		 *                                            total_net_amount, total_tax_amount.
-		 *     @type float|null $subtotal_net_amount Order total excl. shipping, excl. tax.
-		 *     @type float|null $subtotal_tax_amount Tax on the order total excl. shipping.
-		 *     @type float|null $shipping_net_amount Shipping cost excl. tax.
-		 *     @type float|null $shipping_tax_amount Tax on the shipping cost.
-		 *     @type float|null $total_net_amount    Order total excl. tax.
-		 *     @type float|null $total_tax_amount    Total tax on the order.
-		 *     @type string|null $currency           Order currency code.
-		 * }
+		 * @return SS_Shipping_Shipment
 		 */
-		public function build( $is_return ) {
-			$order_id = $this->order_data->get_order_id();
+		public function build_outbound(): SS_Shipping_Shipment {
+			$order_id = $this->order_reader->get_order_id();
 
-			$ss_args = array();
+			$ss_shipping_method_id = $this->shipping_order->get_smart_send_method_id( $order_id, false );
 
-			// Get shipping method.
-			$ss_shipping_method_id = $this->shipping_order->get_smart_send_method_id( $order_id, $is_return );
+			$ss_args = array(
+				'ss_agent' => $this->shipping_order->get_ss_shipping_order_agent( $order_id ),
+			);
 
-			if ( $is_return && isset( $ss_shipping_method_id['smart_send_return_method'] ) ) {
-				// If no return method set return error.
+			return $this->assemble_shipment( $ss_shipping_method_id, $ss_args, false );
+		}
+
+		/**
+		 * Build the internal shipment representation for a return label:
+		 * the shipping method/carrier comes from the order's configured
+		 * return method, and no pick-up point is selected - unless the
+		 * return method could not be resolved to the dedicated
+		 * smart_send_return_method meta (free-shipping/vConnect orders,
+		 * see the v8-oddity note on the else branch below), in which case
+		 * this falls back to the same agent selection as an outbound
+		 * label.
+		 *
+		 * @throws SS_Shipping_Booking_Exception When no return method is configured.
+		 *
+		 * @return SS_Shipping_Shipment
+		 */
+		public function build_return(): SS_Shipping_Shipment {
+			$order_id = $this->order_reader->get_order_id();
+			$ss_args  = array();
+
+			$ss_shipping_method_id = $this->shipping_order->get_smart_send_method_id( $order_id, true );
+
+			if ( isset( $ss_shipping_method_id['smart_send_return_method'] ) ) {
 				if ( empty( $ss_shipping_method_id['smart_send_return_method'] ) ) {
-					return array( 'error' => __( 'No return method set', 'smart-send-logistics' ) );
-				} else {
-					$ss_shipping_method_id = $ss_shipping_method_id['smart_send_return_method'];
+					// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- the exception message is caught by SS_Shipping_Booking_Service and surfaced via SS_Shipping_Booking::get_error_message(), never echoed directly; escaping is not applicable here.
+					throw new SS_Shipping_Booking_Exception( __( 'No return method set', 'smart-send-logistics' ) );
 				}
+
+				$ss_shipping_method_id = $ss_shipping_method_id['smart_send_return_method'];
 			} else {
+				// v8 oddity: free-shipping/vConnect orders never resolve to
+				// the smart_send_return_method array (get_smart_send_method_id()
+				// already returns the concrete method id string for them), so
+				// this branch - identical to build_outbound()'s agent
+				// selection - still runs for a return label in that case.
 				$ss_args['ss_agent'] = $this->shipping_order->get_ss_shipping_order_agent( $order_id );
 			}
 
-			// Determine shipping method and carrier from return settings.
+			return $this->assemble_shipment( $ss_shipping_method_id, $ss_args, true );
+		}
+
+		/**
+		 * Assemble the shipment representation shared by build_outbound()
+		 * and build_return(): carrier/type resolution, parcel split,
+		 * receiver, pick-up point, item lines and totals. Only the
+		 * shipping-method/agent selection (the caller-supplied
+		 * $ss_shipping_method_id and $ss_args['ss_agent']) differs between
+		 * outbound and return bookings.
+		 *
+		 * @param string  $ss_shipping_method_id Smart Send shipping method id.
+		 * @param array   $ss_args               Args built so far by the caller (e.g. 'ss_agent').
+		 * @param boolean $is_return             Whether this is a return label.
+		 *
+		 * @return SS_Shipping_Shipment
+		 */
+		protected function assemble_shipment( $ss_shipping_method_id, array $ss_args, $is_return ): SS_Shipping_Shipment {
+			$order_id = $this->order_reader->get_order_id();
+
+			// Determine shipping method and carrier.
 			$ss_args['ss_carrier'] = SS_SHIPPING_WC()->get_shipping_method_carrier( $ss_shipping_method_id );
 			$ss_args['ss_type']    = SS_SHIPPING_WC()->get_shipping_method_type( $ss_shipping_method_id );
 
@@ -167,7 +210,7 @@ if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 			 */
 			$ss_args = apply_filters( 'smart_send_shipping_label_args', $ss_args, $order_id, $is_return );
 
-			$receiver = $this->order_data->get_receiver_data();
+			$receiver = $this->order_reader->get_receiver_data();
 
 			// Add the pickup point to the shipment, if any.
 			$ss_agent = apply_filters(
@@ -179,7 +222,7 @@ if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 			$pickup_point = empty( $ss_agent ) ? null : $this->build_pickup_point( $ss_agent );
 
 			// Item lines and totals.
-			$items_data = $this->order_data->get_items_data();
+			$items_data = $this->order_reader->get_items_data();
 
 			$parcels = array();
 			$totals  = array(
@@ -193,8 +236,8 @@ if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 			);
 
 			if ( ! empty( $items_data ) ) {
-				$totals     = $this->order_data->get_totals();
-				$order_note = $this->order_data->get_order_note();
+				$totals     = $this->order_reader->get_totals();
+				$order_note = $this->order_reader->get_order_note();
 
 				// Item rows, keyed by product/variation id so a parcel
 				// split can reference them.
@@ -215,7 +258,7 @@ if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 					// A single parcel containing all the items just defined.
 					$parcels[] = array(
 						'internal_id'        => $this->value_or_null( $order_id ),
-						'internal_reference' => $this->value_or_null( $this->order_data->get_order_number() ),
+						'internal_reference' => $this->value_or_null( $this->order_reader->get_order_number() ),
 						'weight'             => $this->value_or_null( $weight_total ),
 						'height'             => null,
 						'width'              => null,
@@ -238,28 +281,29 @@ if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 			 *
 			 * @since 9.0.0
 			 *
-			 * @param array[]  $parcels The assembled parcel rows (see the return doc of self::build()).
+			 * @param array[]  $parcels The assembled parcel rows.
 			 * @param WC_Order $order   The WooCommerce order.
 			 */
 			$parcels = apply_filters( 'smart_send_payload_parcels', $parcels, $this->order );
 
-			return array(
-				'internal_id'         => $this->value_or_null( $order_id ),
-				'internal_reference'  => $this->value_or_null( $this->order_data->get_order_number() ),
-				'shipping_carrier'    => $this->value_or_null( $ss_args['ss_carrier'] ),
-				'shipping_method'     => $this->value_or_null( $ss_args['ss_type'] ),
-				'shipping_date'       => gmdate( 'Y-m-d' ),
-				'receiver'            => $receiver,
-				'pickup_point'        => $pickup_point,
-				'parcels'             => $parcels,
-				'subtotal_net_amount' => $totals['subtotal_net_amount'],
-				'subtotal_tax_amount' => $totals['subtotal_tax_amount'],
-				'shipping_net_amount' => $totals['shipping_net_amount'],
-				'shipping_tax_amount' => $totals['shipping_tax_amount'],
-				'total_net_amount'    => $totals['total_net_amount'],
-				'total_tax_amount'    => $totals['total_tax_amount'],
-				'currency'            => $totals['currency'],
-			);
+			$shipment = new SS_Shipping_Shipment();
+			$shipment->set_internal_id( $this->value_or_null( $order_id ) )
+				->set_internal_reference( $this->value_or_null( $this->order_reader->get_order_number() ) )
+				->set_shipping_carrier( $this->value_or_null( $ss_args['ss_carrier'] ) )
+				->set_shipping_method( $this->value_or_null( $ss_args['ss_type'] ) )
+				->set_shipping_date( gmdate( 'Y-m-d' ) )
+				->set_receiver( $receiver )
+				->set_pickup_point( $pickup_point )
+				->set_parcels( $parcels )
+				->set_subtotal_net_amount( $totals['subtotal_net_amount'] )
+				->set_subtotal_tax_amount( $totals['subtotal_tax_amount'] )
+				->set_shipping_net_amount( $totals['shipping_net_amount'] )
+				->set_shipping_tax_amount( $totals['shipping_tax_amount'] )
+				->set_total_net_amount( $totals['total_net_amount'] )
+				->set_total_tax_amount( $totals['total_tax_amount'] )
+				->set_currency( $totals['currency'] );
+
+			return $shipment;
 		}
 
 		/**
@@ -338,12 +382,12 @@ if ( ! class_exists( 'SS_Shipping_Shipment_Builder' ) ) :
 				$parcel_total_weight = apply_filters(
 					'smart_send_parcel_weight',
 					$this->value_or_null( $item_weight_total ),
-					$this->order_data->get_order_id()
+					$this->order_reader->get_order_id()
 				);
 
 				$parcels[] = array(
-					'internal_id'        => $this->value_or_null( $this->order_data->get_order_id() ),
-					'internal_reference' => $this->value_or_null( $this->order_data->get_order_number() ),
+					'internal_id'        => $this->value_or_null( $this->order_reader->get_order_id() ),
+					'internal_reference' => $this->value_or_null( $this->order_reader->get_order_number() ),
 					'weight'             => $parcel_total_weight,
 					'height'             => null,
 					'width'              => null,

--- a/smart-send-logistics/admin/class-ss-shipping-shipment.php
+++ b/smart-send-logistics/admin/class-ss-shipping-shipment.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WooCommerce Smart Send Shipping Order Payload.
+ * WooCommerce Smart Send internal shipment representation.
  *
  * @package  SS_Shipping_Shipment
  * @category Shipping
@@ -15,160 +15,468 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! class_exists( 'SS_Shipping_Shipment' ) ) :
 
 	/**
-	 * Sends a WooCommerce order to the Smart Send API as a shipment.
+	 * The internal shipment representation (#113) assembled by
+	 * SS_Shipping_Shipment_Builder from SS_Shipping_Order_Reader's output
+	 * plus the agent/pick-up-point selection and parcel split.
 	 *
-	 * SS_Shipping_Shipment_Builder assembles the new internal shipment
-	 * representation (#113); \Smartsend\Resources\BookingResource (#112)
-	 * translates that representation into the v1 wire request
-	 * (Smartsend\Models\Shipment and its sub-models) and sends it. This
-	 * class is now only the order-level orchestrator: build the
-	 * representation, hand it to the booking resource, and expose the
-	 * result to callers (SS_Shipping_Label_Creator).
+	 * A typed, WP-side value object shaped close to the Smart Send v2 API
+	 * schema: a single net amount + tax amount per level (shipment/parcel/
+	 * item), no excl/incl redundancy, and a pickup-point section named
+	 * after v2's PickupParty.service_point_code rather than v1's
+	 * agent_no/agent.
+	 *
+	 * Nested sections (receiver, pickup_point, parcels and each parcel's
+	 * items) are kept as plain arrays rather than their own value-object
+	 * classes - promoting every nesting level would add ceremony without
+	 * adding safety here, since the only other reader is
+	 * \Smartsend\Resources\BookingResource::fromShipment(), which already
+	 * needs array access to build its own sub-models.
+	 *
+	 * This class does not talk to the API and does not know about the v1
+	 * wire format - translating it into the v1 request body is
+	 * \Smartsend\Resources\BookingResource::fromShipment()'s job. It also
+	 * makes zero WordPress function calls, despite living in the WP-side
+	 * global namespace: it is a pure data holder, referenced by the
+	 * "WordPress-light" PSR API client (includes/lib/Smartsend/) purely by
+	 * its fully-qualified global name (\SS_Shipping_Shipment).
 	 */
 	class SS_Shipping_Shipment {
 
 		/**
-		 * The WooCommerce order.
+		 * Order id.
 		 *
-		 * Deliberately untyped: wc_get_order() can return false (or a
-		 * WC_Order_Refund), and the constructor relies on that falsy value.
-		 *
-		 * @var WC_Order|false|null
+		 * @var string|null
 		 */
-		protected $order = null;
+		protected ?string $internal_id = null;
 
 		/**
-		 * Order data access utility.
+		 * Order number.
 		 *
-		 * @var SS_Shipping_Order_Data|null
+		 * @var string|null
 		 */
-		protected ?SS_Shipping_Order_Data $order_data = null;
+		protected ?string $internal_reference = null;
 
 		/**
-		 * The admin order integration.
+		 * Smart Send carrier code.
 		 *
-		 * @var SS_Shipping_WC_Order|null
+		 * @var string|null
 		 */
-		protected ?SS_Shipping_WC_Order $shipping_order = null;
+		protected ?string $shipping_carrier = null;
 
 		/**
-		 * The internal shipment representation assembled by
-		 * SS_Shipping_Shipment_Builder, or an error array.
+		 * Smart Send shipping method code.
+		 *
+		 * @var string|null
+		 */
+		protected ?string $shipping_method = null;
+
+		/**
+		 * Shipping date (Y-m-d).
+		 *
+		 * @var string|null
+		 */
+		protected ?string $shipping_date = null;
+
+		/**
+		 * Receiver data, see SS_Shipping_Order_Reader::get_receiver_data().
 		 *
 		 * @var array|null
 		 */
-		protected ?array $representation = null;
+		protected ?array $receiver = null;
 
 		/**
-		 * The v1 wire shipment model translated from the representation.
+		 * Pickup point data (service_point_code, address, ...), or null.
 		 *
-		 * @var \Smartsend\Models\Shipment|null
+		 * @var array|null
 		 */
-		protected ?\Smartsend\Models\Shipment $shipment = null;
+		protected ?array $pickup_point = null;
 
 		/**
-		 * Init and hook in the integration.
+		 * One row per parcel: internal_id, internal_reference, weight,
+		 * height, width, length, freetext, items (item rows),
+		 * total_net_amount, total_tax_amount.
 		 *
-		 * @param WC_Order|integer     $order          The order (object or id) to build a shipment for.
-		 * @param SS_Shipping_WC_Order $shipping_order The admin order integration.
+		 * @var array[]
 		 */
-		public function __construct( $order, $shipping_order ) {
-			if ( is_numeric( $order ) && $order > 0 ) {
-				$this->order = wc_get_order( $order );
+		protected array $parcels = array();
 
-				if ( ! $this->order ) {
-					return;
-				}
-			} elseif ( $order instanceof WC_Order ) {
-				$this->order = $order;
-			} else {
-				return;
-			}
+		/**
+		 * Order total excl. shipping, excl. tax.
+		 *
+		 * @var float|null
+		 */
+		protected ?float $subtotal_net_amount = null;
 
-			$this->order_data     = new SS_Shipping_Order_Data( $this->order );
-			$this->shipping_order = $shipping_order;
+		/**
+		 * Tax on the order total excl. shipping.
+		 *
+		 * @var float|null
+		 */
+		protected ?float $subtotal_tax_amount = null;
 
-			// Wire shipment model, empty until the representation is
-			// translated. Kept even on a build error so a caller that
-			// still sends the (empty) request behaves as it always has.
-			$this->shipment = new \Smartsend\Models\Shipment();
+		/**
+		 * Shipping cost excl. tax.
+		 *
+		 * @var float|null
+		 */
+		protected ?float $shipping_net_amount = null;
+
+		/**
+		 * Tax on the shipping cost.
+		 *
+		 * @var float|null
+		 */
+		protected ?float $shipping_tax_amount = null;
+
+		/**
+		 * Order total excl. tax.
+		 *
+		 * @var float|null
+		 */
+		protected ?float $total_net_amount = null;
+
+		/**
+		 * Total tax on the order.
+		 *
+		 * @var float|null
+		 */
+		protected ?float $total_tax_amount = null;
+
+		/**
+		 * Order currency code.
+		 *
+		 * @var string|null
+		 */
+		protected ?string $currency = null;
+
+		/**
+		 * Get the order id.
+		 *
+		 * @return string|null
+		 */
+		public function get_internal_id() {
+			return $this->internal_id;
 		}
 
 		/**
-		 * Create single order.
+		 * Set the order id.
 		 *
-		 * @param boolean $is_return Whether the label is a return label.
+		 * @param mixed $internal_id Order id.
 		 *
-		 * @return boolean
+		 * @return self
 		 */
-		public function make_single_shipment_api_call( $is_return ) {
-			$this->make_single_shipment_api_payload( $is_return );
-			$this->make_single_shipment_api_request();
+		public function set_internal_id( $internal_id ): self {
+			$this->internal_id = null === $internal_id ? null : (string) $internal_id;
 
-			if ( SS_SHIPPING_WC()->get_api_handle()->isSuccessful() ) {
-				return true;
-			} else {
-				return false;
-			}
+			return $this;
 		}
 
 		/**
-		 * Get API call data.
+		 * Get the order number.
 		 *
-		 * @return object
+		 * @return string|null
 		 */
-		public function get_shipping_data() {
-			return SS_SHIPPING_WC()->get_api_handle()->getData();
+		public function get_internal_reference() {
+			return $this->internal_reference;
 		}
 
 		/**
-		 * Get error message.
+		 * Set the order number.
 		 *
-		 * @return string
+		 * @param mixed $internal_reference Order number.
+		 *
+		 * @return self
 		 */
-		public function get_error_msg() {
-			return SS_SHIPPING_WC()->get_api_handle()->getErrorString();
+		public function set_internal_reference( $internal_reference ): self {
+			$this->internal_reference = null === $internal_reference ? null : (string) $internal_reference;
+
+			return $this;
 		}
 
 		/**
-		 * Get shipment object.
+		 * Get the Smart Send carrier code.
 		 *
-		 * @return \Smartsend\Models\Shipment
+		 * @return string|null
 		 */
-		public function get_shipment() {
-			return $this->shipment;
+		public function get_shipping_carrier() {
+			return $this->shipping_carrier;
 		}
 
 		/**
-		 * Build the internal shipment representation and translate it into
-		 * the v1 wire shipment model. The translation itself is
-		 * \Smartsend\Resources\BookingResource::fromRepresentation() (#112)
-		 * - the single point where the v1 wire payload is built.
+		 * Set the Smart Send carrier code.
 		 *
-		 * @param boolean $is_return Whether the label is a return label.
+		 * @param mixed $shipping_carrier Smart Send carrier code.
 		 *
-		 * @return array|void The representation, only when it is an error.
+		 * @return self
 		 */
-		protected function make_single_shipment_api_payload( $is_return ) {
-			$builder              = new SS_Shipping_Shipment_Builder( $this->order, $this->order_data, $this->shipping_order );
-			$this->representation = $builder->build( $is_return );
+		public function set_shipping_carrier( $shipping_carrier ): self {
+			$this->shipping_carrier = null === $shipping_carrier ? null : (string) $shipping_carrier;
 
-			if ( isset( $this->representation['error'] ) ) {
-				return $this->representation;
-			}
-
-			$this->shipment = SS_SHIPPING_WC()->get_api_handle()->bookings()->fromRepresentation( $this->representation );
+			return $this;
 		}
 
 		/**
-		 * Call Smart Send Shipment API, log response.
+		 * Get the Smart Send shipping method code.
 		 *
-		 * @return void
+		 * @return string|null
 		 */
-		protected function make_single_shipment_api_request() {
-			// Make API Request. The request and response (incl. HTTP status
-			// code and endpoint) are logged by the client's request logger.
-			SS_SHIPPING_WC()->get_api_handle()->bookings()->create( $this->shipment );
+		public function get_shipping_method() {
+			return $this->shipping_method;
+		}
+
+		/**
+		 * Set the Smart Send shipping method code.
+		 *
+		 * @param mixed $shipping_method Smart Send shipping method code.
+		 *
+		 * @return self
+		 */
+		public function set_shipping_method( $shipping_method ): self {
+			$this->shipping_method = null === $shipping_method ? null : (string) $shipping_method;
+
+			return $this;
+		}
+
+		/**
+		 * Get the shipping date (Y-m-d).
+		 *
+		 * @return string|null
+		 */
+		public function get_shipping_date() {
+			return $this->shipping_date;
+		}
+
+		/**
+		 * Set the shipping date (Y-m-d).
+		 *
+		 * @param string|null $shipping_date Shipping date (Y-m-d).
+		 *
+		 * @return self
+		 */
+		public function set_shipping_date( $shipping_date ): self {
+			$this->shipping_date = $shipping_date;
+
+			return $this;
+		}
+
+		/**
+		 * Get the receiver data.
+		 *
+		 * @return array|null
+		 */
+		public function get_receiver() {
+			return $this->receiver;
+		}
+
+		/**
+		 * Set the receiver data.
+		 *
+		 * @param array|null $receiver Receiver data.
+		 *
+		 * @return self
+		 */
+		public function set_receiver( $receiver ): self {
+			$this->receiver = $receiver;
+
+			return $this;
+		}
+
+		/**
+		 * Get the pickup point data, or null.
+		 *
+		 * @return array|null
+		 */
+		public function get_pickup_point() {
+			return $this->pickup_point;
+		}
+
+		/**
+		 * Set the pickup point data.
+		 *
+		 * @param array|null $pickup_point Pickup point data, or null.
+		 *
+		 * @return self
+		 */
+		public function set_pickup_point( $pickup_point ): self {
+			$this->pickup_point = $pickup_point;
+
+			return $this;
+		}
+
+		/**
+		 * Get the parcel rows.
+		 *
+		 * @return array[]
+		 */
+		public function get_parcels(): array {
+			return $this->parcels;
+		}
+
+		/**
+		 * Set the parcel rows.
+		 *
+		 * @param array[] $parcels Parcel rows.
+		 *
+		 * @return self
+		 */
+		public function set_parcels( array $parcels ): self {
+			$this->parcels = $parcels;
+
+			return $this;
+		}
+
+		/**
+		 * Get the order total excl. shipping, excl. tax.
+		 *
+		 * @return float|null
+		 */
+		public function get_subtotal_net_amount() {
+			return $this->subtotal_net_amount;
+		}
+
+		/**
+		 * Set the order total excl. shipping, excl. tax.
+		 *
+		 * @param mixed $subtotal_net_amount Order total excl. shipping, excl. tax.
+		 *
+		 * @return self
+		 */
+		public function set_subtotal_net_amount( $subtotal_net_amount ): self {
+			$this->subtotal_net_amount = null === $subtotal_net_amount ? null : (float) $subtotal_net_amount;
+
+			return $this;
+		}
+
+		/**
+		 * Get the tax on the order total excl. shipping.
+		 *
+		 * @return float|null
+		 */
+		public function get_subtotal_tax_amount() {
+			return $this->subtotal_tax_amount;
+		}
+
+		/**
+		 * Set the tax on the order total excl. shipping.
+		 *
+		 * @param mixed $subtotal_tax_amount Tax on the order total excl. shipping.
+		 *
+		 * @return self
+		 */
+		public function set_subtotal_tax_amount( $subtotal_tax_amount ): self {
+			$this->subtotal_tax_amount = null === $subtotal_tax_amount ? null : (float) $subtotal_tax_amount;
+
+			return $this;
+		}
+
+		/**
+		 * Get the shipping cost excl. tax.
+		 *
+		 * @return float|null
+		 */
+		public function get_shipping_net_amount() {
+			return $this->shipping_net_amount;
+		}
+
+		/**
+		 * Set the shipping cost excl. tax.
+		 *
+		 * @param mixed $shipping_net_amount Shipping cost excl. tax.
+		 *
+		 * @return self
+		 */
+		public function set_shipping_net_amount( $shipping_net_amount ): self {
+			$this->shipping_net_amount = null === $shipping_net_amount ? null : (float) $shipping_net_amount;
+
+			return $this;
+		}
+
+		/**
+		 * Get the tax on the shipping cost.
+		 *
+		 * @return float|null
+		 */
+		public function get_shipping_tax_amount() {
+			return $this->shipping_tax_amount;
+		}
+
+		/**
+		 * Set the tax on the shipping cost.
+		 *
+		 * @param mixed $shipping_tax_amount Tax on the shipping cost.
+		 *
+		 * @return self
+		 */
+		public function set_shipping_tax_amount( $shipping_tax_amount ): self {
+			$this->shipping_tax_amount = null === $shipping_tax_amount ? null : (float) $shipping_tax_amount;
+
+			return $this;
+		}
+
+		/**
+		 * Get the order total excl. tax.
+		 *
+		 * @return float|null
+		 */
+		public function get_total_net_amount() {
+			return $this->total_net_amount;
+		}
+
+		/**
+		 * Set the order total excl. tax.
+		 *
+		 * @param mixed $total_net_amount Order total excl. tax.
+		 *
+		 * @return self
+		 */
+		public function set_total_net_amount( $total_net_amount ): self {
+			$this->total_net_amount = null === $total_net_amount ? null : (float) $total_net_amount;
+
+			return $this;
+		}
+
+		/**
+		 * Get the total tax on the order.
+		 *
+		 * @return float|null
+		 */
+		public function get_total_tax_amount() {
+			return $this->total_tax_amount;
+		}
+
+		/**
+		 * Set the total tax on the order.
+		 *
+		 * @param mixed $total_tax_amount Total tax on the order.
+		 *
+		 * @return self
+		 */
+		public function set_total_tax_amount( $total_tax_amount ): self {
+			$this->total_tax_amount = null === $total_tax_amount ? null : (float) $total_tax_amount;
+
+			return $this;
+		}
+
+		/**
+		 * Get the order currency code.
+		 *
+		 * @return string|null
+		 */
+		public function get_currency() {
+			return $this->currency;
+		}
+
+		/**
+		 * Set the order currency code.
+		 *
+		 * @param string|null $currency Order currency code.
+		 *
+		 * @return self
+		 */
+		public function set_currency( $currency ): self {
+			$this->currency = $currency;
+
+			return $this;
 		}
 	}
 

--- a/smart-send-logistics/includes/class-ss-shipping-order-reader.php
+++ b/smart-send-logistics/includes/class-ss-shipping-order-reader.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Smart Send order data access.
  *
- * @package  SS_Shipping_Order_Data
+ * @package  SS_Shipping_Order_Reader
  * @category Shipping
  * @author   Smart Send
  */
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // A second copy of the plugin may already have defined the class.
-if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
+if ( ! class_exists( 'SS_Shipping_Order_Reader' ) ) :
 
 	/**
 	 * Answers every order-data question needed to build the booking request
@@ -20,10 +20,11 @@ if ( ! class_exists( 'SS_Shipping_Order_Data' ) ) :
 	 *
 	 * This is the single place that knows how to read receiver address data,
 	 * item lines with weight/price/customs data and order totals. The class
-	 * returns plain arrays; assembling the Smart Send API models from them is
-	 * the job of SS_Shipping_Shipment.
+	 * returns plain arrays; assembling the internal shipment representation
+	 * (SS_Shipping_Shipment) from them is the job of
+	 * SS_Shipping_Shipment_Builder.
 	 */
-	class SS_Shipping_Order_Data {
+	class SS_Shipping_Order_Reader {
 
 		/**
 		 * The WooCommerce order.

--- a/smart-send-logistics/includes/lib/Smartsend/Resources/BookingResource.php
+++ b/smart-send-logistics/includes/lib/Smartsend/Resources/BookingResource.php
@@ -17,13 +17,23 @@ use Smartsend\Models\Shipment\Services;
  * Books a shipment (and its labels) with the Smart Send API.
  *
  * This is the single point where the internal shipment representation
- * assembled by SS_Shipping_Shipment_Builder (#113) is translated into the
- * v1 wire request (Smartsend\Models\Shipment and its sub-models) - the
- * excl/incl price pairs the v1 API expects are (re)computed here, once,
- * from the representation's single net/tax amounts. A future v2 client
- * would replace fromRepresentation() with a v2-shaped translation; nothing
- * above this resource (SS_Shipping_Shipment, SS_Shipping_Shipment_Builder,
- * SS_Shipping_Order_Data) would need to change (#111).
+ * assembled by SS_Shipping_Shipment_Builder (#113) - a typed WP-side value
+ * object, \SS_Shipping_Shipment, not to be confused with this namespace's
+ * own Shipment (the v1 wire model, see the use statement below) - is
+ * translated into the v1 wire request (Smartsend\Models\Shipment and its
+ * sub-models). The excl/incl price pairs the v1 API expects are
+ * (re)computed here, once, from the representation's single net/tax
+ * amounts. A future v2 client would replace fromShipment() with a
+ * v2-shaped translation; nothing above this resource (\SS_Shipping_Shipment,
+ * SS_Shipping_Shipment_Builder, SS_Shipping_Order_Reader) would need to
+ * change (#111).
+ *
+ * This class deliberately stays WordPress-light: it only depends on
+ * \SS_Shipping_Shipment by its fully-qualified global name as a type hint,
+ * and that class itself makes no WordPress calls - the dependency points
+ * from WP-side code down into this PSR-style lib, never the other way
+ * around. It must never construct or return a WP-side type such as
+ * SS_Shipping_Booking; that wrapping is SS_Shipping_Booking_Service's job.
  */
 class BookingResource
 {
@@ -38,7 +48,7 @@ class BookingResource
     /**
      * Book a shipment and create its labels in a single call.
      *
-     * @param   Shipment $shipment The v1 wire shipment, see self::fromRepresentation().
+     * @param   Shipment $shipment The v1 wire shipment, see self::fromShipment().
      * @return  object|true|false
      */
     public function create(Shipment $shipment)
@@ -70,22 +80,22 @@ class BookingResource
      * Translate the internal shipment representation into the v1 wire
      * shipment model.
      *
-     * @param   array $representation The internal shipment representation from SS_Shipping_Shipment_Builder::build().
+     * @param   \SS_Shipping_Shipment $shipment The internal shipment representation from SS_Shipping_Shipment_Builder.
      * @return  Shipment
      */
-    public function fromRepresentation(array $representation): Shipment
+    public function fromShipment(\SS_Shipping_Shipment $shipment): Shipment
     {
-        $receiver = $this->buildReceiver($representation);
+        $receiver = $this->buildReceiver($shipment);
 
-        $shipment = new Shipment();
-        $shipment->setReceiver($receiver);
+        $wire_shipment = new Shipment();
+        $wire_shipment->setReceiver($receiver);
 
-        if (!empty($representation['pickup_point'])) {
-            $shipment->setAgent($this->buildAgent($representation['pickup_point']));
+        if (!empty($shipment->get_pickup_point())) {
+            $wire_shipment->setAgent($this->buildAgent($shipment->get_pickup_point()));
         }
 
         $parcels = array();
-        foreach ($representation['parcels'] as $parcel_row) {
+        foreach ($shipment->get_parcels() as $parcel_row) {
             $parcels[] = $this->buildParcel($parcel_row);
         }
 
@@ -94,38 +104,38 @@ class BookingResource
         $services->setSmsNotification($receiver->getSms()) // Always enable SMS notification.
             ->setEmailNotification($receiver->getEmail()); // Always enable Email notification.
 
-        $shipment->setInternalId($representation['internal_id'])
-            ->setInternalReference($this->valueOrNull($representation['internal_reference']))
-            ->setShippingCarrier($this->valueOrNull($representation['shipping_carrier']))
-            ->setShippingMethod($this->valueOrNull($representation['shipping_method']))
-            ->setShippingDate($representation['shipping_date'])
+        $wire_shipment->setInternalId($shipment->get_internal_id())
+            ->setInternalReference($this->valueOrNull($shipment->get_internal_reference()))
+            ->setShippingCarrier($this->valueOrNull($shipment->get_shipping_carrier()))
+            ->setShippingMethod($this->valueOrNull($shipment->get_shipping_method()))
+            ->setShippingDate($shipment->get_shipping_date())
             ->setParcels($parcels) // Alternatively add each parcel using $shipment->addParcel(Parcel $parcel).
             ->setServices($services)
-            ->setSubtotalPriceExcludingTax($this->valueOrNull($representation['subtotal_net_amount']))
-            ->setSubtotalPriceIncludingTax($this->valueOrNull($this->netPlusTax($representation['subtotal_net_amount'], $representation['subtotal_tax_amount'])))
-            ->setTotalPriceExcludingTax($this->valueOrNull($representation['total_net_amount']))
-            ->setTotalPriceIncludingTax($this->valueOrNull($this->netPlusTax($representation['total_net_amount'], $representation['total_tax_amount'])))
-            ->setShippingPriceExcludingTax($this->valueOrNull($representation['shipping_net_amount']))
-            ->setShippingPriceIncludingTax($this->valueOrNull($this->netPlusTax($representation['shipping_net_amount'], $representation['shipping_tax_amount'])))
-            ->setTotalTaxAmount($this->valueOrNull($representation['total_tax_amount']))
-            ->setCurrency($this->valueOrNull($representation['currency']));
+            ->setSubtotalPriceExcludingTax($this->valueOrNull($shipment->get_subtotal_net_amount()))
+            ->setSubtotalPriceIncludingTax($this->valueOrNull($this->netPlusTax($shipment->get_subtotal_net_amount(), $shipment->get_subtotal_tax_amount())))
+            ->setTotalPriceExcludingTax($this->valueOrNull($shipment->get_total_net_amount()))
+            ->setTotalPriceIncludingTax($this->valueOrNull($this->netPlusTax($shipment->get_total_net_amount(), $shipment->get_total_tax_amount())))
+            ->setShippingPriceExcludingTax($this->valueOrNull($shipment->get_shipping_net_amount()))
+            ->setShippingPriceIncludingTax($this->valueOrNull($this->netPlusTax($shipment->get_shipping_net_amount(), $shipment->get_shipping_tax_amount())))
+            ->setTotalTaxAmount($this->valueOrNull($shipment->get_total_tax_amount()))
+            ->setCurrency($this->valueOrNull($shipment->get_currency()));
 
-        return $shipment;
+        return $wire_shipment;
     }
 
     /**
      * Build the receiver model from the representation's receiver section.
      *
-     * @param   array $representation The internal shipment representation.
+     * @param   \SS_Shipping_Shipment $shipment The internal shipment representation.
      * @return  Receiver
      */
-    protected function buildReceiver(array $representation): Receiver
+    protected function buildReceiver(\SS_Shipping_Shipment $shipment): Receiver
     {
-        $receiver_data = $representation['receiver'];
+        $receiver_data = $shipment->get_receiver();
 
         $receiver = new Receiver();
-        $receiver->setInternalId($representation['internal_id'])
-            ->setInternalReference($this->valueOrNull($representation['internal_reference']))
+        $receiver->setInternalId($shipment->get_internal_id())
+            ->setInternalReference($this->valueOrNull($shipment->get_internal_reference()))
             ->setCompany($this->valueOrNull($receiver_data['company']))
             ->setNameLine1($this->valueOrNull($receiver_data['name_line1']))
             ->setNameLine2($this->valueOrNull($receiver_data['name_line2']))
@@ -144,7 +154,7 @@ class BookingResource
      * Build the agent (pickup point) model from the representation's
      * pickup-point section.
      *
-     * @param   array $pickup_point Pickup point data, see SS_Shipping_Shipment_Builder::build_pickup_point().
+     * @param   array $pickup_point Pickup point data, sourced from \SS_Shipping_Shipment::get_pickup_point(), see SS_Shipping_Shipment_Builder::build_pickup_point().
      * @return  ShipmentAgent
      */
     protected function buildAgent(array $pickup_point): ShipmentAgent
@@ -166,7 +176,7 @@ class BookingResource
     /**
      * Build an item model from an item row of the representation.
      *
-     * @param   array $item_row Item row, see SS_Shipping_Order_Data::get_items_data().
+     * @param   array $item_row Item row, sourced from one of \SS_Shipping_Shipment::get_parcels()'s 'items' arrays, see SS_Shipping_Order_Reader::get_items_data().
      * @return  Item
      */
     protected function buildItem(array $item_row): Item
@@ -201,7 +211,7 @@ class BookingResource
     /**
      * Build a parcel model from a parcel row of the representation.
      *
-     * @param   array $parcel_row Parcel row, see SS_Shipping_Shipment_Builder::build().
+     * @param   array $parcel_row Parcel row, sourced from \SS_Shipping_Shipment::get_parcels().
      * @return  Parcel
      */
     protected function buildParcel(array $parcel_row): Parcel

--- a/smart-send-logistics/smart-send-logistics.php
+++ b/smart-send-logistics/smart-send-logistics.php
@@ -172,12 +172,15 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/includes/class-ss-shipping-logger.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/includes/class-ss-shipping-checkout-debug.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/includes/class-ss-shipping-admin-notices.php';
-			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/includes/class-ss-shipping-order-data.php';
+			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/includes/class-ss-shipping-order-reader.php';
 
 			// Admin components.
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-plugins-screen-updates.php';
-			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-shipment-builder.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-shipment.php';
+			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-shipment-builder.php';
+			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-booking.php';
+			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-booking-exception.php';
+			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-booking-service.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-order-meta.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-order-meta-box.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/admin/class-ss-shipping-wc-order.php';

--- a/tests/Integration/ResourceLayerTest.php
+++ b/tests/Integration/ResourceLayerTest.php
@@ -18,11 +18,12 @@ use Smartsend\Resources\BookingResource;
 use Smartsend\Resources\PickupPointResource;
 
 /**
- * A minimal but fully-shaped internal shipment representation, the shape
- * SS_Shipping_Shipment_Builder::build() returns. See ShipmentPayloadTest for
- * the exhaustive, order-driven coverage of every field.
+ * A minimal but fully-shaped internal shipment representation (the plain
+ * array shape used to fill a SS_Shipping_Shipment value object below). See
+ * ShipmentPayloadTest for the exhaustive, order-driven coverage of every
+ * field.
  */
-function sample_representation(array $overrides = []): array
+function sample_representation_data(array $overrides = []): array
 {
     return array_replace_recursive([
         'internal_id'         => '123',
@@ -80,6 +81,36 @@ function sample_representation(array $overrides = []): array
     ], $overrides);
 }
 
+/**
+ * A minimal but fully-shaped SS_Shipping_Shipment, the internal
+ * representation SS_Shipping_Shipment_Builder returns. See
+ * ShipmentPayloadTest for the exhaustive, order-driven coverage of every
+ * field.
+ */
+function sample_representation(array $overrides = []): SS_Shipping_Shipment
+{
+    $data = sample_representation_data($overrides);
+
+    $shipment = new SS_Shipping_Shipment();
+    $shipment->set_internal_id($data['internal_id'])
+        ->set_internal_reference($data['internal_reference'])
+        ->set_shipping_carrier($data['shipping_carrier'])
+        ->set_shipping_method($data['shipping_method'])
+        ->set_shipping_date($data['shipping_date'])
+        ->set_receiver($data['receiver'])
+        ->set_pickup_point($data['pickup_point'])
+        ->set_parcels($data['parcels'])
+        ->set_subtotal_net_amount($data['subtotal_net_amount'])
+        ->set_subtotal_tax_amount($data['subtotal_tax_amount'])
+        ->set_shipping_net_amount($data['shipping_net_amount'])
+        ->set_shipping_tax_amount($data['shipping_tax_amount'])
+        ->set_total_net_amount($data['total_net_amount'])
+        ->set_total_tax_amount($data['total_tax_amount'])
+        ->set_currency($data['currency']);
+
+    return $shipment;
+}
+
 function pickup_point_api_data(): array
 {
     return [
@@ -108,7 +139,7 @@ it('accepts a Shipment through the client without needing a resource accessor fo
         // The accessor is memoized: the same instance is returned every call.
         ->and($api->bookings())->toBe($resource);
 
-    $shipment = $resource->fromRepresentation(sample_representation());
+    $shipment = $resource->fromShipment(sample_representation());
     expect($resource->create($shipment))->toBeTrue();
     expect($api->isSuccessful())->toBeTrue();
 
@@ -123,7 +154,7 @@ it('surfaces the existing error taxonomy through BookingResource::create()', fun
         return ss_api_response(422, ss_api_error_body('The receiver postal code is invalid.'));
     });
 
-    $shipment = $api->bookings()->fromRepresentation(sample_representation());
+    $shipment = $api->bookings()->fromShipment(sample_representation());
     $result   = $api->bookings()->create($shipment);
 
     expect($result)->toBeFalse();
@@ -135,10 +166,10 @@ it('surfaces the existing error taxonomy through BookingResource::create()', fun
     expect($error->message)->toBe('The receiver postal code is invalid.');
 });
 
-it('builds the v1 wire Shipment model from the internal representation (BookingResource::fromRepresentation)', function () {
+it('builds the v1 wire Shipment model from the internal representation (BookingResource::fromShipment)', function () {
     $api = new Api('secret-token-123', 'example.test', true);
 
-    $shipment = $api->bookings()->fromRepresentation(sample_representation());
+    $shipment = $api->bookings()->fromShipment(sample_representation());
 
     expect($shipment)->toBeInstanceOf(Shipment::class);
 

--- a/tests/Integration/ShipmentPayloadTest.php
+++ b/tests/Integration/ShipmentPayloadTest.php
@@ -2,10 +2,10 @@
 
 /*
  * Characterization ("golden") tests for the booking payload that
- * SS_Shipping_Shipment sends to the Smart Send API. Each test builds a
- * representative order, captures the JSON body posted to the (mocked) API,
- * and compares it to the complete expected payload. If any field of the
- * booking request changes, these tests fail.
+ * SS_Shipping_Booking_Service sends to the Smart Send API. Each test builds
+ * a representative order, captures the JSON body posted to the (mocked)
+ * API, and compares it to the complete expected payload. If any field of
+ * the booking request changes, these tests fail.
  *
  * IMPORTANT: these tests assert CURRENT v8 behaviour, including known
  * oddities (marked "v8 oddity"). Do not "fix" an expectation here without a
@@ -13,15 +13,17 @@
  */
 
 /**
- * Send the order through SS_Shipping_Shipment against a mocked API and
- * return the decoded JSON payload of the createShipmentAndLabels request.
+ * Send the order through SS_Shipping_Booking_Service against a mocked API
+ * and return the decoded JSON payload of the createShipmentAndLabels
+ * request.
  */
 function capture_shipment_payload(WC_Order $order, bool $return = false): array
 {
     $capture = mock_smart_send_api();
 
-    $shipment = new SS_Shipping_Shipment($order, SS_SHIPPING_WC()->get_ss_shipping_wc_order());
-    expect($shipment->make_single_shipment_api_call($return))->toBeTrue();
+    $booking_service = new SS_Shipping_Booking_Service($order, SS_SHIPPING_WC()->get_ss_shipping_wc_order());
+    $booking         = $return ? $booking_service->book_return() : $booking_service->book_outbound();
+    expect($booking->is_successful())->toBeTrue();
 
     $request = end($capture->requests);
     expect($request['url'])->toContain('shipments/labels');

--- a/tests/Integration/ShipmentRepresentationTest.php
+++ b/tests/Integration/ShipmentRepresentationTest.php
@@ -1,26 +1,43 @@
 <?php
 
 /*
- * Coverage for the new internal shipment representation introduced by
- * #113 (SS_Shipping_Shipment_Builder) and the #128 discount-allocation fix
- * built on top of it. ShipmentPayloadTest.php proves the v1 wire payload
- * translated from this representation is unchanged (or, for the two
- * scenarios #128 deliberately fixes, correctly changed); this file asserts
- * the representation itself: a single net + tax amount per level, no
- * excl/incl pairs, and that item-line totals reconcile with the order
- * subtotal for every native WooCommerce coupon type.
+ * Coverage for the internal shipment representation introduced by #113
+ * (SS_Shipping_Shipment_Builder / SS_Shipping_Shipment) and the #128
+ * discount-allocation fix built on top of it. ShipmentPayloadTest.php
+ * proves the v1 wire payload translated from this representation is
+ * unchanged (or, for the two scenarios #128 deliberately fixes, correctly
+ * changed); this file asserts the representation itself: a single net +
+ * tax amount per level, no excl/incl pairs, and that item-line totals
+ * reconcile with the order subtotal for every native WooCommerce coupon
+ * type.
  */
 
 /**
  * Build the internal shipment representation for an order the same way
- * SS_Shipping_Shipment does, without going through the (mocked) API call.
+ * SS_Shipping_Booking_Service does, without going through the (mocked) API
+ * call.
  */
-function build_shipment_representation(WC_Order $order, bool $return = false): array
+function build_shipment_representation(WC_Order $order, bool $return = false): SS_Shipping_Shipment
 {
-    $order_data = new SS_Shipping_Order_Data($order);
-    $builder    = new SS_Shipping_Shipment_Builder($order, $order_data, SS_SHIPPING_WC()->get_ss_shipping_wc_order());
+    $order_reader = new SS_Shipping_Order_Reader($order);
+    $builder      = new SS_Shipping_Shipment_Builder($order, $order_reader, SS_SHIPPING_WC()->get_ss_shipping_wc_order());
 
-    return $builder->build($return);
+    return $return ? $builder->build_return() : $builder->build_outbound();
+}
+
+/**
+ * The public get_* method names of SS_Shipping_Shipment - used to assert
+ * the shipment level exposes a single net + tax amount per level, with no
+ * excl/incl pair getters.
+ */
+function shipment_getter_names(): array
+{
+    $methods = (new ReflectionClass(SS_Shipping_Shipment::class))->getMethods(ReflectionMethod::IS_PUBLIC);
+
+    return array_values(array_filter(
+        array_map(fn ($method) => $method->getName(), $methods),
+        fn ($name) => str_starts_with($name, 'get_')
+    ));
 }
 
 beforeEach(function (): void {
@@ -37,23 +54,24 @@ it('represents shipment, parcel and item totals as a single net + tax amount, wi
 
     $representation = build_shipment_representation($order);
 
-    // Shipment level: single net/tax pair, no excluding/including-tax keys.
-    expect($representation)->toHaveKeys([
-        'subtotal_net_amount',
-        'subtotal_tax_amount',
-        'shipping_net_amount',
-        'shipping_tax_amount',
-        'total_net_amount',
-        'total_tax_amount',
-    ]);
-    foreach (array_keys($representation) as $key) {
-        expect($key)->not->toContain('excluding_tax')
-            ->and($key)->not->toContain('including_tax');
+    // Shipment level: single net/tax pair, no excluding/including-tax getters.
+    $getters = shipment_getter_names();
+    expect($getters)->toContain(
+        'get_subtotal_net_amount',
+        'get_subtotal_tax_amount',
+        'get_shipping_net_amount',
+        'get_shipping_tax_amount',
+        'get_total_net_amount',
+        'get_total_tax_amount',
+    );
+    foreach ($getters as $getter) {
+        expect($getter)->not->toContain('excluding_tax')
+            ->and($getter)->not->toContain('including_tax');
     }
 
     // Parcel level.
-    expect($representation['parcels'])->toHaveCount(1);
-    $parcel = $representation['parcels'][0];
+    expect($representation->get_parcels())->toHaveCount(1);
+    $parcel = $representation->get_parcels()[0];
     expect($parcel)->toHaveKeys(['total_net_amount', 'total_tax_amount']);
     foreach (array_keys($parcel) as $key) {
         expect($key)->not->toContain('excluding_tax')
@@ -83,9 +101,9 @@ it('names the pickup-point section after v2\'s service_point_code, not v1\'s age
 
     $representation = build_shipment_representation($order);
 
-    expect($representation['pickup_point'])->toHaveKey('service_point_code')
-        ->and($representation['pickup_point']['service_point_code'])->toBe('1234')
-        ->and($representation['pickup_point'])->not->toHaveKey('agent_no');
+    expect($representation->get_pickup_point())->toHaveKey('service_point_code')
+        ->and($representation->get_pickup_point()['service_point_code'])->toBe('1234')
+        ->and($representation->get_pickup_point())->not->toHaveKey('agent_no');
 });
 
 it('reconciles item-line totals with the order subtotal for a percentage coupon', function () {
@@ -99,9 +117,9 @@ it('reconciles item-line totals with the order subtotal for a percentage coupon'
 
     $representation = build_shipment_representation($order);
 
-    $item_sum = array_sum(array_column($representation['parcels'][0]['items'], 'total_net_amount'));
+    $item_sum = array_sum(array_column($representation->get_parcels()[0]['items'], 'total_net_amount'));
 
-    expect($item_sum)->toEqual($representation['subtotal_net_amount'])
+    expect($item_sum)->toEqual($representation->get_subtotal_net_amount())
         ->and($item_sum)->toEqual(240.0); // 3 x 100, 20% off.
 });
 
@@ -117,10 +135,10 @@ it('reconciles item-line totals with the order subtotal for a fixed-cart coupon'
 
     $representation = build_shipment_representation($order);
 
-    $item_sum = array_sum(array_column($representation['parcels'][0]['items'], 'total_net_amount'));
+    $item_sum = array_sum(array_column($representation->get_parcels()[0]['items'], 'total_net_amount'));
 
     // 100 order subtotal, 20 fixed-cart discount prorated across both lines.
-    expect($item_sum)->toEqual($representation['subtotal_net_amount'])
+    expect($item_sum)->toEqual($representation->get_subtotal_net_amount())
         ->and($item_sum)->toEqual(80.0);
 });
 
@@ -138,7 +156,7 @@ it('reconciles item-line totals with the order subtotal for a fixed-product coup
 
     $representation = build_shipment_representation($order);
 
-    $items    = $representation['parcels'][0]['items'];
+    $items    = $representation->get_parcels()[0]['items'];
     $item_sum = array_sum(array_column($items, 'total_net_amount'));
 
     // Only product A's line is discounted, by exactly the fixed amount.
@@ -146,6 +164,41 @@ it('reconciles item-line totals with the order subtotal for a fixed-product coup
     $line_a       = current(array_filter($items, fn ($item) => $item['id'] === $product_a_id));
 
     expect($line_a['total_net_amount'])->toEqual(45.0)
-        ->and($item_sum)->toEqual($representation['subtotal_net_amount'])
+        ->and($item_sum)->toEqual($representation->get_subtotal_net_amount())
         ->and($item_sum)->toEqual(85.0);
+});
+
+it('diverges shipping-method/agent selection between build_outbound() and build_return()', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_agent',
+        'return_method'   => 'postnord_returndropoff',
+    ]);
+    SS_SHIPPING_WC()->get_ss_shipping_wc_order()->save_ss_shipping_order_agent($order->get_id(), sample_agent());
+
+    $outbound = build_shipment_representation($order, false);
+    $return   = build_shipment_representation($order, true);
+
+    // Outbound uses the order's Smart Send shipping method and selects the
+    // stored pick-up point.
+    expect($outbound->get_shipping_method())->toBe('agent')
+        ->and($outbound->get_pickup_point())->not->toBeNull();
+
+    // Return uses the configured return method and skips pick-up point
+    // selection entirely.
+    expect($return->get_shipping_method())->toBe('returndropoff')
+        ->and($return->get_pickup_point())->toBeNull();
+});
+
+it('throws a SS_Shipping_Booking_Exception from build_return() when no return method is configured', function () {
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $order   = create_order([
+        'products'        => [$product],
+        'shipping_method' => 'postnord_agent',
+        'return_method'   => '',
+    ]);
+
+    expect(fn () => build_shipment_representation($order, true))
+        ->toThrow(SS_Shipping_Booking_Exception::class, 'No return method set');
 });


### PR DESCRIPTION
## Summary

Follow-up to #111/#112/#113. Pure internal restructure (naming + typing) of the Phase 5 booking classes just merged into `develop` - no behaviour change to the v1 wire payload or booking outcomes, aside from the intentional `is_return` boolean → two-methods split.

- `SS_Shipping_Order_Data` → renamed to `SS_Shipping_Order_Reader` (pure rename, same responsibility/public API).
- The internal shipment representation is now a typed WP-side value object named `SS_Shipping_Shipment` (was a plain array returned by `SS_Shipping_Shipment_Builder::build()`) - fluent setters/getters, nested sections (receiver/pickup_point/parcels/items) stay plain arrays.
- `SS_Shipping_Shipment_Builder::build($is_return)` → split into `build_outbound()` / `build_return()`, sharing a private `assemble_shipment()` helper for the identical item/parcel/totals assembly. `build_return()` throws the new `SS_Shipping_Booking_Exception` when no return method is configured, instead of returning an error array.
- The old orchestrator (`SS_Shipping_Shipment`) is renamed to `SS_Shipping_Booking_Service`, with `book_outbound()`/`book_return()` replacing `make_single_shipment_api_call($is_return)`. Neither method ever throws - a config error or an API-level error both come back as a failed `SS_Shipping_Booking`.
- New `SS_Shipping_Booking` value object wraps a booking outcome: `is_successful()`, `get_error_message()`, `get_data()`, `get_wire_shipment()`.
- `Smartsend\Resources\BookingResource::fromRepresentation(array)` → `fromShipment(\SS_Shipping_Shipment)`, reading via the value object's getters. The PSR lib stays "WordPress-light": it only depends on `\SS_Shipping_Shipment` by name (itself WP-free), and never constructs/returns a WP-side type.
- `SS_Shipping_Label_Creator` and `CLAUDE.md`'s Architecture section updated to match.

**Deliberate behaviour change** (explicitly requested): the old "no return method configured" error used to still POST an empty shipment to the API and surface whatever error the API returned. `book_return()` now fails fast with `SS_Shipping_Booking::get_error_message() === 'No return method set'` without an API call.

**Nesting judgment call**: kept `receiver`, `pickup_point`, `parcels`, and each parcel's `items` as plain arrays inside `SS_Shipping_Shipment` rather than promoting them to their own value-object classes - the only other reader (`BookingResource::fromShipment()`) already needs array access to build its own sub-models, so extra nesting depth would add ceremony without adding safety.

## Test plan

- [x] `composer test:integration` - 181 passed (760 assertions)
- [x] `vendor/bin/phpcs` (project ruleset, excludes the PSR lib) - clean
- [x] `composer phpcs:compat` - clean
- [x] Golden v1 wire payload assertions in `ShipmentPayloadTest.php` unmodified and still passing
- [x] Added coverage that `build_outbound()`/`build_return()` diverge in shipping-method/agent selection, and that `build_return()` throws when no return method is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)