### PR TITLE
Subscription renewals keep delivery configuration, drop booking outcomes

### DIFF
--- a/smart-send-logistics/admin/class-ss-shipping-order-meta.php
+++ b/smart-send-logistics/admin/class-ss-shipping-order-meta.php
@@ -47,21 +47,52 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 		const META_PARCELS = 'ss_shipping_order_parcels';
 
 		/**
-		 * Every order meta key Smart Send writes.
+		 * Meta keys recording a booked-label outcome (shipment ids).
 		 *
-		 * The Subscriptions renewal-meta exclusion is built from this list, so
-		 * a new META_* constant must be added here too (the integration test
-		 * pinning the exclusion list enforces this via reflection).
+		 * These are per-order booking results and must NOT copy to
+		 * subscription renewal orders - a renewal gets its own label.
+		 *
+		 * @return string[]
+		 */
+		public static function booking_outcome_meta_keys() {
+			return array(
+				self::META_LABEL_ID,
+				self::META_RETURN_LABEL_ID,
+			);
+		}
+
+		/**
+		 * Meta keys describing the delivery configuration (pickup point and
+		 * parcel structure).
+		 *
+		 * These SHOULD copy to subscription renewal orders - a renewal ships
+		 * the same way as its parent (same pickup point, same parcel setup);
+		 * it just has not been booked yet.
+		 *
+		 * @return string[]
+		 */
+		public static function delivery_configuration_meta_keys() {
+			return array(
+				self::META_AGENT,
+				self::META_AGENT_NO,
+				self::META_PARCELS,
+			);
+		}
+
+		/**
+		 * Every order meta key Smart Send writes: the union of the booking
+		 * outcome and delivery configuration lists.
+		 *
+		 * A new META_* constant must be classified into exactly one of those
+		 * two lists (the integration test pinning the Subscriptions renewal
+		 * exclusion enforces this via reflection).
 		 *
 		 * @return string[]
 		 */
 		public static function all_meta_keys() {
-			return array(
-				self::META_LABEL_ID,
-				self::META_RETURN_LABEL_ID,
-				self::META_AGENT,
-				self::META_AGENT_NO,
-				self::META_PARCELS,
+			return array_merge(
+				self::booking_outcome_meta_keys(),
+				self::delivery_configuration_meta_keys()
 			);
 		}
 

--- a/smart-send-logistics/admin/class-ss-shipping-order-meta.php
+++ b/smart-send-logistics/admin/class-ss-shipping-order-meta.php
@@ -22,6 +22,50 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 	class SS_Shipping_Order_Meta {
 
 		/**
+		 * Meta key holding the outbound shipment id after a label is booked.
+		 */
+		const META_LABEL_ID = '_ss_shipping_label_id';
+
+		/**
+		 * Meta key holding the return shipment id after a return label is booked.
+		 */
+		const META_RETURN_LABEL_ID = '_ss_shipping_return_label_id';
+
+		/**
+		 * Meta key holding the selected pickup point (agent) object.
+		 */
+		const META_AGENT = '_ss_shipping_order_agent';
+
+		/**
+		 * Meta key holding the selected pickup point agent number.
+		 */
+		const META_AGENT_NO = 'ss_shipping_order_agent_no';
+
+		/**
+		 * Meta key holding the parcel split entered in the order meta box.
+		 */
+		const META_PARCELS = 'ss_shipping_order_parcels';
+
+		/**
+		 * Every order meta key Smart Send writes.
+		 *
+		 * The Subscriptions renewal-meta exclusion is built from this list, so
+		 * a new META_* constant must be added here too (the integration test
+		 * pinning the exclusion list enforces this via reflection).
+		 *
+		 * @return string[]
+		 */
+		public static function all_meta_keys() {
+			return array(
+				self::META_LABEL_ID,
+				self::META_RETURN_LABEL_ID,
+				self::META_AGENT,
+				self::META_AGENT_NO,
+				self::META_PARCELS,
+			);
+		}
+
+		/**
 		 * Register this component's hooks.
 		 *
 		 * @return void
@@ -142,7 +186,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 		 */
 		public function filter_update_agent_meta( $check, $meta_id, $meta_value, $meta_key ) {
 
-			if ( 'ss_shipping_order_agent_no' == $meta_key ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #43 move.
+			if ( self::META_AGENT_NO == $meta_key ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #43 move.
 				$meta      = get_metadata_by_mid( 'post', $meta_id );
 				$object_id = $meta->post_id;
 				if ( $this->save_shipping_agent( $object_id, true, $meta_value ) !== true ) {
@@ -168,7 +212,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $_meta_value is part of the deleted_post_meta hook signature.
 		public function action_deleted_agent_meta( $meta_ids, $object_id, $meta_key, $_meta_value ) {
 
-			if ( 'ss_shipping_order_agent_no' == $meta_key ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #43 move.
+			if ( self::META_AGENT_NO == $meta_key ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #43 move.
 				$this->delete_ss_shipping_order_agent( $object_id );
 			}
 		}
@@ -257,7 +301,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 			if ( ! $order instanceof WC_Order ) {
 				return;
 			}
-			$order->update_meta_data( 'ss_shipping_order_parcels', $parcels );
+			$order->update_meta_data( self::META_PARCELS, $parcels );
 			$order->save();
 		}
 
@@ -273,7 +317,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 			if ( ! $order instanceof WC_Order ) {
 				return false;
 			}
-			return $order->get_meta( 'ss_shipping_order_parcels', true );
+			return $order->get_meta( self::META_PARCELS, true );
 		}
 
 		/**
@@ -289,7 +333,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 			if ( ! $order instanceof WC_Order ) {
 				return;
 			}
-			$order->update_meta_data( 'ss_shipping_order_agent_no', $agent_no );
+			$order->update_meta_data( self::META_AGENT_NO, $agent_no );
 			$order->save();
 		}
 
@@ -311,7 +355,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 				return null;
 			}
 
-			$ss_agent_number = $order->get_meta( 'ss_shipping_order_agent_no', true );
+			$ss_agent_number = $order->get_meta( self::META_AGENT_NO, true );
 			if ( $ss_agent_number ) {
 				// Return the agent_no found
 				return $ss_agent_number;
@@ -339,7 +383,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 			if ( ! $order instanceof WC_Order ) {
 				return;
 			}
-			$order->update_meta_data( '_ss_shipping_order_agent', $agent );
+			$order->update_meta_data( self::META_AGENT, $agent );
 			$order->save();
 		}
 
@@ -359,7 +403,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 				return;
 			}
 
-			$order->delete_meta_data( '_ss_shipping_order_agent' );
+			$order->delete_meta_data( self::META_AGENT );
 		}
 
 		/*
@@ -377,7 +421,7 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 				return null;
 			}
 
-			$ss_agent_info = $order->get_meta( '_ss_shipping_order_agent', true );
+			$ss_agent_info = $order->get_meta( self::META_AGENT, true );
 			if ( $ss_agent_info ) {
 				// Return the agent_no found
 				return $ss_agent_info;
@@ -416,9 +460,9 @@ if ( ! class_exists( 'SS_Shipping_Order_Meta' ) ) :
 				return;
 			}
 			if ( $return ) {
-				$order->update_meta_data( '_ss_shipping_return_label_id', $shipment_id );
+				$order->update_meta_data( self::META_RETURN_LABEL_ID, $shipment_id );
 			} else {
-				$order->update_meta_data( '_ss_shipping_label_id', $shipment_id );
+				$order->update_meta_data( self::META_LABEL_ID, $shipment_id );
 			}
 			$order->save();
 		}

--- a/smart-send-logistics/includes/class-ss-shipping-fulfillment-service.php
+++ b/smart-send-logistics/includes/class-ss-shipping-fulfillment-service.php
@@ -408,9 +408,9 @@ if ( ! class_exists( 'SS_Shipping_Fulfillment_Service' ) ) :
 				return '';
 			}
 			if ( $return ) {
-				$shipment_id = $order->get_meta( '_ss_shipping_return_label_id', true );
+				$shipment_id = $order->get_meta( SS_Shipping_Order_Meta::META_RETURN_LABEL_ID, true );
 			} else {
-				$shipment_id = $order->get_meta( '_ss_shipping_label_id', true );
+				$shipment_id = $order->get_meta( SS_Shipping_Order_Meta::META_LABEL_ID, true );
 			}
 			return $this->get_label_url_from_shipment_id( $shipment_id );
 		}

--- a/smart-send-logistics/includes/class-ss-shipping-subscriptions-compat.php
+++ b/smart-send-logistics/includes/class-ss-shipping-subscriptions-compat.php
@@ -44,10 +44,25 @@ if ( ! class_exists( 'SS_Shipping_Subscriptions_Compat' ) ) :
 		}
 
 		/**
-		 * Prevents data being copied to subscription renewals
+		 * Prevents data being copied to subscription renewals.
+		 *
+		 * Excludes every order meta key Smart Send writes (shipment ids,
+		 * pickup point agent object and number, parcel split) - a renewal
+		 * must get its own label and pickup point selection, not inherit
+		 * the parent order's. The list is built from the meta-key constants
+		 * on SS_Shipping_Order_Meta so it cannot drift from the vocabulary.
+		 *
+		 * @param string $order_meta_query SQL fragment selecting the meta rows to copy.
+		 *
+		 * @return string
 		 */
 		public function woocommerce_subscriptions_renewal_order_meta_query( $order_meta_query ) {
-			$order_meta_query .= " AND `meta_key` NOT IN ( '_ss_shipping_label' )";
+			$excluded_keys = array();
+			foreach ( SS_Shipping_Order_Meta::all_meta_keys() as $meta_key ) {
+				$excluded_keys[] = "'" . esc_sql( $meta_key ) . "'";
+			}
+
+			$order_meta_query .= ' AND `meta_key` NOT IN ( ' . implode( ', ', $excluded_keys ) . ' )';
 
 			return $order_meta_query;
 		}

--- a/smart-send-logistics/includes/class-ss-shipping-subscriptions-compat.php
+++ b/smart-send-logistics/includes/class-ss-shipping-subscriptions-compat.php
@@ -44,13 +44,15 @@ if ( ! class_exists( 'SS_Shipping_Subscriptions_Compat' ) ) :
 		}
 
 		/**
-		 * Prevents data being copied to subscription renewals.
+		 * Prevents booked-label outcomes being copied to subscription renewals.
 		 *
-		 * Excludes every order meta key Smart Send writes (shipment ids,
-		 * pickup point agent object and number, parcel split) - a renewal
-		 * must get its own label and pickup point selection, not inherit
-		 * the parent order's. The list is built from the meta-key constants
-		 * on SS_Shipping_Order_Meta so it cannot drift from the vocabulary.
+		 * Excludes only the booking-outcome meta keys (the outbound and
+		 * return shipment ids) - a renewal must get its own label. The
+		 * delivery-configuration meta (pickup point agent object and number,
+		 * parcel split) deliberately copies through: a renewal ships the same
+		 * way as its parent, it just has not been booked yet. The list is
+		 * built from the meta-key classification on SS_Shipping_Order_Meta
+		 * so it cannot drift from the vocabulary.
 		 *
 		 * @param string $order_meta_query SQL fragment selecting the meta rows to copy.
 		 *
@@ -58,7 +60,7 @@ if ( ! class_exists( 'SS_Shipping_Subscriptions_Compat' ) ) :
 		 */
 		public function woocommerce_subscriptions_renewal_order_meta_query( $order_meta_query ) {
 			$excluded_keys = array();
-			foreach ( SS_Shipping_Order_Meta::all_meta_keys() as $meta_key ) {
+			foreach ( SS_Shipping_Order_Meta::booking_outcome_meta_keys() as $meta_key ) {
 				$excluded_keys[] = "'" . esc_sql( $meta_key ) . "'";
 			}
 

--- a/tests/Integration/SubscriptionsCompatTest.php
+++ b/tests/Integration/SubscriptionsCompatTest.php
@@ -3,12 +3,18 @@
 /*
  * WooCommerce Subscriptions renewal-meta exclusion (issue #138).
  *
- * Subscription renewal orders must not inherit the parent order's Smart Send
- * meta (shipment ids, pickup point selection, parcel split). The exclusion
- * list in SS_Shipping_Subscriptions_Compat is built from the META_* constants
- * on SS_Shipping_Order_Meta; these tests pin the list to that vocabulary via
- * reflection, so adding a new META_* constant fails here until it is
- * classified (added to all_meta_keys() and thereby to the exclusion).
+ * Renewals keep the delivery configuration, drop the booking outcomes:
+ * only the booked-label shipment ids (_ss_shipping_label_id,
+ * _ss_shipping_return_label_id) are excluded from renewal-order meta
+ * copying - a renewal must get its own label. The delivery-configuration
+ * meta (pickup point agent object and number, parcel split) deliberately
+ * copies through, because a renewal ships the same way as its parent.
+ *
+ * The exclusion list is built from the meta-key classification on
+ * SS_Shipping_Order_Meta (booking_outcome_meta_keys() vs
+ * delivery_configuration_meta_keys()); these tests pin the exclusion to
+ * that vocabulary via reflection, so a new META_* constant fails here
+ * until it is classified into exactly one of the two lists.
  */
 
 /**
@@ -27,26 +33,47 @@ function ss_order_meta_key_constants(): array
     );
 }
 
-test('every order meta key constant is excluded from subscription renewal meta copying', function () {
-    $constants = ss_order_meta_key_constants();
-    expect($constants)->not->toBeEmpty();
+test('the renewal exclusion contains exactly the booking-outcome keys', function () {
+    $booking_outcome = SS_Shipping_Order_Meta::booking_outcome_meta_keys();
+    expect($booking_outcome)->not->toBeEmpty();
 
     $compat = new SS_Shipping_Subscriptions_Compat();
     $fragment = $compat->woocommerce_subscriptions_renewal_order_meta_query('SELECT `meta_key` FROM wp_postmeta');
 
     // The original query survives, with an exclusion appended.
-    expect($fragment)->toStartWith('SELECT `meta_key` FROM wp_postmeta')
-        ->and($fragment)->toContain('NOT IN');
+    expect($fragment)->toStartWith('SELECT `meta_key` FROM wp_postmeta');
 
-    // Every meta key Smart Send writes appears, quoted, in the exclusion.
-    foreach ($constants as $name => $meta_key) {
-        expect($fragment)->toContain("'{$meta_key}'");
+    // The NOT IN list is exactly the booking-outcome keys, in order.
+    $expected = "AND `meta_key` NOT IN ( '" . implode("', '", $booking_outcome) . "' )";
+    expect($fragment)->toContain($expected);
+});
+
+test('delivery-configuration keys are NOT excluded and copy to renewals', function () {
+    $compat = new SS_Shipping_Subscriptions_Compat();
+    $fragment = $compat->woocommerce_subscriptions_renewal_order_meta_query('');
+
+    foreach (SS_Shipping_Order_Meta::delivery_configuration_meta_keys() as $meta_key) {
+        expect($fragment)->not->toContain("'{$meta_key}'");
     }
 });
 
-test('all_meta_keys() covers exactly the META_* constants', function () {
-    expect(array_values(ss_order_meta_key_constants()))
-        ->toEqualCanonicalizing(SS_Shipping_Order_Meta::all_meta_keys());
+test('every META_* constant is classified into exactly one of the two lists', function () {
+    $constants = ss_order_meta_key_constants();
+    expect($constants)->not->toBeEmpty();
+
+    $booking_outcome = SS_Shipping_Order_Meta::booking_outcome_meta_keys();
+    $delivery_config = SS_Shipping_Order_Meta::delivery_configuration_meta_keys();
+
+    // The two lists are disjoint...
+    expect(array_intersect($booking_outcome, $delivery_config))->toBe([]);
+
+    // ...their union is exactly the reflected constant vocabulary...
+    expect(array_values($constants))
+        ->toEqualCanonicalizing(array_merge($booking_outcome, $delivery_config));
+
+    // ...and all_meta_keys() is that union.
+    expect(SS_Shipping_Order_Meta::all_meta_keys())
+        ->toEqualCanonicalizing(array_values($constants));
 });
 
 test('the phantom _ss_shipping_label key is gone from the exclusion list', function () {

--- a/tests/Integration/SubscriptionsCompatTest.php
+++ b/tests/Integration/SubscriptionsCompatTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * WooCommerce Subscriptions renewal-meta exclusion (issue #138).
+ *
+ * Subscription renewal orders must not inherit the parent order's Smart Send
+ * meta (shipment ids, pickup point selection, parcel split). The exclusion
+ * list in SS_Shipping_Subscriptions_Compat is built from the META_* constants
+ * on SS_Shipping_Order_Meta; these tests pin the list to that vocabulary via
+ * reflection, so adding a new META_* constant fails here until it is
+ * classified (added to all_meta_keys() and thereby to the exclusion).
+ */
+
+/**
+ * Every META_* constant on SS_Shipping_Order_Meta, discovered via reflection.
+ *
+ * @return array<string, string> constant name => meta key
+ */
+function ss_order_meta_key_constants(): array
+{
+    $constants = (new ReflectionClass(SS_Shipping_Order_Meta::class))->getConstants();
+
+    return array_filter(
+        $constants,
+        fn (string $name): bool => str_starts_with($name, 'META_'),
+        ARRAY_FILTER_USE_KEY
+    );
+}
+
+test('every order meta key constant is excluded from subscription renewal meta copying', function () {
+    $constants = ss_order_meta_key_constants();
+    expect($constants)->not->toBeEmpty();
+
+    $compat = new SS_Shipping_Subscriptions_Compat();
+    $fragment = $compat->woocommerce_subscriptions_renewal_order_meta_query('SELECT `meta_key` FROM wp_postmeta');
+
+    // The original query survives, with an exclusion appended.
+    expect($fragment)->toStartWith('SELECT `meta_key` FROM wp_postmeta')
+        ->and($fragment)->toContain('NOT IN');
+
+    // Every meta key Smart Send writes appears, quoted, in the exclusion.
+    foreach ($constants as $name => $meta_key) {
+        expect($fragment)->toContain("'{$meta_key}'");
+    }
+});
+
+test('all_meta_keys() covers exactly the META_* constants', function () {
+    expect(array_values(ss_order_meta_key_constants()))
+        ->toEqualCanonicalizing(SS_Shipping_Order_Meta::all_meta_keys());
+});
+
+test('the phantom _ss_shipping_label key is gone from the exclusion list', function () {
+    // '_ss_shipping_label' was never written anywhere; the real keys are
+    // suffixed (_ss_shipping_label_id). Quoted-and-delimited match so the
+    // real key does not mask a lingering phantom entry.
+    $compat = new SS_Shipping_Subscriptions_Compat();
+    $fragment = $compat->woocommerce_subscriptions_renewal_order_meta_query('');
+
+    expect($fragment)->not->toContain("'_ss_shipping_label'");
+});


### PR DESCRIPTION
Part of #138

> **Stacked on #137** (`refactor/dissolve-order-facade`) — the compat class this PR fixes only exists there. After #137 merges, retarget this PR to `develop`.

## Problem

`SS_Shipping_Subscriptions_Compat` excluded exactly one meta key from WooCommerce Subscriptions renewal-order meta copying: `_ss_shipping_label` — a phantom key written nowhere. The booked-label shipment ids (`_ss_shipping_label_id`, `_ss_shipping_return_label_id`) therefore copied onto renewals, so a renewal silently inherited the parent order's booking state (e.g. the meta box shows the parent's label as already generated).

## Semantics (per review)

**Renewals keep delivery configuration, drop booking outcomes.**

- **Excluded from renewal copying** — booking-outcome meta: `_ss_shipping_label_id`, `_ss_shipping_return_label_id`. A renewal must get its own label.
- **Deliberately copied to renewals** — delivery-configuration meta: `_ss_shipping_order_agent`, `ss_shipping_order_agent_no`, `ss_shipping_order_parcels`. A renewal ships the same way as its parent (same pickup point, same parcel setup); it just hasn't been booked yet.

## Fix

- The meta-key vocabulary is defined once as `META_*` class constants on `SS_Shipping_Order_Meta`, classified into two lists: `booking_outcome_meta_keys()` (excluded from renewals) and `delivery_configuration_meta_keys()` (copied), with `all_meta_keys()` as their union.
- Every call site that hand-typed the strings now uses the constants (`SS_Shipping_Order_Meta` itself and the two direct `get_meta()` calls in `SS_Shipping_Fulfillment_Service::get_label_url_from_order_id()`).
- The compat class builds its `NOT IN (...)` exclusion from `booking_outcome_meta_keys()` only — zero hand-typed key strings left; phantom entry dropped.
- New integration test (`tests/Integration/SubscriptionsCompatTest.php`) asserts: (1) the exclusion SQL contains exactly the booking-outcome keys, (2) no delivery-configuration key appears in it, and (3) every `META_*` constant discovered via reflection is a member of exactly one of the two lists — so a future key addition fails the test until it is classified. Also asserts the phantom `'_ss_shipping_label'` entry is gone.

## Verification

- `composer test:integration`: 191 passed (822 assertions)
- `vendor/bin/phpcs` (no args) and `composer phpcs:compat`: both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)