### PR TITLE
Temporarily drop PHP 8.4 from the browser test matrix

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -26,7 +26,12 @@ jobs:
         # #79 hardening (worker recycling, core-dump capture) — if they go
         # deterministically red again with the same environment signature,
         # drop them again and record it on #79.
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        # PHP 8.4 was temporarily removed on 2026-08-20 after going
+        # deterministically red the same way (5 of 6 attempts across PRs
+        # #167/#168, fpm SIGSEGV consistently striking the block checkout's
+        # /wp-json/wc/store/v1/batch render; the in-job fpm-restart retry no
+        # longer rescues it). Evidence and the canary reminder live on #79.
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3']
         wp-version: ['latest']
         wc-version: ['latest']
 


### PR DESCRIPTION
## What

Removes PHP 8.4 from the Browser Tests matrix, following the exact precedent of PR #80 (which pulled 8.1/8.2 on 2026-08-11 for the same reason). Tracked for re-adding as a canary on #79.

## Why

The php-fpm SIGSEGV environment flake (#79) has gone deterministic on 8.4: **5 of 6 attempts failed across PRs #167 and #168**, including every in-job fpm-restart retry — reruns no longer clear it. All other matrix versions (7.4–8.3) pass the identical suites reliably, including 8.1/8.2 since their return.

New evidence recorded on #79: the crash site is consistent — fpm workers segfault rendering the block checkout's `POST /wp-json/wc/store/v1/batch` request, so the casualty is almost always a `BlockCheckoutFlowTest` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)