### PR TITLE
Patch pest-plugin-browser's PHP 8.4+ deprecation noise at the source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,43 +1,52 @@
 {
-  "name": "smartsend/woocommerce",
-  "description": "Smart Send plugin for WooCommerce",
-  "minimum-stability": "stable",
-  "license": "proprietary",
-  "authors": [
-    {
-      "name": "Smart Send",
-      "email": "support@smartsend.io"
-    }
-  ],
-  "require-dev": {
-    "squizlabs/php_codesniffer": "^3.10",
-    "wp-coding-standards/wpcs": "^3.1",
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-    "digitalrevolution/php-codesniffer-baseline": "^1.0",
-    "pestphp/pest": "^4.0",
-    "pestphp/pest-plugin-browser": "^4.0",
-    "phpcompatibility/phpcompatibility-wp": "^2.1"
-  },
-  "config": {
-    "platform": {
-      "php": "8.3.0"
+    "name": "smartsend/woocommerce",
+    "description": "Smart Send plugin for WooCommerce",
+    "minimum-stability": "stable",
+    "license": "proprietary",
+    "authors": [
+        {
+            "name": "Smart Send",
+            "email": "support@smartsend.io"
+        }
+    ],
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^3.10",
+        "wp-coding-standards/wpcs": "^3.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "digitalrevolution/php-codesniffer-baseline": "^1.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-browser": "^4.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
+        "cweagans/composer-patches": "^2.0"
     },
-    "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true,
-      "digitalrevolution/php-codesniffer-baseline": true,
-      "pestphp/pest-plugin": true
+    "config": {
+        "platform": {
+            "php": "8.3.0"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "digitalrevolution/php-codesniffer-baseline": true,
+            "pestphp/pest-plugin": true,
+            "cweagans/composer-patches": true
+        }
+    },
+    "scripts": {
+        "phpcs": "phpcs",
+        "phpcs:compat": "phpcs --standard=phpcs.compat.xml.dist",
+        "phpcs:fix": "phpcbf",
+        "test": "pest --testsuite=Integration,Browser",
+        "test:integration": "pest --testsuite=Integration",
+        "test:browser": "pest --testsuite=Browser",
+        "test:docs": "pest --testsuite=Docs",
+        "demo:on": "bin/demo-store.sh on",
+        "demo:off": "bin/demo-store.sh off",
+        "demo:scenario": "bin/demo-store.sh scenario"
+    },
+    "extra": {
+        "patches": {
+            "pestphp/pest-plugin-browser": {
+                "Fix PHP 8.4+ ReflectionProperty::setValue() deprecation (static property needs null, upstream unfixed as of v5.0.1)": "patches/pest-plugin-browser-static-setvalue.patch"
+            }
+        }
     }
-  },
-  "scripts": {
-    "phpcs": "phpcs",
-    "phpcs:compat": "phpcs --standard=phpcs.compat.xml.dist",
-    "phpcs:fix": "phpcbf",
-    "test": "pest --testsuite=Integration,Browser",
-    "test:integration": "pest --testsuite=Integration",
-    "test:browser": "pest --testsuite=Browser",
-    "test:docs": "pest --testsuite=Docs",
-    "demo:on": "bin/demo-store.sh on",
-    "demo:off": "bin/demo-store.sh off",
-    "demo:scenario": "bin/demo-store.sh scenario"
-  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c246f512c1f089350f791fb8a235bdc3",
+    "content-hash": "6838c4c4678868b764a2bd5f4e6913bc",
     "packages": [],
     "packages-dev": [
         {
@@ -1471,6 +1471,129 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "cweagans/composer-configurable-plugin",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-configurable-plugin.git",
+                "reference": "15433906511a108a1806710e988629fd24b89974"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-configurable-plugin/zipball/15433906511a108a1806710e988629fd24b89974",
+                "reference": "15433906511a108a1806710e988629fd24b89974",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "require-dev": {
+                "codeception/codeception": "~4.0",
+                "codeception/module-asserts": "^2.0",
+                "composer/composer": "~2.0",
+                "php-coveralls/php-coveralls": "~2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0.0",
+                "phpro/grumphp": "^1.8.0",
+                "sebastian/phpcpd": "^6.0",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a lightweight configuration system for Composer plugins.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-configurable-plugin/issues",
+                "source": "https://github.com/cweagans/composer-configurable-plugin/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/cweagans",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-12T04:58:58+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "bfa6018a5f864653d9ed899b902ea72f858a2cf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/bfa6018a5f864653d9ed899b902ea72f858a2cf7",
+                "reference": "bfa6018a5f864653d9ed899b902ea72f858a2cf7",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "cweagans/composer-configurable-plugin": "^2.0",
+                "ext-json": "*",
+                "php": ">=8.0.0"
+            },
+            "require-dev": {
+                "codeception/codeception": "~4.0",
+                "codeception/module-asserts": "^2.0",
+                "codeception/module-cli": "^2.0",
+                "codeception/module-filesystem": "^2.0",
+                "composer/composer": "~2.0",
+                "php-coveralls/php-coveralls": "~2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0.0",
+                "phpro/grumphp": "^1.8.0",
+                "sebastian/phpcpd": "^6.0",
+                "squizlabs/php_codesniffer": "^4.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "_": "The following two lines ensure that composer-patches is loaded as early as possible.",
+                "class": "cweagans\\Composer\\Plugin\\Patches",
+                "plugin-modifies-downloads": true,
+                "plugin-modifies-install-path": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/cweagans",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-30T23:44:22+00:00"
         },
         {
             "name": "daverandom/libdns",

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,0 +1,17 @@
+{
+    "_hash": "b8e6dfeeda1611262f8b47ca3b085451f3585a8574a19458025cf0b7d87090fe",
+    "patches": {
+        "pestphp/pest-plugin-browser": [
+            {
+                "package": "pestphp/pest-plugin-browser",
+                "description": "Fix PHP 8.4+ ReflectionProperty::setValue() deprecation (static property needs null, upstream unfixed as of v5.0.1)",
+                "url": "patches/pest-plugin-browser-static-setvalue.patch",
+                "sha256": "30f3ef4b1f7e8f56b04e64b74eb31514f1e2c6e71cb9db80fefe88fb38504e92",
+                "depth": 1,
+                "extra": {
+                    "provenance": "root"
+                }
+            }
+        ]
+    }
+}

--- a/patches/pest-plugin-browser-static-setvalue.patch
+++ b/patches/pest-plugin-browser-static-setvalue.patch
@@ -1,0 +1,10 @@
+--- a/src/Execution.php
++++ b/src/Execution.php
+@@ -172,6 +172,6 @@
+         $property = $reflector->getProperty('count');
+ 
+         // @phpstan-ignore-next-line
+-        $property->setValue(Assert::class, $originalCount);
++        $property->setValue(null, $originalCount);
+     }
+ }


### PR DESCRIPTION
## Summary
Every Docs/Browser run on PHP 8.4+ showed `DEPR`/`!` flags from `vendor/pestphp/pest-plugin-browser/src/Execution.php:175` calling `ReflectionProperty::setValue(Assert::class, ...)` — deprecated since PHP 8.4 (statics need `null` or an object). 

**Why a vendor patch instead of config**: PHPUnit's `<source ignoreIndirectDeprecations>` mechanism classifies these correctly (verified via `--log-events-verbose-text`: "triggered by third-party code") and its IssueFilter drops them — but Pest's output is rendered by Collision, whose printer marks tests `DEPRECATED` from the raw event stream without consulting PHPUnit's source configuration at all. No configuration can fix the displayed status; upstream (v5.0.1 and the 5.x branch) still has the bug. So: `cweagans/composer-patches` + a one-line patch changing the first argument to `null`.

## Test plan
- [x] Full Docs suite on PHP 8.5: **13 passed, zero DEPR flags** (was 8 flagged)
- [x] Integration: 228 passed
- [x] Patch applies on `composer install`/`reinstall` (patches.lock.json committed; plugin allow-listed in composer.json)

Consider upstreaming: the same one-liner fixes it for pestphp/pest-plugin-browser.
🤖 Generated with [Claude Code](https://claude.com/claude-code)