### PR TITLE
Restore shipping zone 1 after the Docs suite runs

### DIFF
--- a/tests/Browser/ShippingMethodSetupTest.php
+++ b/tests/Browser/ShippingMethodSetupTest.php
@@ -30,23 +30,12 @@ beforeAll(function (): void {
         return;
     }
 
-    $GLOBALS['ss_method_setup_state'] = ss_browser_wp_eval(<<<'PHP'
-// Snapshot and clear zone 1's methods: the method list must contain only
-// the method this suite configures, both for the unambiguous 'Edit' click
-// and so the checkout tests see exactly the UI-configured rate.
-$zone = new WC_Shipping_Zone(1);
-$snapshot = array();
-foreach ($zone->get_shipping_methods() as $method) {
-    $snapshot[] = array(
-        'method_id' => $method->id,
-        'settings'  => get_option('woocommerce_' . $method->id . '_' . $method->instance_id . '_settings'),
-        'enabled'   => $method->enabled,
-        'order'     => isset($method->method_order) ? (int) $method->method_order : 0,
-    );
-    $zone->delete_shipping_method($method->instance_id);
-}
-update_option('ss_method_setup_zone_snapshot', $snapshot);
+    // Snapshot and clear zone 1's methods: the method list must contain only
+    // the method this suite configures, both for the unambiguous 'Edit' click
+    // and so the checkout tests see exactly the UI-configured rate.
+    ss_browser_snapshot_and_clear_zone_methods(1, 'ss_method_setup_zone_snapshot');
 
+    $GLOBALS['ss_method_setup_state'] = ss_browser_wp_eval(<<<'PHP'
 // Products for the checkout tests: one inside the weight table (1 kg) and
 // one that pushes the cart outside it (15 kg).
 $make_product = function ($sku, $name, $weight) {
@@ -63,6 +52,8 @@ $make_product = function ($sku, $name, $weight) {
     return $product->get_id();
 };
 
+$zone = new WC_Shipping_Zone(1);
+
 echo json_encode(array(
     'zone_id'          => 1,
     'zone_name'        => $zone->get_zone_name(),
@@ -77,33 +68,9 @@ afterAll(function (): void {
         return;
     }
 
-    ss_browser_wp_eval(<<<'PHP'
-// Remove whatever this suite configured on zone 1 and restore the
-// snapshotted methods (fresh instance ids, same configuration).
-$zone = new WC_Shipping_Zone(1);
-foreach ($zone->get_shipping_methods() as $method) {
-    $zone->delete_shipping_method($method->instance_id);
-}
-global $wpdb;
-foreach (get_option('ss_method_setup_zone_snapshot', array()) as $entry) {
-    $instance_id = $zone->add_shipping_method($entry['method_id']);
-    if (is_array($entry['settings'])) {
-        update_option('woocommerce_' . $entry['method_id'] . '_' . $instance_id . '_settings', $entry['settings']);
-    }
-    // add_shipping_method() appends (enabled, next order); restore the
-    // snapshotted order and enabled flag so the store's rate ordering -
-    // which determines the preselected method at checkout - survives.
-    $wpdb->update(
-        "{$wpdb->prefix}woocommerce_shipping_zone_methods",
-        array(
-            'method_order' => isset($entry['order']) ? (int) $entry['order'] : 0,
-            'is_enabled'   => (isset($entry['enabled']) && 'yes' !== $entry['enabled']) ? 0 : 1,
-        ),
-        array('instance_id' => $instance_id)
-    );
-}
-delete_option('ss_method_setup_zone_snapshot');
+    ss_browser_restore_zone_methods(1, 'ss_method_setup_zone_snapshot');
 
+    ss_browser_wp_eval(<<<'PHP'
 foreach (array('SS-UI-LIGHT', 'SS-UI-HEAVY') as $sku) {
     $product_id = wc_get_product_id_by_sku($sku);
     if ($product_id) {

--- a/tests/Browser/Support/SmartSendStore.php
+++ b/tests/Browser/Support/SmartSendStore.php
@@ -80,6 +80,74 @@ function ss_browser_wp_eval(string $code): array
     return $json;
 }
 
+/**
+ * Snapshot every shipping method configured on the given zone into a wp
+ * option and remove them from the zone, so the zone starts empty for the
+ * calling suite and ss_browser_restore_zone_methods() can put the store's
+ * real methods (e.g. the Flat rate seeded by bin/setup-local-dev.sh) back
+ * afterwards. Clearing goes through WooCommerce's own API rather than the
+ * admin UI: the zone screen is client-side rendered, so page-content checks
+ * for "is there something to delete" are unreliable - see the
+ * ShippingMethod test files' history for the two ways that bit the suites.
+ */
+function ss_browser_snapshot_and_clear_zone_methods(int $zoneId, string $optionName): void
+{
+    $encodedOption = var_export($optionName, true);
+
+    ss_browser_wp_eval(<<<PHP
+        \$zone = new WC_Shipping_Zone({$zoneId});
+        \$snapshot = array();
+        foreach (\$zone->get_shipping_methods() as \$method) {
+            \$snapshot[] = array(
+                'method_id' => \$method->id,
+                'settings'  => get_option('woocommerce_' . \$method->id . '_' . \$method->instance_id . '_settings'),
+                'enabled'   => \$method->enabled,
+                'order'     => isset(\$method->method_order) ? (int) \$method->method_order : 0,
+            );
+            \$zone->delete_shipping_method(\$method->instance_id);
+        }
+        update_option({$encodedOption}, \$snapshot);
+        echo json_encode(array('snapshotted' => count(\$snapshot)));
+        PHP);
+}
+
+/**
+ * Remove whatever the calling suite configured on the given zone and restore
+ * the methods snapshotted by ss_browser_snapshot_and_clear_zone_methods()
+ * (fresh instance ids, same configuration).
+ */
+function ss_browser_restore_zone_methods(int $zoneId, string $optionName): void
+{
+    $encodedOption = var_export($optionName, true);
+
+    ss_browser_wp_eval(<<<PHP
+        \$zone = new WC_Shipping_Zone({$zoneId});
+        foreach (\$zone->get_shipping_methods() as \$method) {
+            \$zone->delete_shipping_method(\$method->instance_id);
+        }
+        global \$wpdb;
+        foreach (get_option({$encodedOption}, array()) as \$entry) {
+            \$instance_id = \$zone->add_shipping_method(\$entry['method_id']);
+            if (is_array(\$entry['settings'])) {
+                update_option('woocommerce_' . \$entry['method_id'] . '_' . \$instance_id . '_settings', \$entry['settings']);
+            }
+            // add_shipping_method() appends (enabled, next order); restore the
+            // snapshotted order and enabled flag so the store's rate ordering -
+            // which determines the preselected method at checkout - survives.
+            \$wpdb->update(
+                "{\$wpdb->prefix}woocommerce_shipping_zone_methods",
+                array(
+                    'method_order' => isset(\$entry['order']) ? (int) \$entry['order'] : 0,
+                    'is_enabled'   => (isset(\$entry['enabled']) && 'yes' !== \$entry['enabled']) ? 0 : 1,
+                ),
+                array('instance_id' => \$instance_id)
+            );
+        }
+        delete_option({$encodedOption});
+        echo json_encode(array('restored' => true));
+        PHP);
+}
+
 function ss_browser_mu_plugin_path(): string
 {
     return ss_browser_wp_path() . '/wp-content/mu-plugins/ss-browser-test-api-mock.php';

--- a/tests/Docs/ShippingMethod/ConfigureShippingMethodTest.php
+++ b/tests/Docs/ShippingMethod/ConfigureShippingMethodTest.php
@@ -33,11 +33,35 @@
 | call has to stay inline in every test here.
 |
 | Runs against the "Denmark" shipping zone that bin/setup-local-dev.sh
-| seeds by default. The first test removes any Smart Send method already
-| on that zone so the suite is safe to re-run locally without resetting the
-| store between runs.
+| seeds by default. beforeAll snapshots the zone's real methods (the seeded
+| Flat rate) and clears the zone - the "empty zone" screenshot needs it
+| empty, and any Smart Send method left over from a previous run would get
+| duplicated by the "add method" test - and afterAll restores the snapshot,
+| so a Docs run leaves the local store the way it found it (a zone stripped
+| of its Flat rate broke the Browser suite's flat-rate storefront test until
+| someone restored it by hand).
 |
 */
+
+beforeAll(function (): void {
+    if (!ss_browser_store_manageable()) {
+        return;
+    }
+
+    // Through WooCommerce's own API (WP-CLI, see the helper's docblock)
+    // rather than by scripting the admin UI - the zone screen is
+    // client-side rendered, so "click Delete until the page looks empty"
+    // can never reliably terminate.
+    ss_browser_snapshot_and_clear_zone_methods(1, 'ss_docs_zone_snapshot');
+});
+
+afterAll(function (): void {
+    if (!ss_browser_store_manageable()) {
+        return;
+    }
+
+    ss_browser_restore_zone_methods(1, 'ss_docs_zone_snapshot');
+});
 
 /**
  * The Denmark zone (zone 1) seeded by bin/setup-local-dev.sh - the zone
@@ -49,23 +73,7 @@ function docs_zone_url(): string
 }
 
 it('starts from an empty shipping zone', function () {
-    // Idempotency: a Smart Send method left over from a previous run of this
-    // suite would otherwise show up in the "empty" screenshot and get
-    // duplicated by the "add method" test below.
-    //
-    // This is done through WooCommerce's own API (docs_clear_shipping_zone_methods(),
-    // shelling out via WP-CLI - see its docblock) rather than by scripting
-    // the admin UI ("click Delete until the page looks empty"). The zone
-    // screen is a client-side-rendered (Vue) app: its compiled JS bundle
-    // contains every method's name and every row's CSS class as template
-    // strings, so both are present in the page source regardless of whether
-    // anything is actually configured - a page-content check for "is there
-    // something to delete" can never reliably go false, and a stray
-    // ->click('Delete') on a method that was never actually rendered just
-    // hangs waiting for a locator that will never appear. Resetting state
-    // directly sidesteps both failure modes entirely.
-    docs_clear_shipping_zone_methods(1);
-
+    // The zone was snapshotted and cleared in beforeAll.
     $page = visit(base_url('/wp-login.php'))
         ->fill('#user_login', admin_username())
         ->fill('#user_pass', admin_password())

--- a/tests/Docs/Support/Screenshots.php
+++ b/tests/Docs/Support/Screenshots.php
@@ -84,27 +84,6 @@ function capture_doc_screenshot(Webpage|AwaitableWebpage $page, string $area, st
 }
 
 /**
- * Remove every shipping method configured on the given zone, directly
- * through WooCommerce's own API (shelling out via the Browser suite's
- * shared ss_browser_wp_eval()) rather than by scripting the admin UI: a
- * UI-driven "click Delete until the page stops mentioning the method" loop
- * is unreliable against a client-side-rendered admin screen, where class
- * names and label text from the JS bundle are present in the page source
- * regardless of whether anything is actually rendered - see the
- * ShippingMethod test's history for the two ways that bit this suite.
- */
-function docs_clear_shipping_zone_methods(int $zoneId): void
-{
-    ss_browser_wp_eval(<<<PHP
-        \$zone = new WC_Shipping_Zone({$zoneId});
-        foreach (\$zone->get_shipping_methods() as \$method) {
-            \$zone->delete_shipping_method(\$method->instance_id);
-        }
-        echo json_encode(array('cleared' => true));
-        PHP);
-}
-
-/**
  * Draw a spotlight highlight around the given element, for screenshots that
  * call out a specific field. Adapted from dumbledore's highlightElement(),
  * using pest-plugin-browser's Webpage::script() (Playwright evaluate) rather


### PR DESCRIPTION
## Problem

`tests/Docs/ShippingMethod/ConfigureShippingMethodTest.php` cleared shipping zone 1's methods and left only the Smart Send method it configured, stripping the Flat rate seeded by `bin/setup-local-dev.sh`. On a local store this broke `tests/Browser/StorefrontTest.php` ("calculates flat rate shipping…") on every subsequent Browser run until the Flat rate was restored by hand. CI was unaffected — it provisions a fresh store per job — so this was purely a local-dev trap.

## Fix

`tests/Browser/ShippingMethodSetupTest.php` already had the right discipline: snapshot zone 1's methods in `beforeAll`, restore them (settings, enabled flag, method order) in `afterAll`. This PR extracts that snapshot/restore logic into shared helpers in `tests/Browser/Support/SmartSendStore.php`:

- `ss_browser_snapshot_and_clear_zone_methods($zoneId, $optionName)`
- `ss_browser_restore_zone_methods($zoneId, $optionName)`

and uses them from both suites. The Docs suite gains a `beforeAll`/`afterAll` pair; its one-way `docs_clear_shipping_zone_methods()` helper (and the in-test clear call) is replaced by the snapshot-and-clear, so a Docs run now leaves the store exactly as it found it.

## Verification

Ran on one local store, back-to-back:

1. `vendor/bin/pest --testsuite=Docs` — 7 passed (~10s); zone 1 afterwards holds only the seeded `flat_rate` with its original enabled flag and method order, snapshot option deleted.
2. `vendor/bin/pest --testsuite=Browser` — 13 passed incl. the previously-trapped flat-rate storefront test and the refactored `ShippingMethodSetupTest` (~44s; 9 pre-existing PHP deprecation notices unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)