### PR TITLE
Checkout Block: the complete server side (Store API cart + checkout extensions)

### DIFF
--- a/smart-send-logistics/includes/class-ss-shipping-wc.php
+++ b/smart-send-logistics/includes/class-ss-shipping-wc.php
@@ -151,6 +151,13 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 		protected ?SS_Shipping_Block_Checkout $block_checkout = null;
 
 		/**
+		 * Store API extensions for the Checkout Block.
+		 *
+		 * @var SS_Shipping_Store_Api|null
+		 */
+		protected ?SS_Shipping_Store_Api $store_api = null;
+
+		/**
 		 * Pickup point display formatter.
 		 *
 		 * @var SS_Shipping_Pickup_Point_Formatter|null
@@ -269,6 +276,7 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/includes/delivery/class-ss-shipping-pickup-point-formatter.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/includes/delivery/class-ss-shipping-pickup-point-lookup.php';
 			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/includes/delivery/class-ss-shipping-pickup-point-validator.php';
+			require_once SS_SHIPPING_PLUGIN_DIR_PATH . '/includes/delivery/class-ss-shipping-store-api.php';
 
 			// Booking domain: order reading, shipment representation,
 			// booking, fulfillment.
@@ -385,6 +393,7 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 				$this->subscriptions_compat   = new SS_Shipping_Subscriptions_Compat();
 
 				$this->block_checkout = new SS_Shipping_Block_Checkout();
+				$this->store_api      = new SS_Shipping_Store_Api( $this->pickup_point_lookup, $this->pickup_point_formatter, $this->settings, $this->order_meta, $this->method_resolver );
 
 				$this->register_component_hooks();
 			} else {
@@ -416,6 +425,7 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 			$this->bulk_actions->register_hooks();
 			$this->subscriptions_compat->register_hooks();
 			$this->block_checkout->register_hooks();
+			$this->store_api->register_hooks();
 		}
 
         /**
@@ -649,6 +659,15 @@ if ( ! class_exists( 'SS_Shipping_WC' ) ) :
 		 */
 		public function block_checkout(): SS_Shipping_Block_Checkout {
 			return $this->block_checkout;
+		}
+
+		/**
+		 * Get the Store API extensions for the Checkout Block.
+		 *
+		 * @return SS_Shipping_Store_Api
+		 */
+		public function store_api(): SS_Shipping_Store_Api {
+			return $this->store_api;
 		}
     }
 

--- a/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-formatter.php
+++ b/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-formatter.php
@@ -86,7 +86,10 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Formatter' ) ) :
 		 *
 		 * @return string
 		 */
-		public function format( $pickup_point, $format_id = 0 ) {
+		// The parameter stays docblock-typed only: PHP 7.4 has no union types
+		// and both the value object and the plain API agent object are
+		// legitimate callers (normalize() accepts either).
+		public function format( $pickup_point, $format_id = 0 ): string {
 			$pickup_point = $this->normalize( $pickup_point );
 
 			if ( 0 == $format_id ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #139 move.
@@ -165,7 +168,10 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Formatter' ) ) :
 		 *
 		 * @return string
 		 */
-		public function dropdown_label( $pickup_point ) {
+		// The parameter stays docblock-typed only: PHP 7.4 has no union types
+		// and both the value object and the plain API agent object are
+		// legitimate callers (format() normalizes either).
+		public function dropdown_label( $pickup_point ): string {
 			$formatted_address = $this->format( $pickup_point );
 
 			/*

--- a/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-formatter.php
+++ b/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-formatter.php
@@ -156,6 +156,33 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Formatter' ) ) :
 		}
 
 		/**
+		 * The checkout drop-down label of a pickup point: the configured
+		 * "Dropdown display format" with the smart_send_pickup_point_option_label
+		 * filter applied - the single pipeline shared by the classic checkout
+		 * drop-down and the Checkout Block cart extension (#74).
+		 *
+		 * @param SS_Shipping_Pickup_Point|object $pickup_point The pickup point (value object or plain agent object).
+		 *
+		 * @return string
+		 */
+		public function dropdown_label( $pickup_point ) {
+			$formatted_address = $this->format( $pickup_point );
+
+			/*
+			 * Filter the label shown for a pickup point in the checkout
+			 * drop-down (classic checkout and Checkout Block alike).
+			 *
+			 * @since 9.0.0
+			 *
+			 * @param string $formatted_address The label formatted per the "Dropdown display format" setting.
+			 * @param object $pickup_point      The pickup point (agent_no, company, address_line1, postal_code, city, country, distance, ...).
+			 *
+			 * @return string The option label to render.
+			 */
+			return apply_filters( 'smart_send_pickup_point_option_label', $formatted_address, $pickup_point );
+		}
+
+		/**
 		 * The order meta box's address block markup for the selected pickup
 		 * point.
 		 *

--- a/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-lookup.php
+++ b/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-lookup.php
@@ -145,6 +145,32 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Lookup' ) ) :
 		}
 
 		/**
+		 * Find one session-cached pickup point by its agent number - the
+		 * resolution both checkout paths run on submission: the shopper can
+		 * only have picked from the cached lookup results, so a match here
+		 * is already server-validated.
+		 *
+		 * @param string $agent_no The submitted agent number.
+		 *
+		 * @return object|null The cached pickup point, or null when none matches.
+		 */
+		public function find_cached_by_agent_no( $agent_no ) {
+			$cached_pickup_points = $this->get_session_pickup_points();
+
+			if ( ! is_array( $cached_pickup_points ) ) {
+				return null;
+			}
+
+			foreach ( $cached_pickup_points as $pickup_point ) {
+				if ( isset( $pickup_point->agent_no ) && $pickup_point->agent_no == $agent_no ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison, moved verbatim from SS_Shipping_Frontend::process_ss_pickup_points().
+					return $pickup_point;
+				}
+			}
+
+			return null;
+		}
+
+		/**
 		 * Log why a pickup point lookup failed and surface the reason in
 		 * WooCommerce's shipping debug mode.
 		 *

--- a/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-lookup.php
+++ b/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-lookup.php
@@ -150,11 +150,20 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Lookup' ) ) :
 		 * only have picked from the cached lookup results, so a match here
 		 * is already server-validated.
 		 *
+		 * A miss is not logged here: an absent or expired session cache is
+		 * normal on fresh sessions, and the Store API caller falls back to
+		 * a findByAgentNo API call on a miss - each caller decides whether
+		 * a miss is terminal and reports it accordingly.
+		 *
 		 * @param string $agent_no The submitted agent number.
 		 *
-		 * @return object|null The cached pickup point, or null when none matches.
+		 * @return SS_Shipping_Pickup_Point|null The cached pickup point, or null when none matches.
 		 */
-		public function find_cached_by_agent_no( $agent_no ) {
+		public function find_cached_by_agent_no( string $agent_no ): ?SS_Shipping_Pickup_Point {
+			if ( '' === $agent_no ) {
+				return null;
+			}
+
 			$cached_pickup_points = $this->get_session_pickup_points();
 
 			if ( ! is_array( $cached_pickup_points ) ) {
@@ -163,7 +172,7 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Lookup' ) ) :
 
 			foreach ( $cached_pickup_points as $pickup_point ) {
 				if ( isset( $pickup_point->agent_no ) && $pickup_point->agent_no == $agent_no ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison, moved verbatim from SS_Shipping_Frontend::process_ss_pickup_points().
-					return $pickup_point;
+					return SS_Shipping_Pickup_Point::from_object( $pickup_point );
 				}
 			}
 

--- a/smart-send-logistics/includes/delivery/class-ss-shipping-store-api.php
+++ b/smart-send-logistics/includes/delivery/class-ss-shipping-store-api.php
@@ -327,14 +327,14 @@ if ( ! class_exists( 'SS_Shipping_Store_Api' ) ) :
 			}
 
 			$details = new SS_Shipping_Delivery_Details();
-			$details->set_pickup_point( SS_Shipping_Pickup_Point::from_object( $pickup_point ) );
+			$details->set_pickup_point( $pickup_point );
 			$this->order_meta->write( $order, $details );
 
 			SS_Shipping_Logger::info(
 				'Pickup point selected at checkout',
 				array(
 					'order_id' => $order->get_id(),
-					'agent_no' => $pickup_point->agent_no,
+					'agent_no' => $pickup_point->get_agent_no(),
 				)
 			);
 		}
@@ -359,17 +359,17 @@ if ( ! class_exists( 'SS_Shipping_Store_Api' ) ) :
 
 		/**
 		 * Re-resolve a submitted agent number into the server-side pickup
-		 * point object: the session-cached lookup results first (cheap,
-		 * already validated - the same cache the classic checkout resolves
+		 * point: the session-cached lookup results first (cheap, already
+		 * validated - the same cache the classic checkout resolves
 		 * against), the findByAgentNo API call as fallback.
 		 *
 		 * @param string   $carrier  Unique carrier code (e.g. 'postnord').
 		 * @param WC_Order $order    The order being placed.
 		 * @param string   $agent_no The submitted agent number.
 		 *
-		 * @return object|null The pickup point object, or null when the agent number cannot be resolved.
+		 * @return SS_Shipping_Pickup_Point|null The pickup point, or null when the agent number cannot be resolved.
 		 */
-		protected function resolve_pickup_point( $carrier, $order, $agent_no ) {
+		protected function resolve_pickup_point( $carrier, $order, $agent_no ): ?SS_Shipping_Pickup_Point {
 			$cached = $this->pickup_point_lookup->find_cached_by_agent_no( $agent_no );
 
 			if ( null !== $cached ) {
@@ -383,7 +383,7 @@ if ( ! class_exists( 'SS_Shipping_Store_Api' ) ) :
 			$response = SS_SHIPPING_WC()->get_api_handle()->pickupPoints()->findByAgentNo( $carrier, $country, $agent_no );
 
 			if ( $response->isSuccessful() && is_object( $response->data() ) ) {
-				return $response->data();
+				return SS_Shipping_Pickup_Point::from_object( $response->data() );
 			}
 
 			SS_Shipping_Logger::warning(

--- a/smart-send-logistics/includes/delivery/class-ss-shipping-store-api.php
+++ b/smart-send-logistics/includes/delivery/class-ss-shipping-store-api.php
@@ -37,6 +37,12 @@ if ( ! class_exists( 'SS_Shipping_Store_Api' ) ) :
 		const ENDPOINT_CART = 'cart';
 
 		/**
+		 * The Store API checkout endpoint identifier (see ENDPOINT_CART on
+		 * why this is a literal).
+		 */
+		const ENDPOINT_CHECKOUT = 'checkout';
+
+		/**
 		 * WooCommerce session key holding the shopper's in-progress pickup
 		 * point selection on the block checkout (pushed by the block via the
 		 * extension update callback), so it survives cart refreshes until
@@ -112,6 +118,8 @@ if ( ! class_exists( 'SS_Shipping_Store_Api' ) ) :
 			} else {
 				add_action( 'woocommerce_blocks_loaded', array( $this, 'register_store_api_extensions' ) );
 			}
+
+			add_action( 'woocommerce_store_api_checkout_update_order_from_request', array( $this, 'persist_pickup_point_from_request' ), 10, 2 );
 		}
 
 		/**
@@ -134,6 +142,14 @@ if ( ! class_exists( 'SS_Shipping_Store_Api' ) ) :
 					'namespace'       => SS_Shipping_Block_Checkout::INTEGRATION_NAME,
 					'data_callback'   => array( $this, 'cart_extension_data' ),
 					'schema_callback' => array( $this, 'cart_extension_schema' ),
+				)
+			);
+
+			woocommerce_store_api_register_endpoint_data(
+				array(
+					'endpoint'        => self::ENDPOINT_CHECKOUT,
+					'namespace'       => SS_Shipping_Block_Checkout::INTEGRATION_NAME,
+					'schema_callback' => array( $this, 'checkout_extension_schema' ),
 				)
 			);
 
@@ -223,6 +239,22 @@ if ( ! class_exists( 'SS_Shipping_Store_Api' ) ) :
 		}
 
 		/**
+		 * Schema of the data the checkout endpoint accepts from the block
+		 * ("data up"): the selected pickup point's agent number.
+		 *
+		 * @return array
+		 */
+		public function checkout_extension_schema() {
+			return array(
+				'agent_no' => array(
+					'description' => __( 'The agent number of the pickup point selected for the order.', 'smart-send-logistics' ),
+					'type'        => array( 'string', 'null' ),
+					'optional'    => true,
+				),
+			);
+		}
+
+		/**
 		 * Extension update callback (wc/store/v1/cart/extensions): keep the
 		 * shopper's in-progress selection in the WooCommerce session so it
 		 * survives cart refreshes. An empty agent_no clears the selection.
@@ -254,6 +286,138 @@ if ( ! class_exists( 'SS_Shipping_Store_Api' ) ) :
 			$agent_no = WC()->session->get( self::SESSION_SELECTED_AGENT_NO );
 
 			return empty( $agent_no ) ? null : (string) $agent_no;
+		}
+
+		/**
+		 * Persist the submitted pickup point on the order during Store API
+		 * checkout (woocommerce_store_api_checkout_update_order_from_request).
+		 *
+		 * Mirrors the classic checkout: a non-agent method ignores any
+		 * submitted agent_no; an agent method requires one and re-resolves
+		 * it server-side (session-cached lookup results first, then the
+		 * findByAgentNo API call) before writing the SERVER-side pickup
+		 * point object through the repository - client data never reaches
+		 * order meta, and the stored meta is byte-identical to the classic
+		 * checkout path.
+		 *
+		 * @param WC_Order        $order   The order being placed.
+		 * @param WP_REST_Request $request The checkout request.
+		 *
+		 * @throws Exception A Store API RouteException (HTTP 400) when an agent method is submitted without a resolvable agent_no.
+		 *
+		 * @return void
+		 */
+		public function persist_pickup_point_from_request( $order, $request ) {
+			$method_code = new SS_Shipping_Method_Code( $this->method_resolver->resolve_outbound( $order ) );
+
+			if ( stripos( $method_code->type(), 'agent' ) === false ) {
+				return;
+			}
+
+			$agent_no = $this->requested_agent_no( $request );
+
+			if ( '' === $agent_no ) {
+				$this->reject_checkout();
+			}
+
+			$pickup_point = $this->resolve_pickup_point( $method_code->carrier(), $order, $agent_no );
+
+			if ( null === $pickup_point ) {
+				$this->reject_checkout();
+			}
+
+			$details = new SS_Shipping_Delivery_Details();
+			$details->set_pickup_point( SS_Shipping_Pickup_Point::from_object( $pickup_point ) );
+			$this->order_meta->write( $order, $details );
+
+			SS_Shipping_Logger::info(
+				'Pickup point selected at checkout',
+				array(
+					'order_id' => $order->get_id(),
+					'agent_no' => $pickup_point->agent_no,
+				)
+			);
+		}
+
+		/**
+		 * The agent_no submitted under our extension namespace, or '' when
+		 * none was submitted.
+		 *
+		 * @param WP_REST_Request $request The checkout request.
+		 *
+		 * @return string
+		 */
+		protected function requested_agent_no( $request ) {
+			$extensions = $request->get_param( 'extensions' );
+
+			if ( ! is_array( $extensions ) || empty( $extensions[ SS_Shipping_Block_Checkout::INTEGRATION_NAME ]['agent_no'] ) ) {
+				return '';
+			}
+
+			return (string) wc_clean( wp_unslash( $extensions[ SS_Shipping_Block_Checkout::INTEGRATION_NAME ]['agent_no'] ) );
+		}
+
+		/**
+		 * Re-resolve a submitted agent number into the server-side pickup
+		 * point object: the session-cached lookup results first (cheap,
+		 * already validated - the same cache the classic checkout resolves
+		 * against), the findByAgentNo API call as fallback.
+		 *
+		 * @param string   $carrier  Unique carrier code (e.g. 'postnord').
+		 * @param WC_Order $order    The order being placed.
+		 * @param string   $agent_no The submitted agent number.
+		 *
+		 * @return object|null The pickup point object, or null when the agent number cannot be resolved.
+		 */
+		protected function resolve_pickup_point( $carrier, $order, $agent_no ) {
+			$cached = $this->pickup_point_lookup->find_cached_by_agent_no( $agent_no );
+
+			if ( null !== $cached ) {
+				return $cached;
+			}
+
+			$country = $order->get_shipping_country();
+
+			// The request and response (incl. HTTP status code and endpoint)
+			// are logged by the client's request logger.
+			$response = SS_SHIPPING_WC()->get_api_handle()->pickupPoints()->findByAgentNo( $carrier, $country, $agent_no );
+
+			if ( $response->isSuccessful() && is_object( $response->data() ) ) {
+				return $response->data();
+			}
+
+			SS_Shipping_Logger::warning(
+				'Pickup point not found - agent number rejected',
+				array(
+					'order_id' => $order->get_id(),
+					'agent_no' => $agent_no,
+					'carrier'  => $carrier,
+				)
+			);
+
+			return null;
+		}
+
+		/**
+		 * Reject the checkout with a Store API validation error (HTTP 400),
+		 * message-parity with the classic checkout's validate_agent_selected().
+		 *
+		 * @throws Exception The Store API RouteException.
+		 *
+		 * @return void
+		 */
+		protected function reject_checkout() {
+			// The Store API moved namespace when it graduated from the Blocks package into WooCommerce
+			// core (WC 7.2); support both locations across the supported WC 5.0+ range.
+			$route_exception = class_exists( 'Automattic\WooCommerce\StoreApi\Exceptions\RouteException' )
+				? 'Automattic\WooCommerce\StoreApi\Exceptions\RouteException'
+				: 'Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException';
+
+			throw new $route_exception(
+				'ss_shipping_pickup_point_required',
+				esc_html__( 'A pickup point must be selected.', 'smart-send-logistics' ),
+				400
+			);
 		}
 
 		/**

--- a/smart-send-logistics/includes/delivery/class-ss-shipping-store-api.php
+++ b/smart-send-logistics/includes/delivery/class-ss-shipping-store-api.php
@@ -1,0 +1,339 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Smart Send Store API extensions for the WooCommerce Checkout Block.
+ *
+ * The headless twin of SS_Shipping_Frontend (#74): extends the Store API
+ * cart endpoint with the server-computed pickup point state ("data down"),
+ * accepts the shopper's agent_no on the checkout endpoint and persists it
+ * through the delivery-details repository ("data up"), and keeps the
+ * in-progress selection in the WooCommerce session via the extension
+ * update callback. All Store API references live inside method bodies
+ * (string class names, literal endpoint identifiers), so this file loads
+ * eagerly with the rest of the delivery domain - no definition-time
+ * dependency on WooCommerce.
+ *
+ * @package  SS_Shipping_Store_Api
+ * @category Shipping
+ * @author   Smart Send
+ */
+
+// A second copy of the plugin may already have defined the class.
+if ( ! class_exists( 'SS_Shipping_Store_Api' ) ) :
+
+	class SS_Shipping_Store_Api {
+
+		/**
+		 * The Store API cart endpoint identifier. Deliberately the literal
+		 * string instead of CartSchema::IDENTIFIER: the schema classes moved
+		 * namespace when the Store API graduated into WooCommerce core, so
+		 * no class-constant reference works across the supported WC range.
+		 * The identifiers themselves are frozen public API.
+		 */
+		const ENDPOINT_CART = 'cart';
+
+		/**
+		 * WooCommerce session key holding the shopper's in-progress pickup
+		 * point selection on the block checkout (pushed by the block via the
+		 * extension update callback), so it survives cart refreshes until
+		 * checkout submission persists it on the order.
+		 */
+		const SESSION_SELECTED_AGENT_NO = 'ss_shipping_selected_agent_no';
+
+		/**
+		 * Headless pickup point lookup (API + session cache).
+		 *
+		 * @var SS_Shipping_Pickup_Point_Lookup
+		 */
+		protected SS_Shipping_Pickup_Point_Lookup $pickup_point_lookup;
+
+		/**
+		 * Pickup point display formatter.
+		 *
+		 * @var SS_Shipping_Pickup_Point_Formatter
+		 */
+		protected SS_Shipping_Pickup_Point_Formatter $pickup_point_formatter;
+
+		/**
+		 * Typed plugin settings reader.
+		 *
+		 * @var SS_Shipping_Settings
+		 */
+		protected SS_Shipping_Settings $settings;
+
+		/**
+		 * Order meta repository (delivery details).
+		 *
+		 * @var SS_Shipping_Order_Meta
+		 */
+		protected SS_Shipping_Order_Meta $order_meta;
+
+		/**
+		 * Shipping method resolver.
+		 *
+		 * @var SS_Shipping_Method_Resolver
+		 */
+		protected SS_Shipping_Method_Resolver $method_resolver;
+
+		/**
+		 * All collaborators are stateless, so fresh defaults are safe for
+		 * ad-hoc construction (tests construct the component directly).
+		 *
+		 * @param SS_Shipping_Pickup_Point_Lookup|null    $pickup_point_lookup    Headless pickup point lookup.
+		 * @param SS_Shipping_Pickup_Point_Formatter|null $pickup_point_formatter Pickup point display formatter.
+		 * @param SS_Shipping_Settings|null               $settings               Typed plugin settings reader.
+		 * @param SS_Shipping_Order_Meta|null             $order_meta             Order meta repository.
+		 * @param SS_Shipping_Method_Resolver|null        $method_resolver        Shipping method resolver.
+		 */
+		public function __construct( ?SS_Shipping_Pickup_Point_Lookup $pickup_point_lookup = null, ?SS_Shipping_Pickup_Point_Formatter $pickup_point_formatter = null, ?SS_Shipping_Settings $settings = null, ?SS_Shipping_Order_Meta $order_meta = null, ?SS_Shipping_Method_Resolver $method_resolver = null ) {
+			$this->pickup_point_lookup    = null === $pickup_point_lookup ? new SS_Shipping_Pickup_Point_Lookup() : $pickup_point_lookup;
+			$this->pickup_point_formatter = null === $pickup_point_formatter ? new SS_Shipping_Pickup_Point_Formatter() : $pickup_point_formatter;
+			$this->settings               = null === $settings ? new SS_Shipping_Settings() : $settings;
+			$this->order_meta             = null === $order_meta ? new SS_Shipping_Order_Meta() : $order_meta;
+			$this->method_resolver        = null === $method_resolver ? new SS_Shipping_Method_Resolver( $this->settings ) : $method_resolver;
+		}
+
+		/**
+		 * Register this component's hooks.
+		 *
+		 * @return void
+		 */
+		public function register_hooks(): void {
+			// woocommerce_blocks_loaded fires during plugins_loaded, which is
+			// before this registration pass (the composition root wires
+			// components on init 0) - so when it already fired, register the
+			// Store API extensions directly instead of hooking it.
+			if ( did_action( 'woocommerce_blocks_loaded' ) ) {
+				$this->register_store_api_extensions();
+			} else {
+				add_action( 'woocommerce_blocks_loaded', array( $this, 'register_store_api_extensions' ) );
+			}
+		}
+
+		/**
+		 * Register the cart/checkout schema extensions and the extension
+		 * update callback with the Store API, under the same namespace as
+		 * the Blocks integration (SS_Shipping_Block_Checkout::INTEGRATION_NAME).
+		 *
+		 * @return void
+		 */
+		public function register_store_api_extensions() {
+			// The Store API extension functions exist since WC 6.4 (Blocks 7.2); the WC floor is 5.0 -
+			// older stores simply get no block-checkout extension data (the classic checkout is unaffected).
+			if ( ! function_exists( 'woocommerce_store_api_register_endpoint_data' ) ) {
+				return;
+			}
+
+			woocommerce_store_api_register_endpoint_data(
+				array(
+					'endpoint'        => self::ENDPOINT_CART,
+					'namespace'       => SS_Shipping_Block_Checkout::INTEGRATION_NAME,
+					'data_callback'   => array( $this, 'cart_extension_data' ),
+					'schema_callback' => array( $this, 'cart_extension_schema' ),
+				)
+			);
+
+			woocommerce_store_api_register_update_callback(
+				array(
+					'namespace' => SS_Shipping_Block_Checkout::INTEGRATION_NAME,
+					'callback'  => array( $this, 'store_selected_agent_no' ),
+				)
+			);
+		}
+
+		/**
+		 * The server-computed pickup point state riding the cart response
+		 * ("data down"): whether the chosen rate is a Smart Send agent-type
+		 * method, the pickup points near the customer's shipping address
+		 * (labels pre-formatted, same pipeline as the classic checkout),
+		 * the session-stored selection, and the display settings the block
+		 * needs. The block re-fetches the cart on every address/rate change,
+		 * so this recomputes automatically with no client-side fetch logic.
+		 *
+		 * @return array
+		 */
+		public function cart_extension_data() {
+			$method_code   = $this->chosen_agent_rate_method_code();
+			$pickup_points = array();
+
+			if ( null !== $method_code ) {
+				foreach ( $this->lookup_pickup_points_for_customer( $method_code->carrier() ) as $pickup_point ) {
+					$pickup_points[] = array(
+						'agent_no' => (string) $pickup_point->agent_no,
+						'label'    => $this->pickup_point_formatter->dropdown_label( $pickup_point ),
+					);
+				}
+			}
+
+			return array(
+				'selected_rate_is_agent' => null !== $method_code,
+				'pickup_points'          => $pickup_points,
+				'selected_agent_no'      => $this->get_selected_agent_no(),
+				'select_default'         => $this->settings->default_select_agent(),
+			);
+		}
+
+		/**
+		 * Schema of the cart extension data (all read-only, server-computed).
+		 *
+		 * @return array
+		 */
+		public function cart_extension_schema() {
+			return array(
+				'selected_rate_is_agent' => array(
+					'description' => __( 'Whether the chosen shipping rate is a Smart Send agent-type method.', 'smart-send-logistics' ),
+					'type'        => 'boolean',
+					'readonly'    => true,
+				),
+				'pickup_points'          => array(
+					'description' => __( 'The pickup points closest to the customer shipping address, with pre-formatted labels.', 'smart-send-logistics' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'agent_no' => array(
+								'description' => __( 'The pickup point agent number.', 'smart-send-logistics' ),
+								'type'        => 'string',
+								'readonly'    => true,
+							),
+							'label'    => array(
+								'description' => __( 'The display label, formatted per the "Dropdown display format" setting.', 'smart-send-logistics' ),
+								'type'        => 'string',
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+				'selected_agent_no'      => array(
+					'description' => __( 'The agent number of the pickup point currently selected in this session, if any.', 'smart-send-logistics' ),
+					'type'        => array( 'string', 'null' ),
+					'readonly'    => true,
+				),
+				'select_default'         => array(
+					'description' => __( 'Whether the closest pickup point is pre-selected (the "Select Default" setting).', 'smart-send-logistics' ),
+					'type'        => 'boolean',
+					'readonly'    => true,
+				),
+			);
+		}
+
+		/**
+		 * Extension update callback (wc/store/v1/cart/extensions): keep the
+		 * shopper's in-progress selection in the WooCommerce session so it
+		 * survives cart refreshes. An empty agent_no clears the selection.
+		 *
+		 * @param array $data The posted extension data.
+		 *
+		 * @return void
+		 */
+		public function store_selected_agent_no( $data ) {
+			if ( ! is_array( $data ) || ! array_key_exists( 'agent_no', $data ) || null === WC()->session ) {
+				return;
+			}
+
+			$agent_no = (string) wc_clean( wp_unslash( $data['agent_no'] ) );
+
+			WC()->session->set( self::SESSION_SELECTED_AGENT_NO, '' === $agent_no ? null : $agent_no );
+		}
+
+		/**
+		 * The session-stored in-progress selection, if any.
+		 *
+		 * @return string|null
+		 */
+		public function get_selected_agent_no() {
+			if ( null === WC()->session ) {
+				return null;
+			}
+
+			$agent_no = WC()->session->get( self::SESSION_SELECTED_AGENT_NO );
+
+			return empty( $agent_no ) ? null : (string) $agent_no;
+		}
+
+		/**
+		 * The Smart Send method code of the session's chosen shipping rate,
+		 * when that rate is a Smart Send agent-type method; null otherwise.
+		 *
+		 * The server-side twin of the classic checkout's rate check in
+		 * SS_Shipping_Frontend::display_ss_pickup_points(): the chosen rate
+		 * comes from the session, its Smart Send method code from the rate
+		 * meta added by SS_Shipping_WC_Method::calculate_shipping().
+		 *
+		 * @return SS_Shipping_Method_Code|null
+		 */
+		protected function chosen_agent_rate_method_code() {
+			if ( null === WC()->session || null === WC()->shipping() ) {
+				return null;
+			}
+
+			$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
+			$chosen_shipping = is_array( $chosen_methods ) ? current( $chosen_methods ) : false;
+
+			if ( empty( $chosen_shipping ) ) {
+				return null;
+			}
+
+			foreach ( WC()->shipping()->get_packages() as $package ) {
+				if ( ! isset( $package['rates'][ $chosen_shipping ] ) ) {
+					continue;
+				}
+
+				$rate = $package['rates'][ $chosen_shipping ];
+
+				if ( SS_SHIPPING_METHOD_ID !== $rate->get_method_id() ) {
+					return null;
+				}
+
+				$meta_data = $rate->get_meta_data();
+
+				if ( empty( $meta_data['smart_send_shipping_method'] ) ) {
+					return null;
+				}
+
+				$method_code = new SS_Shipping_Method_Code( $meta_data['smart_send_shipping_method'] );
+
+				return stripos( $method_code->type(), 'agent' ) !== false ? $method_code : null;
+			}
+
+			return null;
+		}
+
+		/**
+		 * Look up the closest pickup points from the customer's shipping
+		 * address as WooCommerce knows it server-side (WC()->customer, never
+		 * client request data). An incomplete address (no country, postcode
+		 * or street - city is optional, matching the classic checkout)
+		 * yields no points and makes no API call. Lookup failures are
+		 * logged/reported by SS_Shipping_Pickup_Point_Lookup itself.
+		 *
+		 * @param string $carrier Unique carrier code (e.g. 'postnord').
+		 *
+		 * @return object[]
+		 */
+		protected function lookup_pickup_points_for_customer( $carrier ) {
+			$customer = WC()->customer;
+
+			if ( null === $customer ) {
+				return array();
+			}
+
+			$country     = $customer->get_shipping_country();
+			$postal_code = $customer->get_shipping_postcode();
+			$city        = $customer->get_shipping_city();
+			$street      = $customer->get_shipping_address();
+
+			if ( empty( $country ) || empty( $postal_code ) || empty( $street ) ) {
+				return array();
+			}
+
+			return $this->pickup_point_lookup->find_closest_by_address( $carrier, $country, $postal_code, empty( $city ) ? null : $city, $street );
+		}
+	}
+
+endif;

--- a/smart-send-logistics/public/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/public/class-ss-shipping-frontend.php
@@ -139,20 +139,9 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 						}
 
 						foreach ( $ss_pickup_points as $key => $pickup_point ) {
-							$formatted_address = $this->pickup_point_formatter->format( $pickup_point );
-
-							/*
-							 * Filter the label shown for a pickup point in the
-							 * checkout drop-down.
-							 *
-							 * @since 9.0.0
-							 *
-							 * @param string $formatted_address The label formatted per the "Dropdown display format" setting.
-							 * @param object $pickup_point      The pickup point (agent_no, company, address_line1, postal_code, city, country, distance, ...).
-							 *
-							 * @return string The option label to render.
-							 */
-							$pickup_point_options[ $pickup_point->agent_no ] = apply_filters( 'smart_send_pickup_point_option_label', $formatted_address, $pickup_point );
+							// The label pipeline (format + the smart_send_pickup_point_option_label
+							// filter) is shared with the Checkout Block cart extension (#74).
+							$pickup_point_options[ $pickup_point->agent_no ] = $this->pickup_point_formatter->dropdown_label( $pickup_point );
 						}
 
 						/*
@@ -253,23 +242,14 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 
 			$ss_shipping_store_pickup = wc_clean( $_POST['ss_shipping_store_pickup'] );
 			// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput
-			$retrieved_pickup_points = $this->pickup_point_lookup->get_session_pickup_points();
 
-			$selected_pickup_point_no = 0;
-			if ( $retrieved_pickup_points ) {
-				foreach ( $retrieved_pickup_points as $pickup_point_key => $pickup_point_value ) {
-					// If pickup point selected for the order, save it
-					if ( $pickup_point_value->agent_no == $ss_shipping_store_pickup ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- pre-existing loose comparison; tightening is a behaviour change out of scope for the #43 move.
-
-						$selected_pickup_point_no = $pickup_point_value->agent_no;
-						$selected_pickup_point    = $pickup_point_value;
-						break;
-					}
-				}
-			}
+			// If pickup point selected for the order, save it. The
+			// session-cache resolution is shared with the Checkout Block
+			// persistence (#74).
+			$selected_pickup_point = $this->pickup_point_lookup->find_cached_by_agent_no( $ss_shipping_store_pickup );
 
 			// Saving posted pickup point information.
-			if ( ! empty( $selected_pickup_point_no ) ) {
+			if ( null !== $selected_pickup_point && ! empty( $selected_pickup_point->agent_no ) ) {
 				$details = new SS_Shipping_Delivery_Details();
 				$details->set_pickup_point( SS_Shipping_Pickup_Point::from_object( $selected_pickup_point ) );
 				$this->order_meta->write( $order_id, $details );
@@ -278,7 +258,7 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 					'Pickup point selected at checkout',
 					array(
 						'order_id' => $order_id,
-						'agent_no' => $selected_pickup_point_no,
+						'agent_no' => $selected_pickup_point->agent_no,
 					)
 				);
 			}

--- a/smart-send-logistics/public/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/public/class-ss-shipping-frontend.php
@@ -248,20 +248,33 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 			// persistence (#74).
 			$selected_pickup_point = $this->pickup_point_lookup->find_cached_by_agent_no( $ss_shipping_store_pickup );
 
-			// Saving posted pickup point information.
-			if ( null !== $selected_pickup_point && ! empty( $selected_pickup_point->agent_no ) ) {
-				$details = new SS_Shipping_Delivery_Details();
-				$details->set_pickup_point( SS_Shipping_Pickup_Point::from_object( $selected_pickup_point ) );
-				$this->order_meta->write( $order_id, $details );
-
-				SS_Shipping_Logger::info(
-					'Pickup point selected at checkout',
+			if ( null === $selected_pickup_point || ! $selected_pickup_point->get_agent_no() ) {
+				// Recovered failure: the shopper's choice is silently
+				// dropped from the order (the classic checkout has no
+				// fallback resolution), so leave an always-logged trace.
+				SS_Shipping_Logger::warning(
+					'Posted pickup point could not be resolved from the session cache - selection not saved',
 					array(
 						'order_id' => $order_id,
-						'agent_no' => $selected_pickup_point->agent_no,
+						'agent_no' => $ss_shipping_store_pickup,
 					)
 				);
+
+				return;
 			}
+
+			// Saving posted pickup point information.
+			$details = new SS_Shipping_Delivery_Details();
+			$details->set_pickup_point( $selected_pickup_point );
+			$this->order_meta->write( $order_id, $details );
+
+			SS_Shipping_Logger::info(
+				'Pickup point selected at checkout',
+				array(
+					'order_id' => $order_id,
+					'agent_no' => $selected_pickup_point->get_agent_no(),
+				)
+			);
 		}
 
 		/**

--- a/tests/Integration/BlockStoreApiTest.php
+++ b/tests/Integration/BlockStoreApiTest.php
@@ -76,8 +76,22 @@ function block_cart_setup(string $method_code = 'postnord_agent', array $address
     $zone->save();
     $zone->add_shipping_method('flat_rate');
 
+    // Adding the method bumps the 'shipping' transient version, but the
+    // version stamp is (string) time() - SECOND resolution
+    // (WC_Cache_Helper::get_transient_version()). When an earlier test in
+    // the suite primed the wc_shipping_method_count transient with a
+    // 0-count in the SAME wall-clock second, the "bumped" version equals
+    // the cached one and wc_get_shipping_method_count() keeps returning
+    // the stale 0 - which made show_shipping() short-circuit in CI while
+    // passing locally whenever a second boundary happened to fall in
+    // between. Drop the count transient so the zone method is recounted.
+    delete_transient('wc_shipping_method_count');
+
     remember_cleanup_callback(function () use ($zone): void {
         $zone->delete(true);
+        // Same second-resolution staleness in the other direction: without
+        // this, a later test could keep counting the deleted zone's method.
+        delete_transient('wc_shipping_method_count');
     });
 
     remember_cleanup_callback(function () use ($rate_filter): void {
@@ -93,6 +107,17 @@ function block_cart_setup(string $method_code = 'postnord_agent', array $address
         $customer->set_shipping_city('');
         $customer->set_shipping_address_1('');
     });
+
+    // Verify the gate BEFORE calculating: WC_Cart::show_shipping() (and
+    // needs_shipping()) short-circuit when the store counts zero enabled
+    // shipping methods, and calculate_shipping() then silently builds no
+    // packages at all.
+    if (!WC()->cart->show_shipping()) {
+        throw new RuntimeException(
+            'block_cart_setup: WC()->cart->show_shipping() is false even though the test zone exists'
+            . ' (wc_get_shipping_method_count(true) = ' . wc_get_shipping_method_count(true) . ')'
+        );
+    }
 
     WC()->cart->calculate_shipping();
 

--- a/tests/Integration/BlockStoreApiTest.php
+++ b/tests/Integration/BlockStoreApiTest.php
@@ -1,0 +1,341 @@
+<?php
+
+/*
+ * Tests for the Store API extensions of the Checkout Block (PR 2 of issue
+ * #74, SS_Shipping_Store_Api): the cart endpoint carries the server-computed
+ * pickup point state ("data down"), the checkout endpoint accepts agent_no
+ * and persists the server-resolved pickup point through the repository
+ * ("data up") with byte-identical meta to the classic checkout, and an
+ * unresolvable agent_no on an agent method rejects the checkout with a
+ * Store API validation error.
+ *
+ * Dispatch layer: the schema/data/update callbacks are exercised through the
+ * REAL ExtendSchema registry (StoreApi::container()) that the plugin
+ * registered into at bootstrap, plus one full REST GET of /wc/store/v1/cart;
+ * the checkout write fires the real woocommerce_store_api_checkout_update_order_from_request
+ * action against the plugin's registered listener. Full REST POSTs to
+ * /wc/store/v1/checkout are not used - they require a payment gateway and
+ * draft-order session state that the in-process bootstrap does not provide
+ * reliably.
+ *
+ * NOTE: like FrontendSelectorHooksTest.php, this file must run before the
+ * WC_DOING_AJAX-defining test in ShippingDebugModeTest.php (alphabetical
+ * file order guarantees this).
+ */
+
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\StoreApi;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * Set up a cart the way the block checkout sees it server-side: an item in
+ * the cart, the customer's shipping address known to WooCommerce, a Smart
+ * Send rate injected into the calculated packages and chosen in the session.
+ */
+function block_cart_setup(string $method_code = 'postnord_agent', array $address = []): void
+{
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+
+    WC()->cart->empty_cart();
+    WC()->cart->add_to_cart(create_simple_product()->get_id());
+
+    $address = array_merge([
+        'country'  => 'DK',
+        'postcode' => '2300',
+        'city'     => 'Copenhagen',
+        'address'  => 'Islands Brygge 39',
+    ], $address);
+
+    $customer = WC()->customer;
+    $customer->set_shipping_country($address['country']);
+    $customer->set_shipping_postcode($address['postcode']);
+    $customer->set_shipping_city($address['city']);
+    $customer->set_shipping_address_1($address['address']);
+
+    $rate_filter = function (array $rates) use ($method_code): array {
+        $rate = new WC_Shipping_Rate('smart_send_shipping:1', 'Smart Send', 49.0, [], 'smart_send_shipping', 1);
+        $rate->add_meta_data('smart_send_shipping_method', $method_code);
+
+        $rates['smart_send_shipping:1'] = $rate;
+
+        return $rates;
+    };
+    add_filter('woocommerce_package_rates', $rate_filter);
+
+    remember_cleanup_callback(function () use ($rate_filter): void {
+        remove_filter('woocommerce_package_rates', $rate_filter);
+        WC()->cart->empty_cart();
+        WC()->session->set('chosen_shipping_methods', null);
+        WC()->session->set('ss_shipping_agents', null);
+        WC()->session->set(SS_Shipping_Store_Api::SESSION_SELECTED_AGENT_NO, null);
+
+        $customer = WC()->customer;
+        $customer->set_shipping_country('');
+        $customer->set_shipping_postcode('');
+        $customer->set_shipping_city('');
+        $customer->set_shipping_address_1('');
+    });
+
+    WC()->cart->calculate_shipping();
+
+    // Choose the Smart Send rate AFTER calculating: calculating a changed
+    // package resets the session choice to the default rate.
+    WC()->session->set('chosen_shipping_methods', ['smart_send_shipping:1']);
+}
+
+/**
+ * The 'smart-send' cart extension data, computed through the real
+ * ExtendSchema registry the plugin registered into.
+ */
+function block_cart_extension_data(): array
+{
+    $data = StoreApi::container()->get(ExtendSchema::class)->get_endpoint_data('cart');
+
+    return $data->{SS_Shipping_Block_Checkout::INTEGRATION_NAME};
+}
+
+/**
+ * A checkout REST request carrying (or omitting) our extension data.
+ */
+function block_checkout_request(?string $agent_no): WP_REST_Request
+{
+    $request = new WP_REST_Request('POST', '/wc/store/v1/checkout');
+
+    if ($agent_no !== null) {
+        $request->set_param('extensions', [
+            SS_Shipping_Block_Checkout::INTEGRATION_NAME => ['agent_no' => $agent_no],
+        ]);
+    }
+
+    return $request;
+}
+
+beforeEach(function (): void {
+    with_ss_settings();
+});
+
+it('registers cart and checkout schema extensions under the smart-send namespace', function () {
+    $extend = StoreApi::container()->get(ExtendSchema::class);
+
+    $cart_schema = $extend->get_endpoint_schema('cart');
+    expect($cart_schema)->toHaveProperty('smart-send');
+    expect($cart_schema->{'smart-send'}['properties'] ?? $cart_schema->{'smart-send'})
+        ->toHaveKeys(['selected_rate_is_agent', 'pickup_points', 'selected_agent_no', 'select_default']);
+
+    $checkout_schema = $extend->get_endpoint_schema('checkout');
+    expect($checkout_schema)->toHaveProperty('smart-send');
+    expect($checkout_schema->{'smart-send'}['properties'] ?? $checkout_schema->{'smart-send'})
+        ->toHaveKeys(['agent_no']);
+});
+
+it('carries the smart-send extension data in the full cart REST response', function () {
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent()]]);
+    });
+    block_cart_setup();
+
+    $response = rest_do_request(new WP_REST_Request('GET', '/wc/store/v1/cart'));
+
+    expect($response->get_status())->toBe(200);
+
+    $extensions = (array) $response->get_data()['extensions'];
+
+    expect($extensions)->toHaveKey('smart-send')
+        ->and((array) $extensions['smart-send'])
+        ->toHaveKeys(['selected_rate_is_agent', 'pickup_points', 'selected_agent_no', 'select_default']);
+});
+
+it('computes pickup points with formatted labels for an agent rate and a complete address', function () {
+    $capture = mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [
+            sample_agent(['agent_no' => '1111', 'company' => 'First Shop']),
+            sample_agent(['agent_no' => '2222', 'company' => 'Second Shop']),
+        ]]);
+    });
+    block_cart_setup();
+
+    $data = block_cart_extension_data();
+
+    expect($data['selected_rate_is_agent'])->toBeTrue()
+        ->and($data['pickup_points'])->toHaveCount(2)
+        ->and($data['pickup_points'][0]['agent_no'])->toBe('1111')
+        // Format 4 from with_ss_settings(): '#Company, #Street, #Zipcode #City'.
+        ->and($data['pickup_points'][0]['label'])->toContain('First Shop, Main Street 1, 2300 Copenhagen')
+        ->and($data['pickup_points'][1]['label'])->toContain('Second Shop, Main Street 1, 2300 Copenhagen')
+        ->and($data['selected_agent_no'])->toBeNull()
+        ->and($data['select_default'])->toBeFalse();
+
+    // The lookup went to the closest-by-address endpoint with the
+    // customer's server-side address.
+    expect(end($capture->requests)['url'])->toContain('/agents/closest/carrier/postnord/country/DK/postalcode/2300/city/Copenhagen/street/Islands');
+});
+
+it('applies the smart_send_pickup_point_option_label filter to the labels, like classic checkout', function () {
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent()]]);
+    });
+    block_cart_setup();
+
+    $filter = function (string $label, object $agent) {
+        return 'Custom Label ' . $agent->agent_no;
+    };
+    add_filter('smart_send_pickup_point_option_label', $filter, 10, 2);
+    remember_cleanup_callback(function () use ($filter): void {
+        remove_filter('smart_send_pickup_point_option_label', $filter, 10);
+    });
+
+    $data = block_cart_extension_data();
+
+    expect($data['pickup_points'][0]['label'])->toBe('Custom Label 1234');
+});
+
+it('reports a non-agent rate with no pickup points and makes no API call', function () {
+    $capture = mock_smart_send_api();
+    block_cart_setup('postnord_homedelivery');
+
+    $data = block_cart_extension_data();
+
+    expect($data['selected_rate_is_agent'])->toBeFalse()
+        ->and($data['pickup_points'])->toBe([])
+        ->and($capture->requests)->toBe([]);
+});
+
+it('returns no pickup points and makes no API call while the address is incomplete', function () {
+    $capture = mock_smart_send_api();
+    block_cart_setup('postnord_agent', ['postcode' => '']);
+
+    $data = block_cart_extension_data();
+
+    expect($data['selected_rate_is_agent'])->toBeTrue()
+        ->and($data['pickup_points'])->toBe([])
+        ->and($capture->requests)->toBe([]);
+});
+
+it('reflects the Select Default setting in the cart data', function () {
+    with_ss_settings(['default_select_agent' => 'yes']);
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent()]]);
+    });
+    block_cart_setup();
+
+    expect(block_cart_extension_data()['select_default'])->toBeTrue();
+});
+
+it('stores and clears the in-progress selection through the registered extension update callback', function () {
+    mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => [sample_agent()]]);
+    });
+    block_cart_setup();
+
+    $callback = StoreApi::container()->get(ExtendSchema::class)
+        ->get_update_callback(SS_Shipping_Block_Checkout::INTEGRATION_NAME);
+
+    $callback(['agent_no' => '1234']);
+    expect(block_cart_extension_data()['selected_agent_no'])->toBe('1234');
+
+    $callback(['agent_no' => '']);
+    expect(block_cart_extension_data()['selected_agent_no'])->toBeNull();
+});
+
+it('persists the pickup point byte-identically to the classic checkout path', function () {
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+
+    // Both paths resolve against the same session-cached lookup results.
+    WC()->session->set('ss_shipping_agents', [sample_agent()]);
+    remember_cleanup_callback(function (): void {
+        WC()->session->set('ss_shipping_agents', null);
+        unset($_POST['ss_shipping_store_pickup']);
+    });
+
+    // Classic checkout path.
+    $classic_order = create_order(['shipping_method' => 'postnord_agent']);
+    $_POST['ss_shipping_store_pickup'] = '1234';
+    (new SS_Shipping_Frontend())->process_ss_pickup_points($classic_order->get_id(), []);
+    unset($_POST['ss_shipping_store_pickup']);
+
+    // Block checkout path: the real registered listener on the real action.
+    $block_order = create_order(['shipping_method' => 'postnord_agent']);
+    do_action('woocommerce_store_api_checkout_update_order_from_request', $block_order, block_checkout_request('1234'));
+
+    // Byte-equality of the stored meta between the two paths (freshly
+    // reloaded orders, read through the CRUD so both storage backends work).
+    $classic_fresh = wc_get_order($classic_order->get_id());
+    $block_fresh   = wc_get_order($block_order->get_id());
+
+    expect(serialize($block_fresh->get_meta(SS_Shipping_Order_Meta::META_AGENT, true)))
+        ->toBe(serialize($classic_fresh->get_meta(SS_Shipping_Order_Meta::META_AGENT, true)))
+        ->and($block_fresh->get_meta(SS_Shipping_Order_Meta::META_AGENT_NO, true))
+        ->toBe($classic_fresh->get_meta(SS_Shipping_Order_Meta::META_AGENT_NO, true));
+
+    // And the repository reads back the identical pickup point.
+    $classic_point = SS_SHIPPING_WC()->order_meta()->read($classic_order->get_id())->get_pickup_point();
+    $block_point   = SS_SHIPPING_WC()->order_meta()->read($block_order->get_id())->get_pickup_point();
+
+    expect($block_point->get_agent_no())->toBe('1234')
+        ->and(serialize($block_point->to_object()))->toBe(serialize($classic_point->to_object()));
+});
+
+it('rejects checkout with a Store API validation error when an agent method has no agent_no', function () {
+    $order = create_order(['shipping_method' => 'postnord_agent']);
+
+    expect(function () use ($order) {
+        do_action('woocommerce_store_api_checkout_update_order_from_request', $order, block_checkout_request(null));
+    })->toThrow(RouteException::class, 'A pickup point must be selected.');
+
+    expect(wc_get_order($order->get_id())->get_meta(SS_Shipping_Order_Meta::META_AGENT_NO, true))->toBe('');
+});
+
+it('rejects checkout when the submitted agent_no resolves nowhere (cache miss and API miss)', function () {
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+    WC()->session->set('ss_shipping_agents', null);
+
+    mock_smart_send_api(function () {
+        return ss_api_response(404, ss_api_error_body('Agent not found'));
+    });
+
+    $order = create_order(['shipping_method' => 'postnord_agent']);
+
+    expect(function () use ($order) {
+        do_action('woocommerce_store_api_checkout_update_order_from_request', $order, block_checkout_request('0000'));
+    })->toThrow(RouteException::class, 'A pickup point must be selected.');
+
+    expect(wc_get_order($order->get_id())->get_meta(SS_Shipping_Order_Meta::META_AGENT_NO, true))->toBe('');
+});
+
+it('ignores a stray agent_no on a non-agent method and writes nothing', function () {
+    $order = create_order(['shipping_method' => 'postnord_homedelivery']);
+
+    do_action('woocommerce_store_api_checkout_update_order_from_request', $order, block_checkout_request('1234'));
+
+    $fresh = wc_get_order($order->get_id());
+    expect($fresh->get_meta(SS_Shipping_Order_Meta::META_AGENT_NO, true))->toBe('')
+        ->and($fresh->get_meta(SS_Shipping_Order_Meta::META_AGENT, true))->toBe('');
+});
+
+it('falls back to the findByAgentNo API when the agent_no is not in the session cache, and persists the server object', function () {
+    if (is_null(WC()->cart)) {
+        wc_load_cart();
+    }
+    WC()->session->set('ss_shipping_agents', null);
+
+    $capture = mock_smart_send_api(function () {
+        return ss_api_response(200, ['data' => sample_agent(['agent_no' => '9999', 'company' => 'Fallback Shop'])]);
+    });
+
+    $order = create_order(['shipping_method' => 'postnord_agent']);
+
+    do_action('woocommerce_store_api_checkout_update_order_from_request', $order, block_checkout_request('9999'));
+
+    // Resolved server-side by agent number, for the order's carrier/country.
+    expect(end($capture->requests)['url'])->toContain('/agents/carrier/postnord/country/DK/agentno/9999');
+
+    $point = SS_SHIPPING_WC()->order_meta()->read($order->get_id())->get_pickup_point();
+    expect($point->get_agent_no())->toBe('9999')
+        ->and($point->get_company())->toBe('Fallback Shop');
+});

--- a/tests/Integration/BlockStoreApiTest.php
+++ b/tests/Integration/BlockStoreApiTest.php
@@ -64,6 +64,22 @@ function block_cart_setup(string $method_code = 'postnord_agent', array $address
     };
     add_filter('woocommerce_package_rates', $rate_filter);
 
+    // The CI store is provisioned with --skip-seed, so NO shipping zone
+    // method exists there - and WC_Cart::show_shipping() short-circuits
+    // (calculate_shipping() then never builds any package) whenever
+    // wc_get_shipping_method_count() is zero. Create a throwaway zone with
+    // an enabled method so shipping is calculated at all; the Smart Send
+    // rate itself still comes from the woocommerce_package_rates filter.
+    $zone = new WC_Shipping_Zone();
+    $zone->set_zone_name('Block Store API test zone');
+    $zone->add_location($address['country'] ?: 'DK', 'country');
+    $zone->save();
+    $zone->add_shipping_method('flat_rate');
+
+    remember_cleanup_callback(function () use ($zone): void {
+        $zone->delete(true);
+    });
+
     remember_cleanup_callback(function () use ($rate_filter): void {
         remove_filter('woocommerce_package_rates', $rate_filter);
         WC()->cart->empty_cart();
@@ -80,8 +96,21 @@ function block_cart_setup(string $method_code = 'postnord_agent', array $address
 
     WC()->cart->calculate_shipping();
 
-    // Choose the Smart Send rate AFTER calculating: calculating a changed
-    // package resets the session choice to the default rate.
+    // Fail loudly when the rate did not make it into the calculated
+    // packages - otherwise a setup regression reads as a silently wrong
+    // rate selection in the actual tests.
+    $packages      = WC()->shipping()->get_packages();
+    $package_rates = array_keys($packages[0]['rates'] ?? []);
+    if (!in_array('smart_send_shipping:1', $package_rates, true)) {
+        throw new RuntimeException(
+            'block_cart_setup: the Smart Send rate is missing from the calculated package rates ('
+            . (empty($packages) ? 'no packages were calculated' : implode(', ', $package_rates)) . ')'
+        );
+    }
+
+    // Choose the Smart Send rate AFTER calculating, as the LAST setup step:
+    // calculating a changed package resets the session choice to the
+    // default rate.
     WC()->session->set('chosen_shipping_methods', ['smart_send_shipping:1']);
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #148** (`feature/issue-74-block-tooling`). Do not merge before #148; after #148 merges, retarget this PR's base to `develop`.

PR 2 of 3 for #74, per the implementation plan comment. This is the complete server side; no JS beyond the PR 1 placeholders (the block UI, editor placeholder and browser tests are PR 3).

## What this adds

**Data down — pickup points ride the cart response.** New `SS_Shipping_Store_Api` (`includes/delivery/`) extends the Store API **cart** endpoint under the `smart-send` namespace (`SS_Shipping_Block_Checkout::INTEGRATION_NAME`) with server-computed state:

- `selected_rate_is_agent` — the session's chosen rate is a Smart Send agent-type method (`SS_Shipping_Method_Code::type()` contains `agent`, read from the rate meta in the calculated packages — the server-side twin of the classic rate check).
- `pickup_points` (`{agent_no, label}[]`) — computed via `SS_Shipping_Pickup_Point_Lookup` from `WC()->customer`'s shipping address (never client input), labels pre-formatted by the formatter with `smart_send_pickup_point_option_label` applied — the same pipeline as classic. Empty when the rate isn't agent-type or the address is incomplete (no API call then). Lookup failures are logged/reported by the lookup class itself, no double-logging.
- `selected_agent_no` — the in-progress selection, kept in the WC session via a registered **extension update callback** (`wc/store/v1/cart/extensions`), so it survives cart refreshes until checkout persists it.
- `select_default` — the "Select Default" setting from `SS_Shipping_Settings`.

**Data up — checkout extension + persistence.** The **checkout** endpoint schema accepts an optional `agent_no`; on `woocommerce_store_api_checkout_update_order_from_request`:

- Non-agent method → any submitted `agent_no` is ignored, nothing written.
- Agent method → `agent_no` required and **re-resolved server-side**: session-cached lookup results first, `PickupPointResource::findByAgentNo()` as fallback. The server-side object is written through the `SS_Shipping_Order_Meta` repository — byte-identical meta to classic checkout — and "Pickup point selected at checkout" is logged at info, matching the classic audit trail.
- Missing/unresolvable `agent_no` → Store API `RouteException` (HTTP 400) with the classic message "A pickup point must be selected."; unresolvable additionally logs a warning like the meta-box validator.

**Shared code extracted, not copied**: the drop-down label pipeline (`Pickup_Point_Formatter::dropdown_label()`, format + filter) and the session-cache resolution (`Pickup_Point_Lookup::find_cached_by_agent_no()`) moved into the delivery domain; `SS_Shipping_Frontend` now delegates to both — classic behaviour unchanged, pinned by the existing tests.

## Compatibility / design decisions

- **WC 5.0 floor vs Store API availability**: registration goes through the `woocommerce_store_api_register_endpoint_data`/`_update_callback` functions behind a documented `function_exists` guard — they exist since WC 6.4 (Blocks 7.2), so older stores in the 5.0+ range simply get no block-checkout extension data (classic checkout unaffected). Registration runs behind `woocommerce_blocks_loaded` (called directly when it already fired — it fires during `plugins_loaded`, before the composition root's init-0 hook pass).
- **Namespace variance**: endpoint identifiers are the literal `'cart'`/`'checkout'` strings (the schema classes moved from `Automattic\WooCommerce\Blocks\StoreApi\...` to `Automattic\WooCommerce\StoreApi\...` in WC 7.2, so no class-constant reference works across the range); the `RouteException` class is picked at runtime (`class_exists`, modern namespace preferred, Blocks-era fallback).
- **Eager load**: unlike `SS_Shipping_Block_Checkout`, the new class keeps every Store API reference inside method bodies (string class names, literal identifiers), so it has no definition-time WooCommerce dependency and loads eagerly in `includes()` — no lazy require needed.
- Wired per convention: typed property, constructed with the shared components, `register_hooks()` in the `register_component_hooks()` pass, `store_api()` accessor.

## Tests (integration, `tests/Integration/BlockStoreApiTest.php`)

Dispatch layer: the real `ExtendSchema` registry (`StoreApi::container()`) the plugin registered into, plus one full REST `GET /wc/store/v1/cart`; the checkout write fires the real `woocommerce_store_api_checkout_update_order_from_request` action against the plugin's registered listener. Full REST checkout POSTs were not used — they need a payment gateway and draft-order session state the in-process bootstrap doesn't provide reliably.

- Schema registration on cart + checkout under `smart-send`; extension data present in the full cart REST response.
- Agent rate + complete address → formatted labels + option-label filter applied; non-agent rate and incomplete address → no points, **no API call**.
- Checkout persistence byte-identical to the classic path (same session cache, serialized stored meta compared across the two orders).
- Missing `agent_no` and unresolvable `agent_no` → `RouteException` with the classic message; stray `agent_no` on a non-agent method writes nothing.
- Session-cache miss → resolved via mocked `findByAgentNo` and the server object persisted.

`composer test:integration`: **221 passed (991 assertions)**. `vendor/bin/phpcs` and `composer phpcs:compat`: clean. No PHP 8 syntax (7.4 floor).

Part of #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)