### PR TITLE
Add a demo mode for manual testing (composer demo:on/off/scenario)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ composer test:docs          # needs the store running; opens a visible browser l
 composer test               # Integration + Browser (not Docs - see below)
 ```
 
+For manual testing there is a demo mode (`composer demo:on` / `demo:off` / `demo:scenario -- <name>`, backed by `bin/demo-store.sh`): it applies the Browser suite's seeded store state + API mock to the local dev store and leaves it on until turned off. The mock and seeding sources are shared with the Browser suite (`tests/Browser/Support/ApiMockMuPlugin.php` + `Snippets/*.php`) — one source of truth; see README "Manual testing (demo mode)".
+
 Local runs are fast: every suite finishes in under 2 minutes. If a run takes longer, something is wrong (store not running, wrong `WP_BASE_URL`, a hung Playwright session) — kill it and investigate instead of waiting.
 
 CI runs Integration and Browser (`.github/workflows/browser-tests.yml` and `integration-tests.yml`) on every pull request and on pushes to `main` and `develop`. **Docs is intentionally not part of that PR-blocking path** — screenshot generation is slow and a broken screenshot doesn't mean broken code (assertions only guard against a broken/erroring page, not visual regressions). It runs on demand from `.github/workflows/docs-screenshots.yml` (`workflow_dispatch` only, headless, uploads `docs/screenshots/` as a build artifact rather than committing — a human reviews and commits the images after eyeballing them) and locally via `composer test:docs`. Screenshots are committed to `docs/screenshots/` at the repo root (outside `smart-send-logistics/`, mirroring the existing plugin-vs-dev-tooling split) since the whole point of the suite is producing images for direct use in documentation, same as `smartsendio/dumbledore`'s `tests/Docs/`.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,21 @@ composer test
 
 The tests read `WP_BASE_URL`, `WP_ADMIN_USER` and `WP_ADMIN_PASS` from the environment (defaulting to the setup script's defaults: `http://127.0.0.1:8181`, `admin` / `password`). The same flow runs in CI via the Browser Tests workflow, which provisions the store with `bin/setup-local-dev.sh` on every pull request. Failure screenshots are saved to `tests/Browser/Screenshots/` and uploaded as workflow artifacts.
 
+### Manual testing (demo mode)
+
+Demo mode puts the local development store into the same state the Browser suite runs against — a mu-plugin that mocks the Smart Send API, a Denmark shipping zone with a Smart Send pick-up point method, a sample product, and both a classic and a block checkout page — and leaves it on until you turn it off. Useful for clicking through checkout and label generation by hand without a real API token.
+
+```bash
+composer demo:on                             # seed the store + install the API mock; prints URLs + admin creds
+composer demo:off                            # remove the mock and the demo fixtures again
+composer demo:scenario                       # show the active mock scenario + the valid list
+composer demo:scenario -- no-pickup-points   # switch the mock into a failure scenario
+```
+
+Valid scenarios: `success` (the default), `invalid-token` (authentication returns 401), `booking-failure` (label booking returns a 422 validation error), `no-pickup-points` (the pick-up point lookup finds nothing).
+
+The commands target the install at `WP_DEV_PATH` (default `./local-dev/wordpress`); start the store's web server as shown above to browse it. Both commands are idempotent, and `demo:off` only removes what `demo:on` created — zones, products, pages and orders you built on top are left alone. The mock and seeding logic are shared with the Browser suite (`tests/Browser/Support/`), so demo mode always matches what the tests exercise. Demo mode is a local-only tool: it refuses to run against a production environment or a non-localhost site URL.
+
 ### SVN
 
 Wordpress Plugin releases are managed by [SVN](https://developer.wordpress.org/plugins/wordpress-org/how-to-use-subversion/#starting-a-new-plugin) and to sync the plugin to a local folder run:

--- a/bin/demo-store.sh
+++ b/bin/demo-store.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# Demo mode for manual testing: put the local development store into the same
+# state the Browser test suite runs against - the Smart Send API mock (a
+# mu-plugin faking the Smart Send API), a Denmark zone with a Smart Send
+# agent method, a sample product and both checkout pages - and leave it on
+# until switched off again.
+#
+#   bin/demo-store.sh on                    Seed the store + install the mock
+#   bin/demo-store.sh off                   Remove the mock, undo the seeding
+#   bin/demo-store.sh scenario [<name>]     Show or set the mock API scenario
+#
+# Wrapped by the composer scripts demo:on / demo:off / demo:scenario.
+#
+# The mock and the seeding/cleanup logic are shared with the Browser suite -
+# the single source of truth lives in tests/Browser/Support/
+# (ApiMockMuPlugin.php and the Snippets/*.php eval-file scripts); this
+# script only copies/runs those.
+#
+# What demo:off removes vs keeps (the same contract as the test cleanup,
+# Snippets/cleanup-store.php): it deletes only what demo:on created - the
+# seeded product (SKU SS-BROWSER-TEST), the two seeded checkout pages, orders
+# created by the seeding or placed with the fixture billing email
+# (ss-browser-test@smartsend.io), and the zone method instances *if* the
+# seeding added them - and restores the plugin settings, COD gateway state
+# and checkout-page option. Zones, products, pages and orders a developer
+# built on top are left alone.
+#
+# Targets the install at WP_DEV_PATH (default ./local-dev/wordpress), i.e.
+# the store created by bin/setup-local-dev.sh. Local tool only: refuses to
+# run against a production environment or a non-localhost site URL.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_PATH="${WP_DEV_PATH:-$REPO_ROOT/local-dev/wordpress}"
+
+SUPPORT_DIR="$REPO_ROOT/tests/Browser/Support"
+MOCK_SRC="$SUPPORT_DIR/ApiMockMuPlugin.php"
+SNIPPETS_DIR="$SUPPORT_DIR/Snippets"
+STATE_OPTION="ss_demo_state"
+
+log()  { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31mError:\033[0m %s\n' "$*" >&2; exit 1; }
+
+usage() {
+    cat <<'EOF'
+Usage: bin/demo-store.sh <on|off|scenario> [<scenario name>]
+
+Demo mode for manual testing: the browser-suite store state (Smart Send API
+mock, Denmark zone with a Smart Send agent method, sample product, classic +
+block checkout pages), left on until turned off.
+
+  on                 Seed the store and install the API mock; prints URLs and
+                     admin credentials. Idempotent.
+  off                Remove the mock and the demo fixtures, restore what
+                     demo:on changed. Idempotent.
+  scenario [<name>]  Show the active mock API scenario, or set it. With no
+                     name, prints the active scenario and the valid list.
+
+Composer wrappers: composer demo:on / demo:off / demo:scenario -- <name>
+Target install: WP_DEV_PATH (default ./local-dev/wordpress).
+EOF
+}
+
+# ------------------------------------------------------------------------------
+# Target install checks
+# ------------------------------------------------------------------------------
+require_install() {
+    [[ -f "$INSTALL_PATH/wp-load.php" ]] \
+        || fail "No WordPress install found at $INSTALL_PATH (set WP_DEV_PATH or run bin/setup-local-dev.sh first)."
+    INSTALL_PATH="$(cd "$INSTALL_PATH" && pwd)"
+    WP_CLI_PHAR="$INSTALL_PATH/.wp-cli/wp-cli.phar"
+    [[ -f "$WP_CLI_PHAR" ]] \
+        || fail "No WP-CLI phar at $WP_CLI_PHAR - this tool targets stores created by bin/setup-local-dev.sh."
+    MU_PLUGIN_PATH="$INSTALL_PATH/wp-content/mu-plugins/ss-browser-test-api-mock.php"
+}
+
+PHP_BIN="${PHP_BIN:-php}"
+
+wp() {
+    "$PHP_BIN" -d memory_limit=512M -d error_reporting=0 -d display_errors=0 \
+        "$WP_CLI_PHAR" --path="$INSTALL_PATH" "$@" 2>/dev/null
+}
+
+# Local-only guard: never touch a production environment or a remote site.
+guard_local() {
+    local env_type site_url host
+    env_type="$(wp eval 'echo wp_get_environment_type();' || true)"
+    site_url="$(wp option get siteurl || true)"
+    [[ -n "$site_url" ]] || fail "Could not read the site URL from $INSTALL_PATH - is this a working install?"
+    host="$(echo "$site_url" | sed -E 's#https?://([^:/]+).*#\1#')"
+    if [[ "$env_type" == "production" ]]; then
+        fail "WP_ENVIRONMENT_TYPE is 'production' - demo mode is a local-only tool, refusing to run."
+    fi
+    if [[ "$host" != "localhost" && "$host" != "127.0.0.1" && "$host" != *.localhost ]]; then
+        fail "Site URL is $site_url - demo mode only runs against localhost/127.0.0.1 stores."
+    fi
+}
+
+demo_is_on() {
+    wp option get "$STATE_OPTION" >/dev/null 2>&1
+}
+
+current_scenario() {
+    wp option get ss_test_api_scenario 2>/dev/null || echo "success"
+}
+
+valid_scenarios() {
+    # Machine-read from the shared mock source's " * Scenarios: ..." line.
+    sed -n 's/^ \* Scenarios: //p' "$MOCK_SRC"
+}
+
+install_mock() {
+    mkdir -p "$(dirname "$MU_PLUGIN_PATH")"
+    cp "$MOCK_SRC" "$MU_PLUGIN_PATH"
+}
+
+page_url() {
+    wp post list --post_type=page --post__in="$1" --field=url
+}
+
+state_value() {
+    wp option get "$STATE_OPTION" --format=json \
+        | "$PHP_BIN" -r 'echo json_decode(stream_get_contents(STDIN), true)[$argv[1]] ?? "";' "$1"
+}
+
+print_info() {
+    local site_url
+    site_url="$(wp option get siteurl)"
+
+    cat <<EOF
+
+------------------------------------------------------------------------------
+Demo mode is ON - the store now runs against a FAKE Smart Send API.
+
+  Store:            $site_url
+  Classic checkout: $(page_url "$(state_value checkout_page_id)")
+  Block checkout:   $(page_url "$(state_value block_checkout_page_id)")
+  Admin:            $site_url/wp-admin (${WP_ADMIN_USER:-admin} / ${WP_ADMIN_PASS:-password})
+
+  API scenario:     $(current_scenario)
+                    switch:  composer demo:scenario -- <name>
+                    valid:   $(valid_scenarios)
+
+Add the sample product "SS Browser Test Product" to the cart, then open a
+checkout page to see pick-up point selection against the mocked API.
+
+Remember: composer demo:off removes the fake API and the demo fixtures.
+------------------------------------------------------------------------------
+EOF
+}
+
+cmd_on() {
+    if demo_is_on; then
+        log "Demo mode is already on - refreshing the API mock mu-plugin only."
+        install_mock
+        print_info
+        return
+    fi
+    log "Installing the Smart Send API mock mu-plugin"
+    install_mock
+    log "Seeding the store (shared with the Browser suite: Snippets/seed-store.php)"
+    wp eval-file "$SNIPPETS_DIR/seed-store.php" '{}' "$STATE_OPTION" >/dev/null
+    log "Creating the block checkout page"
+    wp eval-file "$SNIPPETS_DIR/create-block-checkout-page.php" "$STATE_OPTION" >/dev/null
+    print_info
+}
+
+cmd_off() {
+    if demo_is_on; then
+        log "Undoing the demo seeding (shared with the Browser suite: Snippets/cleanup-store.php)"
+        wp eval-file "$SNIPPETS_DIR/cleanup-store.php" "$STATE_OPTION" >/dev/null
+    else
+        log "Demo mode is not on (no seeded state found)."
+    fi
+    if [[ -f "$MU_PLUGIN_PATH" ]]; then
+        log "Removing the API mock mu-plugin"
+        rm -f "$MU_PLUGIN_PATH"
+    fi
+    log "Demo mode is OFF - the store talks to the real Smart Send API again."
+}
+
+cmd_scenario() {
+    local scenario="${1:-}"
+    if [[ -z "$scenario" ]]; then
+        echo "Active scenario: $(current_scenario)"
+        echo "Valid scenarios: $(valid_scenarios)"
+        return
+    fi
+    if ! printf ' %s ' "$(valid_scenarios)" | grep -q " $scenario "; then
+        fail "Unknown scenario '$scenario'. Valid scenarios: $(valid_scenarios)"
+    fi
+    if ! demo_is_on; then
+        fail "Demo mode is not on - run 'composer demo:on' first."
+    fi
+    if [[ "$scenario" == "success" ]]; then
+        wp option delete ss_test_api_scenario >/dev/null 2>&1 || true
+    else
+        wp option update ss_test_api_scenario "$scenario" >/dev/null
+    fi
+    echo "Active scenario: $(current_scenario)"
+}
+
+COMMAND="${1:-}"
+case "$COMMAND" in
+    -h|--help|help)
+        usage
+        exit 0
+        ;;
+    on|off|scenario)
+        require_install
+        guard_local
+        shift
+        "cmd_$COMMAND" "${1:-}"
+        ;;
+    "")
+        usage
+        exit 1
+        ;;
+    *)
+        fail "Unknown subcommand '$COMMAND'. Use: on | off | scenario [<name>]"
+        ;;
+esac

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
     "test": "pest --testsuite=Integration,Browser",
     "test:integration": "pest --testsuite=Integration",
     "test:browser": "pest --testsuite=Browser",
-    "test:docs": "pest --testsuite=Docs"
+    "test:docs": "pest --testsuite=Docs",
+    "demo:on": "bin/demo-store.sh on",
+    "demo:off": "bin/demo-store.sh off",
+    "demo:scenario": "bin/demo-store.sh scenario"
   }
 }

--- a/tests/Browser/Support/ApiMockMuPlugin.php
+++ b/tests/Browser/Support/ApiMockMuPlugin.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Smart Send API mock, installed as a temporary mu-plugin.
+ *
+ * The single source of truth for the fake Smart Send API. Two consumers copy
+ * this file into the store's wp-content/mu-plugins/ directory (as
+ * ss-browser-test-api-mock.php) and remove it again when done:
+ *
+ *  - the Browser/Docs test suites, via ss_browser_install_api_mock() /
+ *    ss_browser_remove_api_mock() in tests/Browser/Support/SmartSendStore.php
+ *  - the manual-testing demo mode, via bin/demo-store.sh (demo:on/demo:off)
+ *
+ * Only active while the ss_test_api_mock option is 'yes'; failure scenarios
+ * are switched on via the ss_test_api_scenario option. The line below is
+ * machine-read by bin/demo-store.sh to validate scenario names - keep it in
+ * sync when adding a scenario ('success' means the option is unset).
+ *
+ * Scenarios: success invalid-token booking-failure no-pickup-points
+ *
+ *  - 'invalid-token'    -> the account/authenticate call returns 401
+ *  - 'booking-failure'  -> the shipments/labels booking call returns 422
+ *                          with a validation message
+ *  - 'no-pickup-points' -> the agents/closest lookup returns an empty data
+ *                          set (no pickup points near the address; the
+ *                          client maps this to the NoResults error)
+ */
+add_filter('pre_http_request', function ($pre, $args, $url) {
+    if (get_option('ss_test_api_mock') !== 'yes' || strpos($url, 'smartsend.io') === false) {
+        return $pre;
+    }
+
+    $respond = function ($body, $code = 200) {
+        return array(
+            'response' => array('code' => $code, 'message' => $code === 200 ? 'OK' : 'Error'),
+            'headers'  => array('content-type' => 'application/json'),
+            'body'     => json_encode($body),
+            'cookies'  => array(),
+            'filename' => null,
+        );
+    };
+
+    $scenario = get_option('ss_test_api_scenario');
+
+    if (strpos($url, 'agents/closest') !== false) {
+        if ($scenario === 'no-pickup-points') {
+            // An empty data set: Smartsend\Client maps this to the NoResults
+            // error - the "no pickup points near the address" case.
+            return $respond(array('data' => array()));
+        }
+
+        return $respond(array('data' => array(
+            array('id' => 1, 'agent_no' => '1234', 'company' => 'Browser Test Shop', 'address_line1' => 'Main Street 1', 'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK', 'distance' => 0.42),
+            array('id' => 2, 'agent_no' => '5678', 'company' => 'Second Test Shop', 'address_line1' => 'Other Street 9', 'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK', 'distance' => 1.2),
+        )));
+    }
+
+    if (strpos($url, 'shipments/labels/combine') !== false) {
+        return $respond(array('data' => array(
+            'pdf' => array('link' => 'https://mock.smartsend.test/labels/combined.pdf', 'base_64_encoded' => base64_encode('%PDF-combo')),
+        )));
+    }
+
+    if (strpos($url, 'shipments/labels') !== false) {
+        if ($scenario === 'booking-failure') {
+            // A validation failure in the shape the real API produces
+            // (message + field errors); the plugin renders it through
+            // Response::errorString() into the meta box error div.
+            return $respond(array(
+                'message' => 'The given data was invalid.',
+                'errors'  => array(
+                    'receiver.zip_code' => array('The receiver zip code does not match the receiver country'),
+                ),
+            ), 422);
+        }
+
+        return $respond(array('data' => array(
+            'shipment_id'  => 'browser-shipment-' . uniqid(),
+            'carrier_name' => 'PostNord',
+            'carrier_code' => 'postnord',
+            'pdf'          => array('link' => 'https://mock.smartsend.test/labels/label.pdf', 'base_64_encoded' => base64_encode('%PDF-label')),
+            'parcels'      => array(
+                array('parcel_internal_id' => 1, 'tracking_code' => 'BROWSERTRACK1', 'tracking_link' => 'https://mock.smartsend.test/track/1'),
+            ),
+        )));
+    }
+
+    if (strpos($url, 'agents/carrier') !== false) {
+        return $respond(array('data' => array(
+            'id' => 1, 'agent_no' => '1234', 'company' => 'Browser Test Shop', 'address_line1' => 'Main Street 1', 'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK',
+        )));
+    }
+
+    // Anything else is the account/authenticate call (the API base URL with
+    // no resource path - Smartsend\Resources\AccountResource::getAuthenticatedUser()).
+    if ($scenario === 'invalid-token') {
+        return $respond(array('message' => 'Invalid API token provided'), 401);
+    }
+
+    return $respond(array('data' => array('id' => 1, 'email' => 'mock@smartsend.test', 'website' => 'localhost')));
+}, 5, 3);

--- a/tests/Browser/Support/SmartSendStore.php
+++ b/tests/Browser/Support/SmartSendStore.php
@@ -55,14 +55,30 @@ function ss_browser_wp_eval(string $code): array
     $snippet = tempnam(sys_get_temp_dir(), 'ss-browser-eval-') . '.php';
     file_put_contents($snippet, "<?php\n" . $code);
 
+    try {
+        return ss_browser_wp_eval_file($snippet);
+    } finally {
+        unlink($snippet);
+    }
+}
+
+/**
+ * Run a PHP snippet file inside the store via WP-CLI eval-file (positional
+ * arguments land in the snippet's $args) and return the decoded JSON the
+ * snippet echoed on its last line. The larger seeding/cleanup snippets live
+ * as files in tests/Browser/Support/Snippets/, shared with bin/demo-store.sh.
+ */
+function ss_browser_wp_eval_file(string $snippet, array $args = []): array
+{
     $command = escapeshellarg(PHP_BINARY)
         . ' -d memory_limit=512M -d error_reporting=0 -d display_errors=0 '
         . escapeshellarg(ss_browser_wp_path() . '/.wp-cli/wp-cli.phar')
         . ' --path=' . escapeshellarg(ss_browser_wp_path())
-        . ' eval-file ' . escapeshellarg($snippet) . ' 2>/dev/null';
+        . ' eval-file ' . escapeshellarg($snippet)
+        . implode('', array_map(fn (string $arg): string => ' ' . escapeshellarg($arg), $args))
+        . ' 2>/dev/null';
 
     $output = shell_exec($command);
-    unlink($snippet);
 
     // WP-CLI may print deprecation noise before the snippet's JSON line.
     $json = null;
@@ -154,19 +170,15 @@ function ss_browser_mu_plugin_path(): string
 }
 
 /**
- * Install the Smart Send API mock as a temporary mu-plugin. Only active
- * while the ss_test_api_mock option is 'yes' (set by ss_browser_seed_store()
- * and removed by ss_browser_cleanup_store()).
+ * Install the Smart Send API mock as a temporary mu-plugin. The mock source
+ * is the shared tests/Browser/Support/ApiMockMuPlugin.php (also installed by
+ * bin/demo-store.sh for manual testing). Only active while the
+ * ss_test_api_mock option is 'yes' (set by ss_browser_seed_store() and
+ * removed by ss_browser_cleanup_store()).
  *
  * Failure scenarios are switched on per test via the ss_test_api_scenario
- * option - see ss_browser_set_api_scenario():
- *
- *  - 'invalid-token'    -> the account/authenticate call returns 401
- *  - 'booking-failure'  -> the shipments/labels booking call returns 422
- *                          with a validation message
- *  - 'no-pickup-points' -> the agents/closest lookup returns an empty data
- *                          set (no pickup points near the address; the
- *                          client maps this to the NoResults error)
+ * option - see ss_browser_set_api_scenario() and the scenario list in the
+ * mock source's header.
  */
 function ss_browser_install_api_mock(): void
 {
@@ -175,89 +187,7 @@ function ss_browser_install_api_mock(): void
         mkdir($mu_dir, 0755, true);
     }
 
-    file_put_contents(ss_browser_mu_plugin_path(), <<<'PHP'
-<?php
-/**
- * Smart Send API mock for the Pest browser tests. Installed temporarily by
- * tests/Browser/Support/SmartSendStore.php and removed again when a test
- * file's afterAll runs. Only active while the ss_test_api_mock option is
- * 'yes'; failure scenarios are switched on via ss_test_api_scenario.
- */
-add_filter('pre_http_request', function ($pre, $args, $url) {
-    if (get_option('ss_test_api_mock') !== 'yes' || strpos($url, 'smartsend.io') === false) {
-        return $pre;
-    }
-
-    $respond = function ($body, $code = 200) {
-        return array(
-            'response' => array('code' => $code, 'message' => $code === 200 ? 'OK' : 'Error'),
-            'headers'  => array('content-type' => 'application/json'),
-            'body'     => json_encode($body),
-            'cookies'  => array(),
-            'filename' => null,
-        );
-    };
-
-    $scenario = get_option('ss_test_api_scenario');
-
-    if (strpos($url, 'agents/closest') !== false) {
-        if ($scenario === 'no-pickup-points') {
-            // An empty data set: Smartsend\Client maps this to the NoResults
-            // error - the "no pickup points near the address" case.
-            return $respond(array('data' => array()));
-        }
-
-        return $respond(array('data' => array(
-            array('id' => 1, 'agent_no' => '1234', 'company' => 'Browser Test Shop', 'address_line1' => 'Main Street 1', 'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK', 'distance' => 0.42),
-            array('id' => 2, 'agent_no' => '5678', 'company' => 'Second Test Shop', 'address_line1' => 'Other Street 9', 'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK', 'distance' => 1.2),
-        )));
-    }
-
-    if (strpos($url, 'shipments/labels/combine') !== false) {
-        return $respond(array('data' => array(
-            'pdf' => array('link' => 'https://mock.smartsend.test/labels/combined.pdf', 'base_64_encoded' => base64_encode('%PDF-combo')),
-        )));
-    }
-
-    if (strpos($url, 'shipments/labels') !== false) {
-        if ($scenario === 'booking-failure') {
-            // A validation failure in the shape the real API produces
-            // (message + field errors); the plugin renders it through
-            // Response::errorString() into the meta box error div.
-            return $respond(array(
-                'message' => 'The given data was invalid.',
-                'errors'  => array(
-                    'receiver.zip_code' => array('The receiver zip code does not match the receiver country'),
-                ),
-            ), 422);
-        }
-
-        return $respond(array('data' => array(
-            'shipment_id'  => 'browser-shipment-' . uniqid(),
-            'carrier_name' => 'PostNord',
-            'carrier_code' => 'postnord',
-            'pdf'          => array('link' => 'https://mock.smartsend.test/labels/label.pdf', 'base_64_encoded' => base64_encode('%PDF-label')),
-            'parcels'      => array(
-                array('parcel_internal_id' => 1, 'tracking_code' => 'BROWSERTRACK1', 'tracking_link' => 'https://mock.smartsend.test/track/1'),
-            ),
-        )));
-    }
-
-    if (strpos($url, 'agents/carrier') !== false) {
-        return $respond(array('data' => array(
-            'id' => 1, 'agent_no' => '1234', 'company' => 'Browser Test Shop', 'address_line1' => 'Main Street 1', 'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK',
-        )));
-    }
-
-    // Anything else is the account/authenticate call (the API base URL with
-    // no resource path - Smartsend\Resources\AccountResource::getAuthenticatedUser()).
-    if ($scenario === 'invalid-token') {
-        return $respond(array('message' => 'Invalid API token provided'), 401);
-    }
-
-    return $respond(array('data' => array('id' => 1, 'email' => 'mock@smartsend.test', 'website' => 'localhost')));
-}, 5, 3);
-PHP);
+    copy(__DIR__ . '/ApiMockMuPlugin.php', ss_browser_mu_plugin_path());
 }
 
 function ss_browser_remove_api_mock(): void
@@ -325,217 +255,33 @@ PHP);
 /**
  * Seed the store fixtures a journey file needs and remember how to undo it.
  *
- * Always: snapshots + replaces the plugin's global settings, activates the
- * API mock, enables Cash on Delivery, ensures a Denmark zone with a Smart
- * Send agent method instance, creates the test product and a classic
- * (shortcode) checkout page.
- *
- * $config:
- *  - 'settings' (array)  merged over the default plugin settings
- *  - 'orders'   (array)  a list of order specs; each spec may set
- *                        'auto_return' => true to enable the method's
- *                        auto-generate-return-label flag on the order.
- *                        Created order ids come back in state 'orders'.
- *
- * The counterpart ss_browser_cleanup_store() restores everything.
+ * The actual seeding lives in Snippets/seed-store.php (shared with
+ * bin/demo-store.sh) - see its header for what is created and the supported
+ * $config keys ('settings', 'orders'). The counterpart
+ * ss_browser_cleanup_store() restores everything.
  */
 function ss_browser_seed_store(array $config = []): array
 {
     ss_browser_install_api_mock();
 
-    $config += ['settings' => [], 'orders' => []];
-    $config_json = var_export(json_encode($config), true);
-
-    $GLOBALS['ss_browser_state'] = ss_browser_wp_eval(<<<PHP
-\$config = json_decode({$config_json}, true);
-
-\$original_settings = get_option('woocommerce_smart_send_shipping_settings');
-update_option('woocommerce_smart_send_shipping_settings', array_merge(array(
-    'demo' => 'yes', 'ss_debug' => 'no', 'include_order_comment' => 'no',
-    'save_shipping_labels_in_uploads' => 'no', 'dropdown_display_format' => '4',
-    'default_select_agent' => 'no', 'order_status' => '0',
-), \$config['settings']));
-update_option('ss_test_api_mock', 'yes');
-delete_option('ss_test_api_scenario');
-
-// Cash on delivery so the checkout can be completed.
-\$cod = get_option('woocommerce_cod_settings', array());
-\$cod_was_enabled = isset(\$cod['enabled']) ? \$cod['enabled'] : 'no';
-\$cod['enabled'] = 'yes';
-update_option('woocommerce_cod_settings', \$cod);
-
-// Denmark zone with a Smart Send agent method instance.
-\$zone_id = 0;
-foreach (WC_Shipping_Zones::get_zones() as \$zone_data) {
-    foreach (\$zone_data['zone_locations'] as \$location) {
-        if (\$location->code === 'DK') {
-            \$zone_id = \$zone_data['id'];
-            break 2;
-        }
-    }
-}
-if (!\$zone_id) {
-    \$zone = new WC_Shipping_Zone();
-    \$zone->set_zone_name('Denmark');
-    \$zone->set_zone_locations(array((object) array('code' => 'DK', 'type' => 'country')));
-    \$zone->save();
-    \$zone_id = \$zone->get_id();
-}
-\$zone = new WC_Shipping_Zone(\$zone_id);
-\$instance_id = 0;
-foreach (\$zone->get_shipping_methods() as \$iid => \$method) {
-    if (\$method->id === 'smart_send_shipping') {
-        \$instance_id = \$iid;
-        break;
-    }
-}
-\$created_instance = 0;
-if (!\$instance_id) {
-    \$instance_id = \$zone->add_shipping_method('smart_send_shipping');
-    \$created_instance = 1;
-}
-update_option('woocommerce_smart_send_shipping_' . \$instance_id . '_settings', array(
-    'title' => 'Smart Send Pickup Point',
-    'method' => 'postnord_agent',
-    'return_method' => 'postnord_returndropoff',
-    'auto_generate_return_label' => 'no',
-    'tax_status' => 'none',
-    'requires' => '',
-    'flatfee_cost' => '0',
-    'min_amount' => '0',
-    'advanced_settings_enable' => 'no',
-    'cost_weight' => array(array('ss_min_weight' => '', 'ss_max_weight' => '', 'ss_cost_weight' => '29')),
-));
-
-// The zone must offer a second rate, ordered before the Smart Send one:
-// with a single available rate WooCommerce's classic checkout renders the
-// method as a hidden input instead of a radio (so the checkout test's
-// click can never succeed), and with Smart Send preselected the radio
-// click fires no change event (so the pickup dropdown never renders).
-// CI's store always has the setup script's Flat rate first; enforce the
-// same shape here for stores that have drifted.
-\$flat_instance = 0;
-\$created_flat = 0;
-foreach (\$zone->get_shipping_methods() as \$iid => \$method) {
-    if (\$method->id === 'flat_rate') {
-        \$flat_instance = \$iid;
-        break;
-    }
-}
-if (!\$flat_instance) {
-    \$flat_instance = \$zone->add_shipping_method('flat_rate');
-    \$created_flat = 1;
-    update_option('woocommerce_flat_rate_' . \$flat_instance . '_settings', array('title' => 'Flat rate', 'cost' => '39'));
-}
-global \$wpdb;
-\$wpdb->update("{\$wpdb->prefix}woocommerce_shipping_zone_methods", array('method_order' => 1), array('instance_id' => \$flat_instance));
-\$wpdb->update("{\$wpdb->prefix}woocommerce_shipping_zone_methods", array('method_order' => 2), array('instance_id' => \$instance_id));
-
-// A classic (shortcode) checkout page; the pickup point selector only
-// renders in the classic checkout.
-\$page_id = wp_insert_post(array(
-    'post_title'   => 'SS Classic Checkout',
-    'post_name'    => 'ss-classic-checkout',
-    'post_content' => '[woocommerce_checkout]',
-    'post_status'  => 'publish',
-    'post_type'    => 'page',
-));
-\$original_checkout_page = get_option('woocommerce_checkout_page_id');
-update_option('woocommerce_checkout_page_id', \$page_id);
-
-// A product to buy.
-\$product_id = wc_get_product_id_by_sku('SS-BROWSER-TEST');
-if (!\$product_id) {
-    \$product = new WC_Product_Simple();
-    \$product->set_name('SS Browser Test Product');
-    \$product->set_sku('SS-BROWSER-TEST');
-    \$product->set_regular_price('100');
-    \$product->set_weight('1');
-    \$product->save();
-    \$product_id = \$product->get_id();
-}
-
-// Orders for the admin label tests, built like checkout would build them.
-\$make_order = function (\$spec) use (\$product_id) {
-    \$auto_return = !empty(\$spec['auto_return']);
-    \$order = wc_create_order(array('status' => 'processing', 'created_via' => 'ss-browser-test'));
-    \$order->add_product(wc_get_product(\$product_id), 1);
-    \$address = array(
-        'first_name' => 'Browser', 'last_name' => 'Test', 'address_1' => 'Islands Brygge 39',
-        'city' => 'Copenhagen', 'postcode' => '2300', 'country' => 'DK',
+    $GLOBALS['ss_browser_state'] = ss_browser_wp_eval_file(
+        __DIR__ . '/Snippets/seed-store.php',
+        [json_encode($config)]
     );
-    \$order->set_address(array_merge(\$address, array('email' => 'ss-browser-test@smartsend.io', 'phone' => '+4512345678')), 'billing');
-    \$order->set_address(\$address, 'shipping');
-    \$item = new WC_Order_Item_Shipping();
-    \$item->set_method_title('Smart Send Pickup Point');
-    \$item->set_method_id('smart_send_shipping');
-    \$item->set_instance_id(1);
-    \$item->set_total('29');
-    \$item->add_meta_data('smart_send_shipping_method', 'postnord_agent', true);
-    \$item->add_meta_data('smart_send_return_method', 'postnord_returndropoff', true);
-    \$item->add_meta_data('smart_send_auto_generate_return_label', \$auto_return ? 'yes' : 'no', true);
-    \$order->add_item(\$item);
-    \$order->calculate_totals();
-    \$order->update_meta_data('ss_shipping_order_agent_no', '1234');
-    \$order->update_meta_data('_ss_shipping_order_agent', (object) array(
-        'id' => 1, 'agent_no' => '1234', 'company' => 'Browser Test Shop', 'address_line1' => 'Main Street 1',
-        'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK',
-    ));
-    \$order->save();
-    return \$order->get_id();
-};
-\$order_ids = array();
-foreach (\$config['orders'] as \$spec) {
-    \$order_ids[] = \$make_order(is_array(\$spec) ? \$spec : array());
-}
-
-\$hpos = Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
-
-\$state = array(
-    'original_settings'      => \$original_settings === false ? null : \$original_settings,
-    'zone_id'                => \$zone_id,
-    'instance_id'            => \$instance_id,
-    'created_instance'       => \$created_instance,
-    'flat_instance'          => \$flat_instance,
-    'created_flat'           => \$created_flat,
-    'checkout_page_id'       => \$page_id,
-    'original_checkout_page' => \$original_checkout_page,
-    'cod_was_enabled'        => \$cod_was_enabled,
-    'product_id'             => \$product_id,
-    'orders'                 => \$order_ids,
-    'orders_list_path'       => \$hpos ? '/wp-admin/admin.php?page=wc-orders' : '/wp-admin/edit.php?post_type=shop_order',
-    'hpos'                   => \$hpos ? 1 : 0,
-);
-update_option('ss_browser_test_state', \$state);
-echo json_encode(\$state);
-PHP);
 
     return $GLOBALS['ss_browser_state'];
 }
 
 /**
  * Create a page carrying the Checkout block, alongside the classic
- * (shortcode) checkout page ss_browser_seed_store() sets up - both
- * checkouts coexist against the same store. The stock minimal markup (the
- * same WC_Install writes for a fresh store's checkout page) is enough: the
- * Checkout block force-renders every registered inner block - including the
- * Smart Send pickup point block - when it is missing from the saved
- * content. WooCommerce's checkout page setting stays on the classic page,
- * so the post-purchase redirect exercises the same thank-you rendering as
- * the classic journey.
+ * (shortcode) checkout page ss_browser_seed_store() sets up - see
+ * Snippets/create-block-checkout-page.php (shared with bin/demo-store.sh)
+ * for the rationale. The caller tracks the returned page id and removes the
+ * page again via ss_browser_delete_block_checkout_page().
  */
 function ss_browser_create_block_checkout_page(): int
 {
-    $result = ss_browser_wp_eval(<<<'PHP'
-$page_id = wp_insert_post(array(
-    'post_title'   => 'SS Block Checkout',
-    'post_name'    => 'ss-block-checkout',
-    'post_content' => '<!-- wp:woocommerce/checkout --><div class="wp-block-woocommerce-checkout"></div><!-- /wp:woocommerce/checkout -->',
-    'post_status'  => 'publish',
-    'post_type'    => 'page',
-));
-echo json_encode(array('page_id' => $page_id));
-PHP);
+    $result = ss_browser_wp_eval_file(__DIR__ . '/Snippets/create-block-checkout-page.php');
 
     return (int) $result['page_id'];
 }
@@ -547,9 +293,10 @@ function ss_browser_delete_block_checkout_page(int $page_id): void
 }
 
 /**
- * Undo ss_browser_seed_store(): delete the fixture orders (both the seeded
- * ones and any placed by a checkout test run), the checkout page and the
- * product, restore the settings/COD/zone state and deactivate the mock.
+ * Undo ss_browser_seed_store(): runs Snippets/cleanup-store.php (shared with
+ * bin/demo-store.sh) - fixture orders, checkout page and product deleted,
+ * settings/COD/zone state restored, mock deactivated - then removes the
+ * mu-plugin mock file.
  */
 function ss_browser_cleanup_store(): void
 {
@@ -557,55 +304,7 @@ function ss_browser_cleanup_store(): void
         return;
     }
 
-    ss_browser_wp_eval(<<<'PHP'
-$state = get_option('ss_browser_test_state', array());
-
-// Orders created by the admin fixtures and by the checkout test run.
-$fixture_orders = wc_get_orders(array('created_via' => 'ss-browser-test', 'limit' => -1));
-$checkout_orders = wc_get_orders(array('billing_email' => 'ss-browser-test@smartsend.io', 'limit' => -1));
-foreach (array_merge($fixture_orders, $checkout_orders) as $order) {
-    $order->delete(true);
-}
-
-if (!empty($state['created_instance']) && !empty($state['zone_id'])) {
-    $zone = new WC_Shipping_Zone($state['zone_id']);
-    $zone->delete_shipping_method($state['instance_id']);
-}
-if (!empty($state['created_flat']) && !empty($state['zone_id'])) {
-    $zone = new WC_Shipping_Zone($state['zone_id']);
-    $zone->delete_shipping_method($state['flat_instance']);
-}
-
-if (!empty($state['checkout_page_id'])) {
-    wp_delete_post($state['checkout_page_id'], true);
-}
-if (isset($state['original_checkout_page'])) {
-    update_option('woocommerce_checkout_page_id', $state['original_checkout_page']);
-}
-
-if (($state['cod_was_enabled'] ?? 'no') !== 'yes') {
-    $cod = get_option('woocommerce_cod_settings', array());
-    $cod['enabled'] = $state['cod_was_enabled'] ?? 'no';
-    update_option('woocommerce_cod_settings', $cod);
-}
-
-$product_id = wc_get_product_id_by_sku('SS-BROWSER-TEST');
-if ($product_id) {
-    $product = wc_get_product($product_id);
-    $product->delete(true);
-}
-
-if (empty($state['original_settings'])) {
-    delete_option('woocommerce_smart_send_shipping_settings');
-} else {
-    update_option('woocommerce_smart_send_shipping_settings', $state['original_settings']);
-}
-
-delete_option('ss_test_api_mock');
-delete_option('ss_test_api_scenario');
-delete_option('ss_browser_test_state');
-echo json_encode(array('cleaned' => true));
-PHP);
+    ss_browser_wp_eval_file(__DIR__ . '/Snippets/cleanup-store.php');
 
     ss_browser_remove_api_mock();
 

--- a/tests/Browser/Support/Snippets/cleanup-store.php
+++ b/tests/Browser/Support/Snippets/cleanup-store.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Undo seed-store.php. Run inside the store via WP-CLI:
+ *
+ *   wp eval-file cleanup-store.php [<state option name>]
+ *
+ * Shared between tests/Browser/Support/SmartSendStore.php
+ * (ss_browser_cleanup_store()) and bin/demo-store.sh (demo:off). Reads the
+ * state seed-store.php stored in the given wp option (default
+ * ss_browser_test_state), then: deletes the fixture orders (both the seeded
+ * ones and any placed through the seeded checkout - matched on the fixture
+ * billing email), the seeded checkout page(s) and the seeded product,
+ * restores the plugin settings / COD / checkout-page option, removes the
+ * zone method instances only when the seeding created them, and deactivates
+ * the mock options. It never deletes zones, products, pages or orders it did
+ * not create itself. The mu-plugin mock file is removed by the caller.
+ */
+
+$state_option = isset($args[0]) ? $args[0] : 'ss_browser_test_state';
+$state = get_option($state_option, array());
+
+// Orders created by the admin fixtures and by the checkout test run.
+$fixture_orders = wc_get_orders(array('created_via' => 'ss-browser-test', 'limit' => -1));
+$checkout_orders = wc_get_orders(array('billing_email' => 'ss-browser-test@smartsend.io', 'limit' => -1));
+foreach (array_merge($fixture_orders, $checkout_orders) as $order) {
+    $order->delete(true);
+}
+
+if (!empty($state['created_instance']) && !empty($state['zone_id'])) {
+    $zone = new WC_Shipping_Zone($state['zone_id']);
+    $zone->delete_shipping_method($state['instance_id']);
+}
+if (!empty($state['created_flat']) && !empty($state['zone_id'])) {
+    $zone = new WC_Shipping_Zone($state['zone_id']);
+    $zone->delete_shipping_method($state['flat_instance']);
+}
+
+if (!empty($state['checkout_page_id'])) {
+    wp_delete_post($state['checkout_page_id'], true);
+}
+if (!empty($state['block_checkout_page_id'])) {
+    wp_delete_post($state['block_checkout_page_id'], true);
+}
+if (isset($state['original_checkout_page'])) {
+    update_option('woocommerce_checkout_page_id', $state['original_checkout_page']);
+}
+
+if (($state['cod_was_enabled'] ?? 'no') !== 'yes') {
+    $cod = get_option('woocommerce_cod_settings', array());
+    $cod['enabled'] = $state['cod_was_enabled'] ?? 'no';
+    update_option('woocommerce_cod_settings', $cod);
+}
+
+$product_id = wc_get_product_id_by_sku('SS-BROWSER-TEST');
+if ($product_id) {
+    $product = wc_get_product($product_id);
+    $product->delete(true);
+}
+
+if (empty($state['original_settings'])) {
+    delete_option('woocommerce_smart_send_shipping_settings');
+} else {
+    update_option('woocommerce_smart_send_shipping_settings', $state['original_settings']);
+}
+
+delete_option('ss_test_api_mock');
+delete_option('ss_test_api_scenario');
+delete_option($state_option);
+echo json_encode(array('cleaned' => true));

--- a/tests/Browser/Support/Snippets/create-block-checkout-page.php
+++ b/tests/Browser/Support/Snippets/create-block-checkout-page.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Create a page carrying the Checkout block, alongside the classic
+ * (shortcode) checkout page seed-store.php sets up - both checkouts coexist
+ * against the same store. Run inside the store via WP-CLI:
+ *
+ *   wp eval-file create-block-checkout-page.php [<state option name>]
+ *
+ * The stock minimal markup (the same WC_Install writes for a fresh store's
+ * checkout page) is enough: the Checkout block force-renders every
+ * registered inner block - including the Smart Send pickup point block -
+ * when it is missing from the saved content. WooCommerce's checkout page
+ * setting stays on the classic page, so the post-purchase redirect exercises
+ * the same thank-you rendering as the classic journey.
+ *
+ * Shared between tests/Browser/Support/SmartSendStore.php
+ * (ss_browser_create_block_checkout_page()) and bin/demo-store.sh (demo:on).
+ * When a state option name is given, the page id is recorded into that
+ * option's state array as 'block_checkout_page_id' so cleanup-store.php
+ * deletes the page (the tests instead track the id themselves and delete it
+ * per test file). Echoes {"page_id": ...} on the last line.
+ */
+
+$page_id = wp_insert_post(array(
+    'post_title'   => 'SS Block Checkout',
+    'post_name'    => 'ss-block-checkout',
+    'post_content' => '<!-- wp:woocommerce/checkout --><div class="wp-block-woocommerce-checkout"></div><!-- /wp:woocommerce/checkout -->',
+    'post_status'  => 'publish',
+    'post_type'    => 'page',
+));
+
+if (isset($args[0])) {
+    $state = get_option($args[0], array());
+    $state['block_checkout_page_id'] = $page_id;
+    update_option($args[0], $state);
+}
+
+echo json_encode(array('page_id' => $page_id));

--- a/tests/Browser/Support/Snippets/seed-store.php
+++ b/tests/Browser/Support/Snippets/seed-store.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Seed the store fixtures the Browser suite journeys (and the manual-testing
+ * demo mode) build on. Run inside the store via WP-CLI:
+ *
+ *   wp eval-file seed-store.php '<config json>' [<state option name>]
+ *
+ * Shared between tests/Browser/Support/SmartSendStore.php
+ * (ss_browser_seed_store()) and bin/demo-store.sh (demo:on) - the single
+ * source of truth for what "a store exercising the Smart Send plugin against
+ * the mocked API" looks like. Echoes the resulting state as JSON on the last
+ * line and stores it in the given wp option (default ss_browser_test_state)
+ * so cleanup-store.php can undo everything.
+ *
+ * Always: snapshots + replaces the plugin's global settings, activates the
+ * API mock (the mu-plugin file itself is copied in by the caller), enables
+ * Cash on Delivery, ensures a Denmark zone with a Smart Send agent method
+ * instance ordered after a Flat rate, creates the test product and a classic
+ * (shortcode) checkout page.
+ *
+ * Config keys:
+ *  - 'settings' (array)  merged over the default plugin settings
+ *  - 'orders'   (array)  a list of order specs; each spec may set
+ *                        'auto_return' => true to enable the method's
+ *                        auto-generate-return-label flag on the order.
+ *                        Created order ids come back in state 'orders'.
+ */
+
+$config = json_decode(isset($args[0]) ? $args[0] : '{}', true);
+$config = is_array($config) ? $config : array();
+$config += array('settings' => array(), 'orders' => array());
+$state_option = isset($args[1]) ? $args[1] : 'ss_browser_test_state';
+
+$original_settings = get_option('woocommerce_smart_send_shipping_settings');
+update_option('woocommerce_smart_send_shipping_settings', array_merge(array(
+    'demo' => 'yes', 'ss_debug' => 'no', 'include_order_comment' => 'no',
+    'save_shipping_labels_in_uploads' => 'no', 'dropdown_display_format' => '4',
+    'default_select_agent' => 'no', 'order_status' => '0',
+), $config['settings']));
+update_option('ss_test_api_mock', 'yes');
+delete_option('ss_test_api_scenario');
+
+// Cash on delivery so the checkout can be completed.
+$cod = get_option('woocommerce_cod_settings', array());
+$cod_was_enabled = isset($cod['enabled']) ? $cod['enabled'] : 'no';
+$cod['enabled'] = 'yes';
+update_option('woocommerce_cod_settings', $cod);
+
+// Denmark zone with a Smart Send agent method instance.
+$zone_id = 0;
+foreach (WC_Shipping_Zones::get_zones() as $zone_data) {
+    foreach ($zone_data['zone_locations'] as $location) {
+        if ($location->code === 'DK') {
+            $zone_id = $zone_data['id'];
+            break 2;
+        }
+    }
+}
+if (!$zone_id) {
+    $zone = new WC_Shipping_Zone();
+    $zone->set_zone_name('Denmark');
+    $zone->set_zone_locations(array((object) array('code' => 'DK', 'type' => 'country')));
+    $zone->save();
+    $zone_id = $zone->get_id();
+}
+$zone = new WC_Shipping_Zone($zone_id);
+$instance_id = 0;
+foreach ($zone->get_shipping_methods() as $iid => $method) {
+    if ($method->id === 'smart_send_shipping') {
+        $instance_id = $iid;
+        break;
+    }
+}
+$created_instance = 0;
+if (!$instance_id) {
+    $instance_id = $zone->add_shipping_method('smart_send_shipping');
+    $created_instance = 1;
+}
+update_option('woocommerce_smart_send_shipping_' . $instance_id . '_settings', array(
+    'title' => 'Smart Send Pickup Point',
+    'method' => 'postnord_agent',
+    'return_method' => 'postnord_returndropoff',
+    'auto_generate_return_label' => 'no',
+    'tax_status' => 'none',
+    'requires' => '',
+    'flatfee_cost' => '0',
+    'min_amount' => '0',
+    'advanced_settings_enable' => 'no',
+    'cost_weight' => array(array('ss_min_weight' => '', 'ss_max_weight' => '', 'ss_cost_weight' => '29')),
+));
+
+// The zone must offer a second rate, ordered before the Smart Send one:
+// with a single available rate WooCommerce's classic checkout renders the
+// method as a hidden input instead of a radio (so the checkout test's
+// click can never succeed), and with Smart Send preselected the radio
+// click fires no change event (so the pickup dropdown never renders).
+// CI's store always has the setup script's Flat rate first; enforce the
+// same shape here for stores that have drifted.
+$flat_instance = 0;
+$created_flat = 0;
+foreach ($zone->get_shipping_methods() as $iid => $method) {
+    if ($method->id === 'flat_rate') {
+        $flat_instance = $iid;
+        break;
+    }
+}
+if (!$flat_instance) {
+    $flat_instance = $zone->add_shipping_method('flat_rate');
+    $created_flat = 1;
+    update_option('woocommerce_flat_rate_' . $flat_instance . '_settings', array('title' => 'Flat rate', 'cost' => '39'));
+}
+global $wpdb;
+$wpdb->update("{$wpdb->prefix}woocommerce_shipping_zone_methods", array('method_order' => 1), array('instance_id' => $flat_instance));
+$wpdb->update("{$wpdb->prefix}woocommerce_shipping_zone_methods", array('method_order' => 2), array('instance_id' => $instance_id));
+
+// A classic (shortcode) checkout page; the pickup point selector only
+// renders in the classic checkout.
+$page_id = wp_insert_post(array(
+    'post_title'   => 'SS Classic Checkout',
+    'post_name'    => 'ss-classic-checkout',
+    'post_content' => '[woocommerce_checkout]',
+    'post_status'  => 'publish',
+    'post_type'    => 'page',
+));
+$original_checkout_page = get_option('woocommerce_checkout_page_id');
+update_option('woocommerce_checkout_page_id', $page_id);
+
+// A product to buy.
+$product_id = wc_get_product_id_by_sku('SS-BROWSER-TEST');
+if (!$product_id) {
+    $product = new WC_Product_Simple();
+    $product->set_name('SS Browser Test Product');
+    $product->set_sku('SS-BROWSER-TEST');
+    $product->set_regular_price('100');
+    $product->set_weight('1');
+    $product->save();
+    $product_id = $product->get_id();
+}
+
+// Orders for the admin label tests, built like checkout would build them.
+$make_order = function ($spec) use ($product_id) {
+    $auto_return = !empty($spec['auto_return']);
+    $order = wc_create_order(array('status' => 'processing', 'created_via' => 'ss-browser-test'));
+    $order->add_product(wc_get_product($product_id), 1);
+    $address = array(
+        'first_name' => 'Browser', 'last_name' => 'Test', 'address_1' => 'Islands Brygge 39',
+        'city' => 'Copenhagen', 'postcode' => '2300', 'country' => 'DK',
+    );
+    $order->set_address(array_merge($address, array('email' => 'ss-browser-test@smartsend.io', 'phone' => '+4512345678')), 'billing');
+    $order->set_address($address, 'shipping');
+    $item = new WC_Order_Item_Shipping();
+    $item->set_method_title('Smart Send Pickup Point');
+    $item->set_method_id('smart_send_shipping');
+    $item->set_instance_id(1);
+    $item->set_total('29');
+    $item->add_meta_data('smart_send_shipping_method', 'postnord_agent', true);
+    $item->add_meta_data('smart_send_return_method', 'postnord_returndropoff', true);
+    $item->add_meta_data('smart_send_auto_generate_return_label', $auto_return ? 'yes' : 'no', true);
+    $order->add_item($item);
+    $order->calculate_totals();
+    $order->update_meta_data('ss_shipping_order_agent_no', '1234');
+    $order->update_meta_data('_ss_shipping_order_agent', (object) array(
+        'id' => 1, 'agent_no' => '1234', 'company' => 'Browser Test Shop', 'address_line1' => 'Main Street 1',
+        'address_line2' => null, 'postal_code' => '2300', 'city' => 'Copenhagen', 'country' => 'DK',
+    ));
+    $order->save();
+    return $order->get_id();
+};
+$order_ids = array();
+foreach ($config['orders'] as $spec) {
+    $order_ids[] = $make_order(is_array($spec) ? $spec : array());
+}
+
+$hpos = Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+
+$state = array(
+    'original_settings'      => $original_settings === false ? null : $original_settings,
+    'zone_id'                => $zone_id,
+    'instance_id'            => $instance_id,
+    'created_instance'       => $created_instance,
+    'flat_instance'          => $flat_instance,
+    'created_flat'           => $created_flat,
+    'checkout_page_id'       => $page_id,
+    'original_checkout_page' => $original_checkout_page,
+    'cod_was_enabled'        => $cod_was_enabled,
+    'product_id'             => $product_id,
+    'orders'                 => $order_ids,
+    'orders_list_path'       => $hpos ? '/wp-admin/admin.php?page=wc-orders' : '/wp-admin/edit.php?post_type=shop_order',
+    'hpos'                   => $hpos ? 1 : 0,
+);
+update_option($state_option, $state);
+echo json_encode($state);


### PR DESCRIPTION
## What

A "demo mode" for manual testing: put the local development store into the same state the Browser suite runs against — the Smart Send API mock, a Denmark zone with a Smart Send agent method, a sample product and both checkout pages — and leave it on until turned off.

```
composer demo:on                             # seed store state + install the API mock; prints URLs + admin creds
composer demo:off                            # remove the mock, restore/clean what demo:on changed
composer demo:scenario -- no-pickup-points   # flip the mock scenario (success | invalid-token | booking-failure | no-pickup-points)
```

## How

**One source of truth, no duplication** (commit 1, pure refactor): the mu-plugin API mock now lives as a standalone file `tests/Browser/Support/ApiMockMuPlugin.php`, and the seeding/cleanup/block-checkout-page logic as WP-CLI `eval-file` snippets under `tests/Browser/Support/Snippets/`. `SmartSendStore.php` copies/runs those via the new `ss_browser_wp_eval_file()` helper instead of embedding them as heredocs — the test helpers' behaviour is unchanged.

**`bin/demo-store.sh`** (commit 2) mirrors `bin/setup-local-dev.sh`'s conventions (`WP_DEV_PATH`, the pinned `wp-cli.phar`) and reuses the exact same shared sources under its own state option (`ss_demo_state`), so demo mode and a test run never clobber each other's undo state. Scenario names are machine-read from the mock source's `* Scenarios:` header line, so a new scenario added to the mock is automatically accepted. Safety: refuses to run when the install is missing, when `WP_ENVIRONMENT_TYPE` is `production`, or when the site URL is not localhost.

`demo:off` follows the test cleanup's remove-vs-keep contract (documented in the script header and `Snippets/cleanup-store.php`): only what the seeding created is deleted; zones, products, pages and orders a developer built on top are left alone. Both `demo:on` and `demo:off` are idempotent.

## Testing

- Integration: 228 passed
- Browser: 15 passed (run again after the exact smoke sequence `demo:on && demo:off` — stays green)
- Smoke-tested: `demo:on`, `demo:on` again (idempotent), `demo:scenario` (list), `demo:scenario no-pickup-points`, `demo:scenario bogus` (rejected, exit 1), `demo:scenario success`, both checkout pages reachable, `demo:off`, `demo:off` again (idempotent)
- `vendor/bin/phpcs` exit 0, `composer phpcs:compat` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)