### PR TITLE
Condense the checkout debug bar to a two-line summary

### DIFF
--- a/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-lookup.php
+++ b/smart-send-logistics/includes/delivery/class-ss-shipping-pickup-point-lookup.php
@@ -76,9 +76,6 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Lookup' ) ) :
 					'Smart Send: pickup point lookup skipped - no API token configured (plugin not connected).',
 					array( 'carrier' => $carrier )
 				);
-				SS_Shipping_Checkout_Debug::add_notice(
-					__( 'Smart Send: pickup point lookup skipped - no API token configured (plugin not connected).', 'smart-send-logistics' )
-				);
 
 				WC()->session->set( self::SESSION_KEY, array() );
 
@@ -147,13 +144,6 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Lookup' ) ) :
 					sprintf( 'Smart Send: no %s pickup points found near the entered address.', $carrier ),
 					array( 'carrier' => $carrier )
 				);
-				SS_Shipping_Checkout_Debug::add_notice(
-					sprintf(
-						/* translators: %s: carrier code. */
-						__( 'Smart Send: no %s pickup points found near the entered address.', 'smart-send-logistics' ),
-						$carrier
-					)
-				);
 
 				WC()->session->set( self::SESSION_KEY, array() );
 
@@ -180,19 +170,6 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Lookup' ) ) :
 				array(
 					'carrier'      => $carrier,
 					'result_count' => count( $ss_pickup_points ),
-				)
-			);
-			SS_Shipping_Checkout_Debug::add_notice(
-				sprintf(
-					/* translators: 1: number of pickup points found, 2: carrier code. */
-					_n(
-						'Smart Send: found %1$d %2$s pickup point near the entered address.',
-						'Smart Send: found %1$d %2$s pickup points near the entered address.',
-						count( $ss_pickup_points ),
-						'smart-send-logistics'
-					),
-					count( $ss_pickup_points ),
-					$carrier
 				)
 			);
 
@@ -254,11 +231,11 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Lookup' ) ) :
 		 * The checkout falls back to the "Shipping to closest pickup point"
 		 * text whenever no pickup points are available. That fallback hides several
 		 * distinct causes, so this classifies the failure (transport error,
-		 * API error response) by exception type and reports it: always to the
-		 * log at the error level and via
-		 * SS_Shipping_Checkout_Debug::add_notice() when WooCommerce shipping
-		 * debug mode is on (a no-op during checkout AJAX requests, matching
-		 * core - the log entry is then the only trace).
+		 * API error response) by exception type and logs it at the error
+		 * level. Log only: the checkout shipping debug bar carries one
+		 * pickup-point-section line per render, emitted by the classic
+		 * checkout surface (SS_Shipping_Frontend) with the method context
+		 * this headless lookup does not have.
 		 *
 		 * @param string                                    $carrier Unique carrier code the lookup ran for.
 		 * @param \Smartsend\Exceptions\HttpClientException $e       The failure.
@@ -268,20 +245,12 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Lookup' ) ) :
 
 			if ( $e instanceof \Smartsend\Exceptions\UnauthenticatedException ) {
 				$log_message = sprintf( 'Smart Send: pickup point lookup for %1$s failed with an authentication error (HTTP 401): %2$s', $carrier, $message );
-				/* translators: 1: carrier code, 2: error message returned by the Smart Send API. */
-				$notice_message = sprintf( __( 'Smart Send: pickup point lookup for %1$s failed with an authentication error (HTTP 401): %2$s', 'smart-send-logistics' ), $carrier, $message );
 			} elseif ( $e instanceof \Smartsend\Exceptions\ForbiddenException ) {
 				$log_message = sprintf( 'Smart Send: pickup point lookup for %1$s failed with an authorization error (HTTP 403): %2$s', $carrier, $message );
-				/* translators: 1: carrier code, 2: error message returned by the Smart Send API. */
-				$notice_message = sprintf( __( 'Smart Send: pickup point lookup for %1$s failed with an authorization error (HTTP 403): %2$s', 'smart-send-logistics' ), $carrier, $message );
 			} elseif ( $e instanceof \Smartsend\Exceptions\ConnectionException ) {
 				$log_message = sprintf( 'Smart Send: pickup point lookup for %1$s failed with a transport error: %2$s Falling back to "Shipping to closest pickup point".', $carrier, $message );
-				/* translators: 1: carrier code, 2: error message. */
-				$notice_message = sprintf( __( 'Smart Send: pickup point lookup for %1$s failed with a transport error: %2$s Falling back to "Shipping to closest pickup point".', 'smart-send-logistics' ), $carrier, $message );
 			} else {
 				$log_message = sprintf( 'Smart Send: pickup point lookup for %1$s failed with an API error: %2$s Falling back to "Shipping to closest pickup point".', $carrier, $message );
-				/* translators: 1: carrier code, 2: error message. */
-				$notice_message = sprintf( __( 'Smart Send: pickup point lookup for %1$s failed with an API error: %2$s Falling back to "Shipping to closest pickup point".', 'smart-send-logistics' ), $carrier, $message );
 			}
 
 			SS_Shipping_Logger::error(
@@ -291,7 +260,6 @@ if ( ! class_exists( 'SS_Shipping_Pickup_Point_Lookup' ) ) :
 					'error_message' => $message,
 				)
 			);
-			SS_Shipping_Checkout_Debug::add_notice( $notice_message );
 		}
 	}
 

--- a/smart-send-logistics/includes/shipping-method/class-ss-shipping-availability-reporter.php
+++ b/smart-send-logistics/includes/shipping-method/class-ss-shipping-availability-reporter.php
@@ -17,25 +17,32 @@ if ( ! class_exists( 'SS_Shipping_Availability_Reporter' ) ) :
 	/**
 	 * Reports the shipping-class and free-shipping availability outcomes of
 	 * SS_Shipping_WC_Method to the two logging surfaces (#92): the log gets
-	 * the English message, the checkout shipping debug bar the translated
-	 * one.
+	 * the full English step trace; the checkout shipping debug bar gets a
+	 * single translated verdict line, and only when the shipping-class
+	 * condition made the method unavailable (an available method's one-line
+	 * summary - including the free-shipping outcome - is emitted by
+	 * calculate_shipping() instead).
 	 *
 	 * Extracted from the two ~130-line switch/if matrices in
-	 * SS_Shipping_WC_Method (#140) into data-driven message tables; every
-	 * message string is byte-identical to the historic ones so existing
-	 * translations keep matching.
+	 * SS_Shipping_WC_Method (#140) into data-driven message tables; the log
+	 * message strings are byte-identical to the historic ones so they stay
+	 * greppable across versions.
 	 */
 	class SS_Shipping_Availability_Reporter {
 
 		/**
-		 * Report the shipping-class availability outcome.
+		 * Report the shipping-class availability outcome: always to the log;
+		 * to the debug bar only when the condition made the method
+		 * unavailable (calculate_shipping() never runs then, so this is the
+		 * method's one debug bar line).
 		 *
 		 * @param string  $method_title               The shipping method title.
 		 * @param string  $display_shipping_class_opt The configured shipping-class condition.
 		 * @param boolean $is_available               Whether the method ended up available.
+		 * @param string  $rate_id                    The shipping rate id (e.g. 'smart_send_shipping:2').
 		 * @return void
 		 */
-		public function report_shipping_class_availability( $method_title, $display_shipping_class_opt, $is_available ) {
+		public function report_shipping_class_availability( $method_title, $display_shipping_class_opt, $is_available, $rate_id = '' ) {
 			$messages = $this->shipping_class_messages();
 
 			if ( ! isset( $messages[ $display_shipping_class_opt ] ) ) {
@@ -48,11 +55,25 @@ if ( ! class_exists( 'SS_Shipping_Availability_Reporter' ) ) :
 				sprintf( $entry['log'], $method_title ),
 				array( 'shipping_class_option' => $display_shipping_class_opt )
 			);
-			SS_Shipping_Checkout_Debug::add_notice( sprintf( $entry['notice'], $method_title ) );
+
+			if ( ! $is_available ) {
+				SS_Shipping_Checkout_Debug::add_notice(
+					sprintf(
+						/* translators: 1: shipping method title, 2: shipping rate id, 3: the shipping-class reason the method is unavailable. */
+						__( 'Smart Send: Evaluated method "%1$s" (%2$s) as not available: %3$s', 'smart-send-logistics' ),
+						$method_title,
+						$rate_id,
+						$entry['reason']
+					)
+				);
+			}
 		}
 
 		/**
-		 * Report the free-shipping (flat fee) availability outcome.
+		 * Report the free-shipping (flat fee) availability outcome to the
+		 * log. The debug bar carries no separate free-shipping line - the
+		 * outcome is part of the one-line evaluation summary
+		 * calculate_shipping() emits ("Flat fee cost X applied").
 		 *
 		 * @param string     $method_title The shipping method title.
 		 * @param string     $requires     The configured free-shipping condition.
@@ -72,22 +93,19 @@ if ( ! class_exists( 'SS_Shipping_Availability_Reporter' ) ) :
 			}
 
 			if ( empty( $entry['with_amounts'] ) ) {
-				$log_message    = sprintf( $entry['log'], $method_title );
-				$notice_message = sprintf( $entry['notice'], $method_title );
+				$log_message = sprintf( $entry['log'], $method_title );
 			} else {
-				$log_message    = sprintf( $entry['log'], $method_title, $total, $min_amount );
-				$notice_message = sprintf( $entry['notice'], $method_title, $total, $min_amount );
+				$log_message = sprintf( $entry['log'], $method_title, $total, $min_amount );
 			}
 
 			SS_Shipping_Logger::debug( $log_message, array( 'requires' => $requires ) );
-			SS_Shipping_Checkout_Debug::add_notice( $notice_message );
 		}
 
 		/**
 		 * The shipping-class message matrix: per configured condition, the
-		 * English log template and translated notice template for the
-		 * available/unavailable outcomes. All templates take the method
-		 * title as their only argument.
+		 * English log template (taking the method title) for the
+		 * available/unavailable outcomes, plus - on the unavailable side -
+		 * the translated reason clause for the debug bar verdict line.
 		 *
 		 * @return array
 		 */
@@ -95,50 +113,38 @@ if ( ! class_exists( 'SS_Shipping_Availability_Reporter' ) ) :
 			return array(
 				SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_ALL => array(
 					'available'   => array(
-						'log'    => 'Smart Send "%s": shipping method IS available, because ALL products belong to one of the shipping classes',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": shipping method IS available, because ALL products belong to one of the shipping classes', 'smart-send-logistics' ),
+						'log' => 'Smart Send "%s": shipping method IS available, because ALL products belong to one of the shipping classes',
 					),
 					'unavailable' => array(
 						'log'    => 'Smart Send "%s": shipping method is NOT available, because ALL products belong to one of the shipping classes',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": shipping method is NOT available, because ALL products belong to one of the shipping classes', 'smart-send-logistics' ),
+						'reason' => __( 'not ALL products belong to one of the selected shipping classes.', 'smart-send-logistics' ),
 					),
 				),
 				SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_ONE => array(
 					'available'   => array(
-						'log'    => 'Smart Send "%s": shipping method IS available, because at least ONE product belongs to one of the shipping classes',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": shipping method IS available, because at least ONE product belongs to one of the shipping classes', 'smart-send-logistics' ),
+						'log' => 'Smart Send "%s": shipping method IS available, because at least ONE product belongs to one of the shipping classes',
 					),
 					'unavailable' => array(
 						'log'    => 'Smart Send "%s": shipping method is NOT available, because at least ONE product belongs to one of the shipping classes',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": shipping method is NOT available, because at least ONE product belongs to one of the shipping classes', 'smart-send-logistics' ),
+						'reason' => __( 'no product belongs to one of the selected shipping classes.', 'smart-send-logistics' ),
 					),
 				),
 				SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_NALL => array(
 					'available'   => array(
-						'log'    => 'Smart Send "%s": shipping method IS available, because ALL products do NOT belong to one of the shipping classes',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": shipping method IS available, because ALL products do NOT belong to one of the shipping classes', 'smart-send-logistics' ),
+						'log' => 'Smart Send "%s": shipping method IS available, because ALL products do NOT belong to one of the shipping classes',
 					),
 					'unavailable' => array(
 						'log'    => 'Smart Send "%s": shipping method is NOT available, because ALL products do NOT belong to one of the shipping classes',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": shipping method is NOT available, because ALL products do NOT belong to one of the shipping classes', 'smart-send-logistics' ),
+						'reason' => __( 'at least one product belongs to one of the selected shipping classes.', 'smart-send-logistics' ),
 					),
 				),
 				SS_Shipping_Method_Settings::SHIPPING_CLASS_OPT_NONE => array(
 					'available'   => array(
-						'log'    => 'Smart Send "%s": shipping method IS available, because at least ONE product does NOT belongs to one of the shipping classes',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": shipping method IS available, because at least ONE product does NOT belongs to one of the shipping classes', 'smart-send-logistics' ),
+						'log' => 'Smart Send "%s": shipping method IS available, because at least ONE product does NOT belongs to one of the shipping classes',
 					),
 					'unavailable' => array(
 						'log'    => 'Smart Send "%s": shipping method is NOT available, because at least ONE product does NOT belongs to one of the shipping classes',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": shipping method is NOT available, because at least ONE product does NOT belongs to one of the shipping classes', 'smart-send-logistics' ),
+						'reason' => __( 'ALL products belong to one of the selected shipping classes.', 'smart-send-logistics' ),
 					),
 				),
 			);
@@ -146,11 +152,10 @@ if ( ! class_exists( 'SS_Shipping_Availability_Reporter' ) ) :
 
 		/**
 		 * The free-shipping message matrix: per configured condition, the
-		 * English log template and translated notice template. Entries with
-		 * 'with_amounts' take (title, total, minimum amount); the others
-		 * take the title only. ENABLED/DISABLED/default have one fixed
-		 * outcome (preserved v8 behaviour: their message ignores
-		 * $is_available).
+		 * English log template. Entries with 'with_amounts' take (title,
+		 * total, minimum amount); the others take the title only.
+		 * ENABLED/DISABLED/default have one fixed outcome (preserved v8
+		 * behaviour: their message ignores $is_available).
 		 *
 		 * @return array
 		 */
@@ -160,70 +165,48 @@ if ( ! class_exists( 'SS_Shipping_Availability_Reporter' ) ) :
 					'available'   => array(
 						'with_amounts' => true,
 						'log'          => 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed.',
-						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
-						'notice'       => __( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed.', 'smart-send-logistics' ),
 					),
 					'unavailable' => array(
 						'with_amounts' => true,
 						'log'          => 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed.',
-						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
-						'notice'       => __( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed.', 'smart-send-logistics' ),
 					),
 				),
 				SS_Shipping_Method_Settings::REQUIRES_COUPON => array(
 					'available'   => array(
-						'log'    => 'Smart Send "%s": free shipping (flat fee) IS available, because a coupon is needed.',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": free shipping (flat fee) IS available, because a coupon is needed.', 'smart-send-logistics' ),
+						'log' => 'Smart Send "%s": free shipping (flat fee) IS available, because a coupon is needed.',
 					),
 					'unavailable' => array(
-						'log'    => 'Smart Send "%s": free shipping (flat fee) is NOT available, because a coupon is needed.',
-						/* translators: %s: shipping method title. */
-						'notice' => __( 'Smart Send "%s": free shipping (flat fee) is NOT available, because a coupon is needed.', 'smart-send-logistics' ),
+						'log' => 'Smart Send "%s": free shipping (flat fee) is NOT available, because a coupon is needed.',
 					),
 				),
 				SS_Shipping_Method_Settings::REQUIRES_BOTH => array(
 					'available'   => array(
 						'with_amounts' => true,
 						'log'          => 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.',
-						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
-						'notice'       => __( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.', 'smart-send-logistics' ),
 					),
 					'unavailable' => array(
 						'with_amounts' => true,
 						'log'          => 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.',
-						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
-						'notice'       => __( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed AND a coupon is needed.', 'smart-send-logistics' ),
 					),
 				),
 				SS_Shipping_Method_Settings::REQUIRES_EITHER => array(
 					'available'   => array(
 						'with_amounts' => true,
 						'log'          => 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.',
-						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
-						'notice'       => __( 'Smart Send "%1$s": free shipping (flat fee) IS available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.', 'smart-send-logistics' ),
 					),
 					'unavailable' => array(
 						'with_amounts' => true,
 						'log'          => 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.',
-						/* translators: 1: shipping method title, 2: cart total, 3: minimum order amount. */
-						'notice'       => __( 'Smart Send "%1$s": free shipping (flat fee) is NOT available, because the total is %2$s a minimum order amount of %3$s is needed OR a coupon is needed.', 'smart-send-logistics' ),
 					),
 				),
 				SS_Shipping_Method_Settings::REQUIRES_ENABLED => array(
-					'log'    => 'Smart Send "%s": free shipping (flat fee) IS available, because it is always enabled.',
-					/* translators: %s: shipping method title. */
-					'notice' => __( 'Smart Send "%s": free shipping (flat fee) IS available, because it is always enabled.', 'smart-send-logistics' ),
+					'log' => 'Smart Send "%s": free shipping (flat fee) IS available, because it is always enabled.',
 				),
 				SS_Shipping_Method_Settings::REQUIRES_DISABLED => array(
-					'log'    => 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is always disabled.',
-					/* translators: %s: shipping method title. */
-					'notice' => __( 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is always disabled.', 'smart-send-logistics' ),
+					'log' => 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is always disabled.',
 				),
 				'default'                                  => array(
-					'log'    => 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is not available.',
-					/* translators: %s: shipping method title. */
-					'notice' => __( 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is not available.', 'smart-send-logistics' ),
+					'log' => 'Smart Send "%s": free shipping (flat fee) is NOT available, because it is not available.',
 				),
 			);
 		}

--- a/smart-send-logistics/includes/shipping-method/class-ss-shipping-rate-sorter.php
+++ b/smart-send-logistics/includes/shipping-method/class-ss-shipping-rate-sorter.php
@@ -81,12 +81,14 @@ if ( ! class_exists( 'SS_Shipping_Rate_Sorter' ) ) :
 		}
 
 		/**
-		 * Surface which Smart Send rates ended up offered for the package.
+		 * Log which Smart Send rates ended up offered for the package.
 		 *
 		 * Runs on woocommerce_package_rates after every shipping method has
 		 * calculated its rates, so this is the final set the shopper is
-		 * offered. The summary goes to the checkout shipping debug bar and
-		 * to the log as a developer trace.
+		 * offered. Log-only developer trace: the checkout shipping debug bar
+		 * already carries one evaluation summary line per method (from
+		 * calculate_shipping()), so a second offered-rates line would be
+		 * noise there.
 		 *
 		 * @param array $available_shipping_methods WC_Shipping_Rate objects keyed by rate id.
 		 */
@@ -100,17 +102,12 @@ if ( ! class_exists( 'SS_Shipping_Rate_Sorter' ) ) :
 			}
 
 			if ( empty( $offered ) ) {
-				$log_message    = 'Smart Send: no Smart Send rates offered for this package.';
-				$notice_message = __( 'Smart Send: no Smart Send rates offered for this package.', 'smart-send-logistics' );
+				$log_message = 'Smart Send: no Smart Send rates offered for this package.';
 			} else {
-				$rate_list   = implode( ', ', $offered );
-				$log_message = sprintf( 'Smart Send: rates offered for this package: %s.', $rate_list );
-				/* translators: %s: list of offered rates, each as "label" (rate id, cost). */
-				$notice_message = sprintf( __( 'Smart Send: rates offered for this package: %s.', 'smart-send-logistics' ), $rate_list );
+				$log_message = sprintf( 'Smart Send: rates offered for this package: %s.', implode( ', ', $offered ) );
 			}
 
 			SS_Shipping_Logger::debug( $log_message, array( 'offered_rates' => $offered ) );
-			SS_Shipping_Checkout_Debug::add_notice( $notice_message );
 		}
 	}
 

--- a/smart-send-logistics/includes/shipping-method/class-ss-shipping-wc-method.php
+++ b/smart-send-logistics/includes/shipping-method/class-ss-shipping-wc-method.php
@@ -236,15 +236,6 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 					'method'  => $rate['meta_data']['smart_send_shipping_method'],
 				)
 			);
-			SS_Shipping_Checkout_Debug::add_notice(
-				sprintf(
-					/* translators: 1: shipping rate label, 2: Smart Send shipping method code, 3: shipping rate id. */
-					__( 'Smart Send: evaluated method "%1$s" (%2$s, rate id %3$s).', 'smart-send-logistics' ),
-					$rate['label'],
-					$rate['meta_data']['smart_send_shipping_method'],
-					$rate['id']
-				)
-			);
 
 			// Set tax status based on selection otherwise always taxed
 			$this->tax_status = $this->get_option( 'tax_status' );
@@ -259,6 +250,11 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			$weight_unit     = get_option( 'woocommerce_weight_unit' );
 			$weight_in_table = $weight_table->contains( $cart_weight );
 
+			// How the offered cost was derived, for the one-line debug bar
+			// summary emitted at the end: null (no rate), a flat fee, or the
+			// last applied weight table row.
+			$cost_derivation = null;
+
 			if ( ! $weight_in_table ) {
 				SS_Shipping_Logger::debug(
 					sprintf( 'Smart Send "%1$s": no rate added - cart weight %2$s %3$s did not match any weight table row.', $rate['label'], $cart_weight, $weight_unit ),
@@ -267,32 +263,16 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 						'cart_weight' => $cart_weight,
 					)
 				);
-				SS_Shipping_Checkout_Debug::add_notice(
-					sprintf(
-						/* translators: 1: shipping rate label, 2: cart weight, 3: weight unit. */
-						__( 'Smart Send "%1$s": no rate added - cart weight %2$s %3$s did not match any weight table row.', 'smart-send-logistics' ),
-						$rate['label'],
-						$cart_weight,
-						$weight_unit
-					)
-				);
 			} elseif ( $this->is_free_shipping( $package ) ) {
 
 				$rate['cost'] = $this->get_option( 'flatfee_cost' );
 				$this->add_rate( $rate );
+				$cost_derivation = array( 'type' => 'flat_fee' );
 				SS_Shipping_Logger::debug(
 					sprintf( 'Smart Send "%1$s": free shipping applies - rate added with flat fee cost %2$s.', $rate['label'], $rate['cost'] ),
 					array(
 						'rate_id' => $rate['id'],
 						'cost'    => $rate['cost'],
-					)
-				);
-				SS_Shipping_Checkout_Debug::add_notice(
-					sprintf(
-						/* translators: 1: shipping rate label, 2: flat fee cost. */
-						__( 'Smart Send "%1$s": free shipping applies - rate added with flat fee cost %2$s.', 'smart-send-logistics' ),
-						$rate['label'],
-						$rate['cost']
 					)
 				);
 
@@ -319,9 +299,13 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 					);
 
 					$this->add_rate( $rate );
-					$rate_added     = true;
-					$matched_row    = sprintf( '%1$s-%2$s %3$s', $weight_cost['ss_min_weight'], $weight_cost['ss_max_weight'], $weight_unit );
-					$matched_rows[] = $matched_row;
+					$rate_added      = true;
+					$matched_row     = sprintf( '%1$s-%2$s %3$s', $weight_cost['ss_min_weight'], $weight_cost['ss_max_weight'], $weight_unit );
+					$matched_rows[]  = $matched_row;
+					$cost_derivation = array(
+						'type' => 'weight_row',
+						'row'  => $matched_row,
+					);
 					SS_Shipping_Logger::debug(
 						sprintf(
 							'Smart Send "%1$s": cart weight %2$s %3$s matched weight table row %4$s - rate added with cost %5$s.',
@@ -335,17 +319,6 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 							'rate_id'     => $rate['id'],
 							'cost'        => $rate['cost'],
 							'cart_weight' => $cart_weight,
-						)
-					);
-					SS_Shipping_Checkout_Debug::add_notice(
-						sprintf(
-							/* translators: 1: shipping rate label, 2: cart weight, 3: weight unit, 4: matched weight table row as "min-max unit", 5: rate cost. */
-							__( 'Smart Send "%1$s": cart weight %2$s %3$s matched weight table row %4$s - rate added with cost %5$s.', 'smart-send-logistics' ),
-							$rate['label'],
-							$cart_weight,
-							$weight_unit,
-							$matched_row,
-							$rate['cost']
 						)
 					);
 				}
@@ -387,15 +360,6 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 							'cart_weight' => $cart_weight,
 						)
 					);
-					SS_Shipping_Checkout_Debug::add_notice(
-						sprintf(
-							/* translators: 1: shipping rate label, 2: cart weight, 3: weight unit. */
-							__( 'Smart Send "%1$s": no rate added - cart weight %2$s %3$s did not match any weight table row.', 'smart-send-logistics' ),
-							$rate['label'],
-							$cart_weight,
-							$weight_unit
-						)
-					);
 				}
 			}
 
@@ -414,6 +378,11 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 					array( 'rate_id' => $rate['id'] )
 				);
 			}
+
+			// One-line debug bar summary of this method's evaluation: the
+			// verdict plus how the offered cost was derived - the step-by-step
+			// trace above stays in the log only (#92).
+			$this->add_evaluation_summary_notice( $rate, $cost_derivation, $package['contents_cost'], $cart_weight, $weight_unit );
 
 			/**
 			 * Developers can add additional rates based on this one via this action
@@ -435,6 +404,70 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 			// Built from the constant (never $this->id) so the hook name can't drift
 			// out of sync with it if SS_SHIPPING_METHOD_ID's value ever changes - see #106.
 			do_action( 'woocommerce_' . SS_SHIPPING_METHOD_ID . '_shipping_add_rate', $this, $rate );
+		}
+
+		/**
+		 * Show the one-line evaluation summary of this method in the checkout
+		 * shipping debug bar: whether the rate ended up available for the
+		 * package (with the evaluated total and cart weight) and, when it did,
+		 * how its cost was derived (flat fee or weight table row).
+		 *
+		 * @param array      $rate            The rate array built by calculate_shipping().
+		 * @param array|null $cost_derivation How the cost was derived: null (no rate), ['type' => 'flat_fee'] or ['type' => 'weight_row', 'row' => 'min-max unit'].
+		 * @param mixed      $contents_cost   The package contents cost the evaluation ran against.
+		 * @param mixed      $cart_weight     The evaluated cart weight.
+		 * @param string     $weight_unit     The store weight unit.
+		 * @return void
+		 */
+		protected function add_evaluation_summary_notice( $rate, $cost_derivation, $contents_cost, $cart_weight, $weight_unit ) {
+			if ( ! isset( $this->rates[ $rate['id'] ] ) || null === $cost_derivation ) {
+				SS_Shipping_Checkout_Debug::add_notice(
+					sprintf(
+						/* translators: 1: shipping rate label, 2: shipping rate id, 3: package contents cost, 4: cart weight, 5: weight unit. */
+						__( 'Smart Send: Evaluated method "%1$s" (%2$s) as not available (total=%3$s, weight=%4$s %5$s): the cart weight matched no weight table row.', 'smart-send-logistics' ),
+						$rate['label'],
+						$rate['id'],
+						$contents_cost,
+						$cart_weight,
+						$weight_unit
+					)
+				);
+
+				return;
+			}
+
+			$cost = $this->rates[ $rate['id'] ]->get_cost();
+
+			if ( 'flat_fee' === $cost_derivation['type'] ) {
+				SS_Shipping_Checkout_Debug::add_notice(
+					sprintf(
+						/* translators: 1: shipping rate label, 2: shipping rate id, 3: package contents cost, 4: cart weight, 5: weight unit, 6: flat fee cost. */
+						__( 'Smart Send: Evaluated method "%1$s" (%2$s) as available (total=%3$s, weight=%4$s %5$s). Flat fee cost %6$s applied.', 'smart-send-logistics' ),
+						$rate['label'],
+						$rate['id'],
+						$contents_cost,
+						$cart_weight,
+						$weight_unit,
+						$cost
+					)
+				);
+
+				return;
+			}
+
+			SS_Shipping_Checkout_Debug::add_notice(
+				sprintf(
+					/* translators: 1: shipping rate label, 2: shipping rate id, 3: package contents cost, 4: cart weight, 5: weight unit, 6: applied weight table row as "min-max unit", 7: rate cost. */
+					__( 'Smart Send: Evaluated method "%1$s" (%2$s) as available (total=%3$s, weight=%4$s %5$s). Weight table row %6$s applied, cost %7$s.', 'smart-send-logistics' ),
+					$rate['label'],
+					$rate['id'],
+					$contents_cost,
+					$cart_weight,
+					$weight_unit,
+					$cost_derivation['row'],
+					$cost
+				)
+			);
 		}
 
 		public function is_available( $package ) {
@@ -478,7 +511,7 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 							break;
 					}
 
-					$this->availability_reporter->report_shipping_class_availability( $this->title, $display_shipping_class_opt, $is_available );
+					$this->availability_reporter->report_shipping_class_availability( $this->title, $display_shipping_class_opt, $is_available, $this->get_rate_id() );
 				}
 
 				// Exclude customer roles
@@ -504,9 +537,10 @@ if ( ! class_exists( 'SS_Shipping_WC_Method' ) ) :
 							);
 							SS_Shipping_Checkout_Debug::add_notice(
 								sprintf(
-									/* translators: 1: shipping method title, 2: customer role. */
-									__( 'Smart Send "%1$s": shipping method is NOT available, because customer role "%2$s" is being excluded.', 'smart-send-logistics' ),
+									/* translators: 1: shipping method title, 2: shipping rate id, 3: customer role. */
+									__( 'Smart Send: Evaluated method "%1$s" (%2$s) as not available: customer role "%3$s" is excluded.', 'smart-send-logistics' ),
 									$this->title,
+									$this->get_rate_id(),
 									$customer_role
 								)
 							);

--- a/smart-send-logistics/public/class-ss-shipping-frontend.php
+++ b/smart-send-logistics/public/class-ss-shipping-frontend.php
@@ -137,6 +137,7 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 			list( $country, $postal_code, $city, $street ) = $this->resolve_shipping_address();
 
 			$ss_pickup_points = array();
+			$lookup_exception = null;
 
 			if ( empty( $country ) || empty( $postal_code ) || empty( $street ) ) {
 				// No lookup can run without an address - render the
@@ -153,9 +154,14 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 				} catch ( Exception $e ) {
 					// Logged and session-cached by the lookup itself - only
 					// rendering is left to do here.
-					$status = $this->checkout_options->pickup_point_status_for_exception( $e );
+					$status           = $this->checkout_options->pickup_point_status_for_exception( $e );
+					$lookup_exception = $e;
 				}
 			}
+
+			// One-line debug bar summary of the delivery-options section:
+			// pickup points apply to this method, plus the lookup outcome.
+			$this->add_pickup_point_section_notice( $method->get_label(), $method->get_id(), $status, count( $ss_pickup_points ), $lookup_exception );
 
 			if ( SS_Shipping_Checkout_Options::PICKUP_POINT_STATUS_FOUND === $status ) {
 
@@ -209,6 +215,68 @@ if ( ! class_exists( 'SS_Shipping_Frontend' ) ) :
 				);
 			}
 			// phpcs:enable WordPress.Security.NonceVerification.Missing
+		}
+
+		/**
+		 * Show the one-line delivery-options summary in the checkout shipping
+		 * debug bar: pickup points apply to the chosen method, plus the lookup
+		 * outcome (found N / waiting for the address / the failure).
+		 *
+		 * @param string          $method_label     The chosen shipping rate's label.
+		 * @param string          $rate_id          The chosen shipping rate's id (e.g. 'smart_send_shipping:2').
+		 * @param string          $status           The SS_Shipping_Checkout_Options::PICKUP_POINT_STATUS_* slug.
+		 * @param int             $found_count      How many pickup points the lookup found.
+		 * @param \Exception|null $lookup_exception The lookup failure, when the status came from one.
+		 * @return void
+		 */
+		protected function add_pickup_point_section_notice( $method_label, $rate_id, $status, $found_count, $lookup_exception ) {
+			$error_message = null === $lookup_exception ? '' : $lookup_exception->getMessage();
+
+			switch ( $status ) {
+				case SS_Shipping_Checkout_Options::PICKUP_POINT_STATUS_FOUND:
+					$outcome = sprintf(
+						/* translators: %d: number of pickup points found. */
+						_n( 'Found %d pickup point near the entered address.', 'Found %d pickup points near the entered address.', $found_count, 'smart-send-logistics' ),
+						$found_count
+					);
+					break;
+				case SS_Shipping_Checkout_Options::PICKUP_POINT_STATUS_ADDRESS_INCOMPLETE:
+					$outcome = __( 'Waiting for the shipping address.', 'smart-send-logistics' );
+					break;
+				case SS_Shipping_Checkout_Options::PICKUP_POINT_STATUS_NOT_CONNECTED:
+					$outcome = __( 'No API token configured (plugin not connected).', 'smart-send-logistics' );
+					break;
+				case SS_Shipping_Checkout_Options::PICKUP_POINT_STATUS_AUTH_FAILED:
+					/* translators: %s: error message returned by the Smart Send API. */
+					$outcome = sprintf( __( 'Failed with an authentication error (HTTP 401): %s', 'smart-send-logistics' ), $error_message );
+					break;
+				case SS_Shipping_Checkout_Options::PICKUP_POINT_STATUS_ACCESS_DENIED:
+					/* translators: %s: error message returned by the Smart Send API. */
+					$outcome = sprintf( __( 'Failed with an authorization error (HTTP 403): %s', 'smart-send-logistics' ), $error_message );
+					break;
+				case SS_Shipping_Checkout_Options::PICKUP_POINT_STATUS_NONE_FOUND:
+					$outcome = __( 'No pickup points found near the entered address.', 'smart-send-logistics' );
+					break;
+				default:
+					if ( $lookup_exception instanceof \Smartsend\Exceptions\ConnectionException ) {
+						/* translators: %s: transport error message. */
+						$outcome = sprintf( __( 'Failed with a transport error: %s', 'smart-send-logistics' ), $error_message );
+					} else {
+						/* translators: %s: error message returned by the Smart Send API. */
+						$outcome = sprintf( __( 'Failed with an API error: %s', 'smart-send-logistics' ), $error_message );
+					}
+					break;
+			}
+
+			SS_Shipping_Checkout_Debug::add_notice(
+				sprintf(
+					/* translators: 1: shipping rate label, 2: shipping rate id, 3: the pickup point lookup outcome sentence. */
+					__( 'Smart Send: Showing pickup point for "%1$s" (%2$s). %3$s', 'smart-send-logistics' ),
+					$method_label,
+					$rate_id,
+					$outcome
+				)
+			);
 		}
 
 		/**

--- a/tests/Integration/LoggingPolicyTest.php
+++ b/tests/Integration/LoggingPolicyTest.php
@@ -230,7 +230,7 @@ it('logs a debug trace when the meta box is rendered for a non Smart Send order'
         ->and(implode("\n", ss_policy_logged($spy, 'debug')))->toContain('No Smart Send shipping method on order - skipping meta box content');
 });
 
-it('surfaces which Smart Send rates ended up offered for the package', function () {
+it('logs which Smart Send rates ended up offered for the package, without a debug bar notice', function () {
     with_option('woocommerce_shipping_debug_mode', 'yes');
     $spy = spy_on_logger();
 
@@ -243,22 +243,23 @@ it('surfaces which Smart Send rates ended up offered for the package', function 
     ]);
 
     $expected = 'Smart Send: rates offered for this package: "SS Policy Rate" (smart_send_shipping:7, cost 49).';
-    $trace    = implode("\n", ss_policy_notices());
 
-    expect($trace)->toContain($expected)
-        ->and($trace)->not->toContain('Flat rate')
-        ->and(implode("\n", ss_policy_logged($spy, 'debug')))->toContain($expected);
+    // Log-only trace: the debug bar already carries one evaluation summary
+    // per method, so the sorter adds no second line there.
+    expect(implode("\n", ss_policy_logged($spy, 'debug')))->toContain($expected)
+        ->and(ss_policy_notices())->toBe([]);
 });
 
-it('reports when no Smart Send rates were offered for the package', function () {
+it('logs when no Smart Send rates were offered for the package, without a debug bar notice', function () {
     with_option('woocommerce_shipping_debug_mode', 'yes');
-    spy_on_logger();
+    $spy = spy_on_logger();
 
     $other = new WC_Shipping_Rate('flat_rate:3', 'Flat rate', '10', [], 'flat_rate', 3);
 
     SS_SHIPPING_WC()->rate_sorter()->sort_shipping_methods(['flat_rate:3' => $other]);
 
-    expect(implode("\n", ss_policy_notices()))->toContain('Smart Send: no Smart Send rates offered for this package.');
+    expect(implode("\n", ss_policy_logged($spy, 'debug')))->toContain('Smart Send: no Smart Send rates offered for this package.')
+        ->and(ss_policy_notices())->toBe([]);
 });
 
 it('explains that the last matching weight row wins when rows overlap', function () {

--- a/tests/Integration/NoticeTranslationTest.php
+++ b/tests/Integration/NoticeTranslationTest.php
@@ -9,8 +9,8 @@
  * NOTE: tests here assert on checkout notices and must run before the
  * WC_DOING_AJAX-defining tests in ShippingDebugModeTest.php (alphabetical
  * file order guarantees this). Reuses spy_on_logger() from LoggerTest.php
- * and ss_policy_notices() from LoggingPolicyTest.php, both of which load
- * earlier alphabetically.
+ * and ss_policy_notices()/ss_policy_method()/ss_policy_package() from
+ * LoggingPolicyTest.php, both of which load earlier alphabetically.
  */
 
 beforeEach(function (): void {
@@ -25,51 +25,48 @@ beforeEach(function (): void {
     });
 });
 
+/**
+ * Render the pickup point section for a chosen Smart Send agent rate the
+ * way checkout does, so the frontend emits its delivery-options debug bar
+ * line. (Local twin of PickupLookupDebugTest's helper, which loads later
+ * alphabetically.)
+ */
+function notice_translation_render_pickup_section(): void
+{
+    add_filter('woocommerce_is_checkout', '__return_true');
+    $_POST = array_merge($_POST, [
+        's_country'  => 'DK',
+        's_postcode' => '2300',
+        's_city'     => 'Copenhagen',
+        's_address'  => 'Main Street 1',
+    ]);
+    WC()->session->set('chosen_shipping_methods', ['smart_send_shipping:1']);
+
+    remember_cleanup_callback(function (): void {
+        remove_filter('woocommerce_is_checkout', '__return_true');
+        unset($_POST['s_country'], $_POST['s_postcode'], $_POST['s_city'], $_POST['s_address']);
+        WC()->session->set('chosen_shipping_methods', null);
+        WC()->session->set('ss_shipping_agents', null);
+    });
+
+    $rate = new WC_Shipping_Rate('smart_send_shipping:1', 'Smart Send', 49.0, [], 'smart_send_shipping', 1);
+    $rate->add_meta_data('smart_send_shipping_method', 'postnord_agent');
+
+    ob_start();
+    (new SS_Shipping_Frontend())->display_ss_pickup_points($rate, 0);
+    ob_end_clean();
+}
+
 it('renders the checkout debug notice through the translation functions while the log entry stays English', function () {
     with_option('woocommerce_shipping_debug_mode', 'yes');
     with_ss_settings(['ss_debug' => 'yes']); // Debug-level log entries require the plugin debug setting.
     $spy = spy_on_logger();
 
-    $english = 'Smart Send: no Smart Send rates offered for this package.';
-    $translated = 'OVERSAT: ingen Smart Send-priser for denne pakke.';
+    $english_template = 'Smart Send: Evaluated method "%1$s" (%2$s) as available (total=%3$s, weight=%4$s %5$s). Weight table row %6$s applied, cost %7$s.';
+    $translated_template = 'OVERSAT: metode "%1$s" (%2$s) tilgaengelig (total=%3$s, vaegt=%4$s %5$s). Vaegtraekke %6$s, pris %7$s.';
 
-    $filter = function (string $translation, string $text, string $domain) use ($english, $translated): string {
-        if ('smart-send-logistics' === $domain && $english === $text) {
-            return $translated;
-        }
-
-        return $translation;
-    };
-    add_filter('gettext', $filter, 10, 3);
-    remember_cleanup_callback(function () use ($filter): void {
-        remove_filter('gettext', $filter, 10);
-    });
-
-    $other = new WC_Shipping_Rate('flat_rate:3', 'Flat rate', '10', [], 'flat_rate', 3);
-    SS_SHIPPING_WC()->rate_sorter()->sort_shipping_methods(['flat_rate:3' => $other]);
-
-    // The merchant-facing debug bar notice is translated ...
-    expect(ss_policy_notices())->toContain($translated)
-        ->and(implode("\n", ss_policy_notices()))->not->toContain($english)
-        // ... while the log entry keeps the greppable English template.
-        ->and(implode("\n", array_map(
-            fn (array $entry): string => (string) $entry['message'],
-            array_filter($spy->entries, fn (array $entry): bool => 'debug' === $entry['level'])
-        )))->toContain($english)
-        ->and(implode("\n", array_map(
-            fn (array $entry): string => (string) $entry['message'],
-            $spy->entries
-        )))->not->toContain($translated);
-});
-
-it('substitutes values into a translated sprintf template on the debug bar', function () {
-    with_option('woocommerce_shipping_debug_mode', 'yes');
-    spy_on_logger();
-
-    $translated_template = 'OVERSAT: metode "%1$s" evalueret (%2$s, pris-id %3$s).';
-
-    $filter = function (string $translation, string $text, string $domain) use ($translated_template): string {
-        if ('smart-send-logistics' === $domain && 'Smart Send: evaluated method "%1$s" (%2$s, rate id %3$s).' === $text) {
+    $filter = function (string $translation, string $text, string $domain) use ($english_template, $translated_template): string {
+        if ('smart-send-logistics' === $domain && $english_template === $text) {
             return $translated_template;
         }
 
@@ -84,33 +81,78 @@ it('substitutes values into a translated sprintf template on the debug bar', fun
     $package = ss_policy_package([$product]);
 
     $method = ss_policy_method([
+        'cost_weight' => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
+    ], 99962);
+    $method->calculate_shipping($package);
+
+    $unit = get_option('woocommerce_weight_unit');
+
+    // The merchant-facing debug bar notice is translated ...
+    expect(ss_policy_notices())->toContain(
+        'OVERSAT: metode "SS Policy Method" (smart_send_shipping:99962) tilgaengelig (total=100, vaegt=2 ' . $unit . '). Vaegtraekke 1-5 ' . $unit . ', pris 49.'
+    );
+
+    // ... while the log keeps the greppable English step trace, untouched
+    // by the translation filter.
+    $debug_log = implode("\n", array_map(
+        fn (array $entry): string => (string) $entry['message'],
+        array_filter($spy->entries, fn (array $entry): bool => 'debug' === $entry['level'])
+    ));
+    expect($debug_log)->toContain('Smart Send "SS Policy Method": cart weight 2 ' . $unit . ' matched weight table row 1-5 ' . $unit . ' - rate added with cost 49.')
+        ->and($debug_log)->not->toContain('OVERSAT');
+});
+
+it('substitutes values into a translated sprintf template on the debug bar', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+    spy_on_logger();
+
+    $translated_template = 'OVERSAT: "%1$s" (%2$s) ikke tilgaengelig (total=%3$s, vaegt=%4$s %5$s): ingen vaegtraekke.';
+
+    $filter = function (string $translation, string $text, string $domain) use ($translated_template): string {
+        if ('smart-send-logistics' === $domain && 'Smart Send: Evaluated method "%1$s" (%2$s) as not available (total=%3$s, weight=%4$s %5$s): the cart weight matched no weight table row.' === $text) {
+            return $translated_template;
+        }
+
+        return $translation;
+    };
+    add_filter('gettext', $filter, 10, 3);
+    remember_cleanup_callback(function () use ($filter): void {
+        remove_filter('gettext', $filter, 10);
+    });
+
+    $product = create_simple_product(['price' => 100, 'weight' => 10]);
+    $package = ss_policy_package([$product]);
+
+    $method = ss_policy_method([
         'title'       => 'Oversat Metode',
         'cost_weight' => [['ss_min_weight' => '1', 'ss_max_weight' => '5', 'ss_cost_weight' => '49']],
     ], 99961);
     $method->calculate_shipping($package);
 
+    $unit = get_option('woocommerce_weight_unit');
+
     expect(ss_policy_notices())->toContain(
-        'OVERSAT: metode "Oversat Metode" evalueret (postnord_agent, pris-id smart_send_shipping:99961).'
+        'OVERSAT: "Oversat Metode" (smart_send_shipping:99961) ikke tilgaengelig (total=100, vaegt=10 ' . $unit . '): ingen vaegtraekke.'
     );
 });
 
-it('uses singular and plural pickup point summaries via _n()', function () {
+it('uses singular and plural pickup point outcomes via _n()', function () {
     with_option('woocommerce_shipping_debug_mode', 'yes');
     spy_on_logger();
     mock_smart_send_api(function () {
         return ss_api_response(200, ['data' => [sample_agent()]]);
     });
 
-    SS_SHIPPING_WC()->pickup_point_lookup()->find_closest_by_address('postnord', 'DK', '2300', 'Copenhagen', 'Main Street 1');
+    notice_translation_render_pickup_section();
 
-    expect(ss_policy_notices())->toContain('Smart Send: found 1 postnord pickup point near the entered address.');
+    expect(ss_policy_notices())->toContain('Smart Send: Showing pickup point for "Smart Send" (smart_send_shipping:1). Found 1 pickup point near the entered address.');
 
     wc_clear_notices();
     mock_smart_send_api(function () {
         return ss_api_response(200, ['data' => [sample_agent(), sample_agent(['agent_no' => '5678'])]]);
     });
 
-    SS_SHIPPING_WC()->pickup_point_lookup()->find_closest_by_address('postnord', 'DK', '2300', 'Copenhagen', 'Main Street 1');
+    notice_translation_render_pickup_section();
 
-    expect(ss_policy_notices())->toContain('Smart Send: found 2 postnord pickup points near the entered address.');
+    expect(ss_policy_notices())->toContain('Smart Send: Showing pickup point for "Smart Send" (smart_send_shipping:1). Found 2 pickup points near the entered address.');
 });

--- a/tests/Integration/PickupLookupDebugTest.php
+++ b/tests/Integration/PickupLookupDebugTest.php
@@ -106,16 +106,20 @@ it('surfaces a transport failure as a debug notice and logs it at error level', 
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: pickup point lookup for postnord failed with a transport error: '
-        . 'The connection to the Smart Send API timed out. Please try again. If the problem persists, ask your host '
+    $transport_detail = 'The connection to the Smart Send API timed out. Please try again. If the problem persists, ask your host '
         . 'whether outgoing requests to app.smartsend.io are blocked or slow.'
-        . ' (http_request_failed: cURL error 28: Operation timed out after 30001 milliseconds)'
+        . ' (http_request_failed: cURL error 28: Operation timed out after 30001 milliseconds)';
+
+    $expected_log = 'Smart Send: pickup point lookup for postnord failed with a transport error: '
+        . $transport_detail
         . ' Falling back to "Shipping to closest pickup point".';
 
-    // The customer-facing fallback is byte-for-byte unchanged.
+    $expected_notice = 'Smart Send: Showing pickup point for "Smart Send" (smart_send_shipping:1). '
+        . 'Failed with a transport error: ' . $transport_detail;
+
     expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
-        ->and(pickup_debug_notice_texts())->toContain($expected)
-        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected);
+        ->and(pickup_debug_notice_texts())->toContain($expected_notice)
+        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected_log);
 });
 
 it('surfaces an authentication failure as an error box, a debug notice and an error log entry', function () {
@@ -129,12 +133,15 @@ it('surfaces an authentication failure as an error box, a debug notice and an er
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: pickup point lookup for postnord failed with an authentication error (HTTP 401): '
+    $expected_log = 'Smart Send: pickup point lookup for postnord failed with an authentication error (HTTP 401): '
         . 'The API token is invalid.';
 
+    $expected_notice = 'Smart Send: Showing pickup point for "Smart Send" (smart_send_shipping:1). '
+        . 'Failed with an authentication error (HTTP 401): The API token is invalid.';
+
     expect($output)->toContain('<div class="woocommerce-error ss-agent-info ss-agent-info--auth_failed">The shop is not correctly connected with Smart Send.</div>')
-        ->and(pickup_debug_notice_texts())->toContain($expected)
-        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected);
+        ->and(pickup_debug_notice_texts())->toContain($expected_notice)
+        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected_log);
 });
 
 it('surfaces an authorization failure as an error box, a debug notice and an error log entry', function () {
@@ -148,12 +155,15 @@ it('surfaces an authorization failure as an error box, a debug notice and an err
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: pickup point lookup for postnord failed with an authorization error (HTTP 403): '
+    $expected_log = 'Smart Send: pickup point lookup for postnord failed with an authorization error (HTTP 403): '
         . 'Your plan does not include pickup points.';
 
+    $expected_notice = 'Smart Send: Showing pickup point for "Smart Send" (smart_send_shipping:1). '
+        . 'Failed with an authorization error (HTTP 403): Your plan does not include pickup points.';
+
     expect($output)->toContain('<div class="woocommerce-error ss-agent-info ss-agent-info--access_denied">The shop does not have access to pickup points.</div>')
-        ->and(pickup_debug_notice_texts())->toContain($expected)
-        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected);
+        ->and(pickup_debug_notice_texts())->toContain($expected_notice)
+        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected_log);
 });
 
 it('surfaces a missing API token as an error box and an error log entry without an API call', function () {
@@ -164,12 +174,15 @@ it('surfaces a missing API token as an error box and an error log entry without 
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: pickup point lookup skipped - no API token configured (plugin not connected).';
+    $expected_log = 'Smart Send: pickup point lookup skipped - no API token configured (plugin not connected).';
+
+    $expected_notice = 'Smart Send: Showing pickup point for "Smart Send" (smart_send_shipping:1). '
+        . 'No API token configured (plugin not connected).';
 
     expect($output)->toContain('<div class="woocommerce-error ss-agent-info ss-agent-info--not_connected">Connect the Smart Send plugin to enable pickup points.</div>')
         ->and($capture->requests)->toBeEmpty()
-        ->and(pickup_debug_notice_texts())->toContain($expected)
-        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected);
+        ->and(pickup_debug_notice_texts())->toContain($expected_notice)
+        ->and(implode("\n", pickup_debug_logged($spy, 'error')))->toContain($expected_log);
 });
 
 it('reports a validation error body by its message', function () {
@@ -183,8 +196,8 @@ it('reports a validation error body by its message', function () {
 
     expect($output)->toContain(PICKUP_DEBUG_FALLBACK)
         ->and(pickup_debug_notice_texts())->toContain(
-            'Smart Send: pickup point lookup for postnord failed with an API error: '
-            . 'The given data was invalid. Falling back to "Shipping to closest pickup point".'
+            'Smart Send: Showing pickup point for "Smart Send" (smart_send_shipping:1). '
+            . 'Failed with an API error: The given data was invalid.'
         );
 });
 
@@ -197,12 +210,15 @@ it('reports an empty agent list as a debug notice and logs it at info level', fu
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: no postnord pickup points found near the entered address.';
+    $expected_log = 'Smart Send: no postnord pickup points found near the entered address.';
+
+    $expected_notice = 'Smart Send: Showing pickup point for "Smart Send" (smart_send_shipping:1). '
+        . 'No pickup points found near the entered address.';
 
     expect($output)->toContain(PICKUP_DEBUG_NONE_FOUND)
-        ->and(pickup_debug_notice_texts())->toContain($expected)
+        ->and(pickup_debug_notice_texts())->toContain($expected_notice)
         // Worth noticing but not a fault: logged at info (always on), never error.
-        ->and(implode("\n", pickup_debug_logged($spy, 'info')))->toContain($expected)
+        ->and(implode("\n", pickup_debug_logged($spy, 'info')))->toContain($expected_log)
         ->and(implode("\n", pickup_debug_logged($spy, 'error')))->not->toContain('no postnord pickup points');
 });
 
@@ -251,7 +267,7 @@ it('renders the agent dropdown and no failure notice when the lookup succeeds', 
         ->and(implode("\n", pickup_debug_notice_texts()))->not->toContain('pickup point lookup');
 });
 
-it('surfaces a success summary with the carrier and result count (#92)', function () {
+it('surfaces a success summary with the method and result count (#92)', function () {
     with_option('woocommerce_shipping_debug_mode', 'yes');
     with_ss_settings(['ss_debug' => 'yes']); // Debug-level log entries require the plugin debug setting.
     $spy = spy_on_logger();
@@ -261,11 +277,14 @@ it('surfaces a success summary with the carrier and result count (#92)', functio
 
     $output = pickup_debug_render();
 
-    $expected = 'Smart Send: found 2 postnord pickup points near the entered address.';
+    $expected_log = 'Smart Send: found 2 postnord pickup points near the entered address.';
+
+    $expected_notice = 'Smart Send: Showing pickup point for "Smart Send" (smart_send_shipping:1). '
+        . 'Found 2 pickup points near the entered address.';
 
     expect($output)->toContain('ss_shipping_store_pickup')
-        ->and(pickup_debug_notice_texts())->toContain($expected)
-        ->and(implode("\n", pickup_debug_logged($spy, 'debug')))->toContain($expected);
+        ->and(pickup_debug_notice_texts())->toContain($expected_notice)
+        ->and(implode("\n", pickup_debug_logged($spy, 'debug')))->toContain($expected_log);
 });
 
 it('adds no success summary notice when shipping debug mode is off', function () {

--- a/tests/Integration/ShippingDebugModeTest.php
+++ b/tests/Integration/ShippingDebugModeTest.php
@@ -2,10 +2,12 @@
 
 /*
  * WooCommerce shipping debug mode support (#5): when the merchant enables
- * WooCommerce → Settings → Shipping → "Enable debug mode", the Smart Send
- * rate-calculation trace is surfaced as checkout notices through
- * SS_Shipping_Checkout_Debug::add_notice(). With the option off nothing
- * changes.
+ * WooCommerce → Settings → Shipping → "Enable debug mode", every evaluated
+ * Smart Send method is surfaced as ONE summary notice through
+ * SS_Shipping_Checkout_Debug::add_notice() - the availability verdict with
+ * the evaluated total and cart weight, plus how the offered cost was
+ * derived. The step-by-step trace stays in the log only. With the option
+ * off nothing changes.
  *
  * The notice gating mirrors WooCommerce core: only when
  * woocommerce_shipping_debug_mode is "yes", never when WOOCOMMERCE_CHECKOUT
@@ -73,6 +75,19 @@ function ss_debug_notice_texts(): array
     );
 }
 
+/**
+ * Only the Smart Send debug notices - WooCommerce core adds its own zone
+ * notices ("Customer matched zone ...") to the same bar while debug mode
+ * is on.
+ */
+function ss_debug_smart_send_notices(): array
+{
+    return array_values(array_filter(
+        ss_debug_notice_texts(),
+        fn (string $notice): bool => str_starts_with($notice, 'Smart Send')
+    ));
+}
+
 beforeEach(function (): void {
     with_ss_settings();
 
@@ -87,11 +102,11 @@ beforeEach(function (): void {
     });
 });
 
-it('surfaces the rate calculation trace as notices when shipping debug mode is on', function () {
+it('surfaces one evaluation summary line per method when shipping debug mode is on', function () {
     with_option('woocommerce_shipping_debug_mode', 'yes');
 
     $product = create_simple_product(['price' => 100, 'weight' => 1.5]);
-    $package = ss_debug_cart_package([[$product, 2]]); // 3 kg
+    $package = ss_debug_cart_package([[$product, 2]]); // 3 kg, 200 total
 
     $method = ss_debug_create_method([
         'cost_weight' => [
@@ -100,15 +115,18 @@ it('surfaces the rate calculation trace as notices when shipping debug mode is o
     ]);
     $method->calculate_shipping($package);
 
-    $unit  = get_option('woocommerce_weight_unit');
-    $trace = implode("\n", ss_debug_notice_texts());
+    $unit    = get_option('woocommerce_weight_unit');
+    $notices = ss_debug_smart_send_notices();
 
-    expect($trace)->toContain('Smart Send: evaluated method "SS Debug Method" (postnord_agent, rate id smart_send_shipping:99941).')
-        ->and($trace)->toContain('Smart Send "SS Debug Method": free shipping (flat fee) is NOT available, because it is not available.')
-        ->and($trace)->toContain('Smart Send "SS Debug Method": cart weight 3 ' . $unit . ' matched weight table row 1-5 ' . $unit . ' - rate added with cost 49.');
+    // ONE Smart Send line: the verdict, the evaluated inputs and the cost derivation.
+    expect($notices)->toHaveCount(1)
+        ->and($notices[0])->toBe(
+            'Smart Send: Evaluated method "SS Debug Method" (smart_send_shipping:99941) as available'
+            . ' (total=200, weight=3 ' . $unit . '). Weight table row 1-5 ' . $unit . ' applied, cost 49.'
+        );
 });
 
-it('surfaces the free shipping decision when the flat fee rules are met', function () {
+it('surfaces the free shipping decision inside the evaluation summary', function () {
     with_option('woocommerce_shipping_debug_mode', 'yes');
 
     $product = create_simple_product(['price' => 100, 'weight' => 2]);
@@ -121,10 +139,14 @@ it('surfaces the free shipping decision when the flat fee rules are met', functi
     ]);
     $method->calculate_shipping($package);
 
-    $trace = implode("\n", ss_debug_notice_texts());
+    $unit    = get_option('woocommerce_weight_unit');
+    $notices = ss_debug_smart_send_notices();
 
-    expect($trace)->toContain('Smart Send "SS Debug Method": free shipping (flat fee) IS available, because it is always enabled.')
-        ->and($trace)->toContain('Smart Send "SS Debug Method": free shipping applies - rate added with flat fee cost 25.');
+    expect($notices)->toHaveCount(1)
+        ->and($notices[0])->toBe(
+            'Smart Send: Evaluated method "SS Debug Method" (smart_send_shipping:99941) as available'
+            . ' (total=100, weight=2 ' . $unit . '). Flat fee cost 25 applied.'
+        );
 });
 
 it('explains why no rate was added when the cart weight matches no table row', function () {
@@ -138,11 +160,15 @@ it('explains why no rate was added when the cart weight matches no table row', f
     ]);
     $method->calculate_shipping($package);
 
-    $unit  = get_option('woocommerce_weight_unit');
-    $trace = implode("\n", ss_debug_notice_texts());
+    $unit    = get_option('woocommerce_weight_unit');
+    $notices = ss_debug_smart_send_notices();
 
     expect($method->rates)->toHaveCount(0)
-        ->and($trace)->toContain('Smart Send "SS Debug Method": no rate added - cart weight 10 ' . $unit . ' did not match any weight table row.');
+        ->and($notices)->toHaveCount(1)
+        ->and($notices[0])->toBe(
+            'Smart Send: Evaluated method "SS Debug Method" (smart_send_shipping:99941) as not available'
+            . ' (total=100, weight=10 ' . $unit . '): the cart weight matched no weight table row.'
+        );
 });
 
 it('explains why the method is excluded by the availability options', function () {
@@ -162,7 +188,30 @@ it('explains why the method is excluded by the availability options', function (
 
     $trace = implode("\n", ss_debug_notice_texts());
 
-    expect($trace)->toContain('Smart Send "SS Debug Method": shipping method is NOT available, because customer role "guest" is being excluded.');
+    expect($trace)->toContain('Smart Send: Evaluated method "SS Debug Method" (smart_send_shipping:99941) as not available: customer role "guest" is excluded.');
+});
+
+it('explains why the method is excluded by the shipping-class condition', function () {
+    with_option('woocommerce_shipping_debug_mode', 'yes');
+
+    $product = create_simple_product(['price' => 100, 'weight' => 1]);
+    $package = ss_debug_cart_package([$product]);
+
+    // Require ALL products in a shipping class the product is not in.
+    $method = ss_debug_create_method([
+        'advanced_settings_enable'   => 'yes',
+        'display_shipping_class'     => ['some-missing-class'],
+        'display_shipping_class_opt' => 'all_shipping_class',
+    ]);
+
+    expect($method->is_available($package))->toBeFalse();
+
+    $trace = implode("\n", ss_debug_notice_texts());
+
+    expect($trace)->toContain(
+        'Smart Send: Evaluated method "SS Debug Method" (smart_send_shipping:99941) as not available:'
+        . ' not ALL products belong to one of the selected shipping classes.'
+    );
 });
 
 it('adds no notices when shipping debug mode is off', function () {


### PR DESCRIPTION
## What

Follow-up to #164/#165. The shipping debug bar (WooCommerce → Settings → Shipping → "Enable debug mode") used to print one notice per internal step:

```
Smart Send: evaluated method "GLS Pickup Point" (gls_agent, rate id smart_send_shipping:2).
Smart Send "GLS Pickup Point": free shipping (flat fee) IS available, because the total is 371 a minimum order amount of 199 is needed.
Smart Send "GLS Pickup Point": free shipping applies - rate added with flat fee cost 0.
Smart Send: rates offered for this package: "GLS Pickup Point" (smart_send_shipping:2, cost 0).
Smart Send: pickup point lookup for gls failed with an API error: ...
```

It now carries exactly two Smart Send lines per checkout render:

```
Smart Send: Evaluated method "GLS Pickup Point" (smart_send_shipping:2) as available (total=371, weight=2.75 kg). Flat fee cost 0 applied.
Smart Send: Showing pickup point for "GLS Pickup Point" (smart_send_shipping:2). Failed with an API error: Not found [Team] smart-send-woocommerce.test
```

**Line 1 — evaluation summary per method** (from `calculate_shipping()`): verdict + evaluated inputs + cost derivation (`Flat fee cost X applied.` / `Weight table row 1-5 kg applied, cost 49.` / `as not available (...): the cart weight matched no weight table row.`). When `is_available()` already rejects the method (shipping class / customer role), that check emits the method's one line in the same format with the failing reason — `calculate_shipping()` never runs then.

**Line 2 — delivery options for the chosen agent method** (from `SS_Shipping_Frontend`, which has the method context the headless lookup lacks): `Showing pickup point for "X" (rate id).` + outcome — `Found N pickup points near the entered address.` / `Waiting for the shipping address.` / `No API token configured (plugin not connected).` / `Failed with an authentication error (HTTP 401): <API message>` / etc., mirroring the #164 statuses.

**Notices only — every log entry is unchanged**: the step-by-step trace, the offered-rates summary and the lookup outcomes stay greppable in the WooCommerce log at their existing levels. The rate sorter and the lookup no longer write to the bar at all. The rare overlapping-weight-rows explainer keeps its dedicated notice.

## Tests

- `ShippingDebugModeTest`: asserts exactly ONE Smart Send line per evaluated method (byte-exact) for the available/flat-fee/weight-miss cases, plus the role- and shipping-class-rejection lines (new coverage for the latter). Core's own "Customer matched zone" notices are filtered out of the count.
- `PickupLookupDebugTest`: notice expectations moved to the line-2 format; all log expectations unchanged.
- `LoggingPolicyTest`: offered-rates tests now assert log-only (no bar notice).
- `NoticeTranslationTest`: gettext/sprintf/_n() coverage rewired to the new templates (summary line + Found-N outcome).
- Integration: 255 passed. Browser: 30 passed. phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)