### PR TITLE
Fix composer test OOM: raise test memory_limit to 512M

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,17 @@
          colors="true"
          failOnWarning="false"
 >
+    <!--
+        The combined `composer test` run (Integration's in-process WordPress
+        plus the Browser suite's Playwright client) exceeds the default CLI
+        128M memory_limit and dies with PHPUnit's opaque "Premature end of
+        PHPUnit's PHP process" at the suite boundary. 512M matches the
+        memory limit the README's store-server command uses.
+    -->
+    <php>
+        <ini name="memory_limit" value="512M"/>
+    </php>
+
     <testsuites>
         <testsuite name="Integration">
             <directory>tests/Integration</directory>


### PR DESCRIPTION
## Summary
`composer test` (Integration + Browser combined) died at the suite boundary with PHPUnit's opaque *"Premature end of PHPUnit's PHP process"*. Root cause: **OOM** — the in-process WordPress from 228 integration tests plus the Playwright client boot exceeds the CLI's default 128M `memory_limit`. The real message was invisible because WordPress forces `display_errors` off and PHPUnit redirects `error_log` into a private tmpfile (recovered it with a shutdown-hook trap: `Allowed memory size of 134217728 bytes exhausted` in the browser plugin's InitScript).

Fix: `memory_limit=512M` in `phpunit.xml.dist` (matching the README's store-server limit). Standalone suites and CI were never affected — each suite fits 128M alone and CI runs them as separate jobs.

## Test plan
- [x] `composer test`: was exit 2 at the boundary → now **255 passed, exit 0, ~83s**
- [x] Individual suites unaffected
🤖 Generated with [Claude Code](https://claude.com/claude-code)