### PR TITLE
Docs slow-motion: pause after the final assertion too

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -56,6 +56,11 @@ uses()->beforeEach(function (): void {
     if (! getenv('CI') && ! getenv('SS_DOCS_HEADLESS')) {
         Playwright::headed();
     }
+})->afterEach(function (): void {
+    // In slow-motion mode (SS_DOCS_SLOWMO), also pause AFTER the last
+    // assertion of each test - the final UI state is usually the one worth
+    // seeing, and without this the browser closes the moment it is reached.
+    docs_slowmo_pause();
 })->in('Docs');
 
 /*


### PR DESCRIPTION
## Summary
Follow-up to #154: in `SS_DOCS_SLOWMO` mode, a Docs-scoped `afterEach` now pauses once more after each test's LAST assertion — previously the browser closed the instant the final (often most interesting) state was reached.

## Test plan
- [x] `SS_DOCS_SLOWMO=1000` filtered Docs run: 9.1s → 12.9s (final pause fires per test), green
- [x] Without the var: unaffected (pause is a no-op)
🤖 Generated with [Claude Code](https://claude.com/claude-code)